### PR TITLE
chore(flake/home-manager): `2d47379a` -> `f99eace7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -430,11 +430,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705879479,
-        "narHash": "sha256-ZIohbyly1KOe+8I3gdyNKgVN/oifKdmeI0DzMfytbtg=",
+        "lastModified": 1707175763,
+        "narHash": "sha256-0MKHC6tQ4KEuM5rui6DjKZ/VNiSANB4E+DJ/+wPS1PU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2d47379ad591bcb14ca95a90b6964b8305f6c913",
+        "rev": "f99eace7c167b8a6a0871849493b1c613d0f1b80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`f99eace7`](https://github.com/nix-community/home-manager/commit/f99eace7c167b8a6a0871849493b1c613d0f1b80) | `` jetbrains-remote: add module ``                           |
| [`f65dcd6c`](https://github.com/nix-community/home-manager/commit/f65dcd6c15db0fc2045d56ef8fdf4a03aa52e81f) | `` neomutt: fix crypt_use_gpgme in newer versions ``         |
| [`7b4ea8d8`](https://github.com/nix-community/home-manager/commit/7b4ea8d82fdeaa71ab942a8a8f6f8add8afdfad0) | `` arrpc: add module ``                                      |
| [`13dbf262`](https://github.com/nix-community/home-manager/commit/13dbf2623d6465d5c4db54ce8a5a630dce79c3e9) | `` swayosd: update executable ``                             |
| [`b319781e`](https://github.com/nix-community/home-manager/commit/b319781e304c668da0ef144b1b4ee48977d4877d) | `` home-manager: Check VISUAL before EDITOR for editor ``    |
| [`3c6f2dd5`](https://github.com/nix-community/home-manager/commit/3c6f2dd59cb8c0b06ed1fe01f297e75bbaec3003) | `` himalaya: adjust module for v1.0.0-beta ``                |
| [`274bd470`](https://github.com/nix-community/home-manager/commit/274bd470a544647d90d7491037fdf8af61b7d8d0) | `` nix-gc: add service ``                                    |
| [`afcedcf2`](https://github.com/nix-community/home-manager/commit/afcedcf2c8e424d0465e823cf833eb3adebe1db7) | `` mcfly: add interfaceView option ``                        |
| [`a28b12d7`](https://github.com/nix-community/home-manager/commit/a28b12d7412324aa22a5f9df8909672dec33613e) | `` vscode: add openvscode-server ``                          |
| [`4740f2cc`](https://github.com/nix-community/home-manager/commit/4740f2ccda184e9cc509d7a82b26d7271e0c79d9) | `` kitty: always export `KITTY_SHELL_INTEGRATION` ``         |
| [`1683c507`](https://github.com/nix-community/home-manager/commit/1683c507c2c58a502294330de940e2b4b51bdf75) | `` vdirsyncer: create postHook script when non-empty ``      |
| [`f80df90c`](https://github.com/nix-community/home-manager/commit/f80df90c105d081a49d123c34a57ead9dac615b9) | `` fish: implement shellInitLast (after others) ``           |
| [`4ab01785`](https://github.com/nix-community/home-manager/commit/4ab01785b85aac4dd0f0414f7c0ca4c007e64054) | `` flake.lock: Update ``                                     |
| [`9291f28f`](https://github.com/nix-community/home-manager/commit/9291f28f93a818e4496a6f71f6c77f59108d4d46) | `` Translate using Weblate (Turkish) ``                      |
| [`230836bb`](https://github.com/nix-community/home-manager/commit/230836bb7ca318aec7bad8442954da611d06a172) | `` hyprland: fix hyprctl crash ``                            |
| [`1ca21064`](https://github.com/nix-community/home-manager/commit/1ca210648a6ca9b957efde5da957f3de6b1f0c45) | `` tests: reduce closure sizes ``                            |
| [`880d9bc2`](https://github.com/nix-community/home-manager/commit/880d9bc2110f7cae59698f715b8ca42cdc53670c) | `` nix: fix generation of nix.conf for nix >= 2.20 ``        |
| [`4d53427b`](https://github.com/nix-community/home-manager/commit/4d53427bce7bf3d17e699252fd84dc7468afc46e) | `` xfconf: fix config loading ``                             |
| [`2db6a2a4`](https://github.com/nix-community/home-manager/commit/2db6a2a42930ffff0ffd690dec3f2c0b6f4fe66d) | `` docs: add style sheets and `scrubDerivations` ``          |
| [`d634c3ab`](https://github.com/nix-community/home-manager/commit/d634c3abafa454551f2083b054cd95c3f287be61) | `` tealdeer: add option to toggle update on activation ``    |
| [`4d54c29b`](https://github.com/nix-community/home-manager/commit/4d54c29bce71f8c261513e0662cc573d30f3e33e) | `` home-manager: remove the export of `run` ``               |
| [`ebba24a6`](https://github.com/nix-community/home-manager/commit/ebba24a6fefa3d749291be7192ef817736a10bd1) | `` wob: add module ``                                        |
| [`7a461c70`](https://github.com/nix-community/home-manager/commit/7a461c70ed20e7e4a2af1710fdfb89ec70473e47) | `` firefox: fix darwin NativeMessagingHostsPath ``           |
| [`e5f2a059`](https://github.com/nix-community/home-manager/commit/e5f2a0590a9387e17e6433b280e45d14f82683b4) | `` flake.lock: Update (#4964) ``                             |
| [`b2f56952`](https://github.com/nix-community/home-manager/commit/b2f56952074cb46e93902ecaabfb04dd93733434) | `` network-manager-applet: add XDG data directory ``         |
| [`690764d2`](https://github.com/nix-community/home-manager/commit/690764d2dcfccf01ddfc9f19220c88182339f40f) | `` firefox: Reimplement FF native messaging ``               |
| [`c7ce343d`](https://github.com/nix-community/home-manager/commit/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) | `` home-manager: add extendModules attribute ``              |
| [`c82e52b0`](https://github.com/nix-community/home-manager/commit/c82e52b0d96eb9f1c8334add871dce8e837d043b) | `` flake.lock: Update ``                                     |
| [`03958aff`](https://github.com/nix-community/home-manager/commit/03958aff4415a5278d0ea462db370e9d770e904e) | `` firefox: add default containers ``                        |
| [`70688f19`](https://github.com/nix-community/home-manager/commit/70688f195a294a09d31d6bfe339bb090d443e949) | `` keepassx: remove module ``                                |
| [`6359d40f`](https://github.com/nix-community/home-manager/commit/6359d40f6ec0b72a38e02b333f343c3d4929ec10) | `` firefox: implement native messaging hosts ``              |
| [`e8481103`](https://github.com/nix-community/home-manager/commit/e84811035d7c8ec79ed6c687a97e19e2a22123c1) | `` treewide: deprecate `VERBOSE_ECHO` ``                     |
| [`190c6f46`](https://github.com/nix-community/home-manager/commit/190c6f46090a62ad025828bd8e16799d8fcdab1e) | `` home-manager: avoid running empty `nix profile remove` `` |
| [`42567290`](https://github.com/nix-community/home-manager/commit/425672900691a16a897fc47b4d5c3013d2a822a0) | `` treewide: deprecate `DRY_RUN_CMD` and `DRY_RUN_NULL` ``   |
| [`6b28ab2d`](https://github.com/nix-community/home-manager/commit/6b28ab2d798c1c84e24053d95f4ee1dd9d81e2fb) | `` tealdeer: add cache update activation script ``           |
| [`3df2a80f`](https://github.com/nix-community/home-manager/commit/3df2a80f3f85f91ea06e5e91071fa74ba92e5084) | `` zoxide: fix nushell 0.89 deprecation ``                   |
| [`3d0dc78e`](https://github.com/nix-community/home-manager/commit/3d0dc78e80031731240c979d87eed8e090d35439) | `` bemenu: allow floats in settings ``                       |