### PR TITLE
chore(flake/nix-index-database): `f8e04fbc` -> `3e3dad28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705806513,
-        "narHash": "sha256-FcOmNjhHFfPz2udZbRpZ1sfyhVMr+C2O8kOxPj+HDDk=",
+        "lastModified": 1707016097,
+        "narHash": "sha256-V4lHr6hFQ3rK650dh64Xffxsf4kse9vUYWsM+ldjkco=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f8e04fbcebcc24cebc91989981bd45f69b963ed7",
+        "rev": "3e3dad2808379c522138e2e8b0eb73500721a237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`3e3dad28`](https://github.com/nix-community/nix-index-database/commit/3e3dad2808379c522138e2e8b0eb73500721a237) | `` update packages.nix to release 2024-02-04-030719 `` |
| [`e260ddfd`](https://github.com/nix-community/nix-index-database/commit/e260ddfd7ab5d360172870b9dfb0fa15093cdb29) | `` flake.lock: Update ``                               |
| [`c782f2a4`](https://github.com/nix-community/nix-index-database/commit/c782f2a4f6fc94311ab5ef31df2f1149a1856181) | `` update packages.nix to release 2024-01-28-030920 `` |
| [`2c1a58ea`](https://github.com/nix-community/nix-index-database/commit/2c1a58ea29af0bd3da947c6bb3e7a7704a2f972b) | `` flake.lock: Update ``                               |