### PR TITLE
chore(flake/stylix): `a2d8d6b4` -> `7e62834e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707303782,
-        "narHash": "sha256-5JHbqDtBpfX0H/WUIXSswMUrOKBkC4TlWS8uZfFTMDo=",
+        "lastModified": 1707348250,
+        "narHash": "sha256-e8xqppNtalaof3DaYLSAAQkJ/XfJGzOtLt7J0qWZtC8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a2d8d6b460bb6c53cb09ce645fd041c0c308c0c8",
+        "rev": "7e62834e25dc114ed249655c4f673fe67617a4c1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                             |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7e62834e`](https://github.com/danth/stylix/commit/7e62834e25dc114ed249655c4f673fe67617a4c1) | `` wezterm: flip active and inactive tab colors (#246) ``           |
| [`9942fca8`](https://github.com/danth/stylix/commit/9942fca8707efbd8c3f6108549f098462425d1b3) | `` qutebrowser: use correct `fonts.web.size.default` type (#239) `` |