### PR TITLE
chore(flake/flake-parts): `07f63952` -> `b253292d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -252,11 +252,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -550,11 +550,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`8a099348`](https://github.com/hercules-ci/flake-parts/commit/8a099348752aa5fa09b3ebb6b5f422af10d250aa) | `` flake.lock: Update ``                         |
| [`b60b914a`](https://github.com/hercules-ci/flake-parts/commit/b60b914ac6f706bdb6e55c0eadeffa732a60bd16) | `` dev: Make the test slightly more sensible ``  |
| [`14114c56`](https://github.com/hercules-ci/flake-parts/commit/14114c563acab4cee2828aa8dad9036d617e1ea2) | `` templates: make flake-parts input explicit `` |
| [`238b0dc9`](https://github.com/hercules-ci/flake-parts/commit/238b0dc94b068a32530e8675425d22753d4af343) | `` apps: Add polyfill ``                         |
| [`562a6b5e`](https://github.com/hercules-ci/flake-parts/commit/562a6b5e54193e32c9819903c166cf211072e46c) | `` dev: Test apps ``                             |
| [`acd542d1`](https://github.com/hercules-ci/flake-parts/commit/acd542d16b086b2aeb823c090bf6121e7a1af12b) | `` apps: use lib.getExe to find executable ``    |