### PR TITLE
chore(flake/stylix): `a9e3ce06` -> `ccca01b5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705668784,
-        "narHash": "sha256-U/1Qol9H5nb8FtWSXSiHY8T4Y7TOIo7NHuqe4uuiBec=",
+        "lastModified": 1706783767,
+        "narHash": "sha256-Rn21YNSa4TgZzTsarghUPQv+fz1dZcfdDKQZS9H79Hg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a9e3ce064a778b386fb88fb152c02ae95aa2cbd2",
+        "rev": "ccca01b5b0393119822b1888cb7c68e294fc115b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ccca01b5`](https://github.com/danth/stylix/commit/ccca01b5b0393119822b1888cb7c68e294fc115b) | `` nushell: add Home Manager module (#235) ``     |
| [`7a7c9001`](https://github.com/danth/stylix/commit/7a7c90015de7454060e103e94bb4e6010b5aa062) | `` k9s: use new name for skin option (#232) ``    |
| [`1a5dee19`](https://github.com/danth/stylix/commit/1a5dee1957dc45e125013ae3919ff284cfb83cdc) | `` treewide: remove tailing whitespaces (#228) `` |
| [`81de262b`](https://github.com/danth/stylix/commit/81de262bf170ce4152950402e17eba1453a3ebfe) | `` rofi: allow theme customizability (#230) ``    |
| [`606a7983`](https://github.com/danth/stylix/commit/606a7983a0199004bdbeab898472e2ffd963dde5) | `` doc: update 'base16.nix' URL (#227) ``         |
| [`423c819d`](https://github.com/danth/stylix/commit/423c819d7702a78c52a80df7721d6c04bcbf2eab) | `` bemenu: move over to upstream module (#206) `` |
| [`bf31640f`](https://github.com/danth/stylix/commit/bf31640f49cb115508c31bf3bd0b4b80bb8ab71d) | `` doc: specify commit message format ``          |