### PR TITLE
chore(flake/stylix): `7e62834e` -> `f3b302dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -778,11 +778,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707348250,
-        "narHash": "sha256-e8xqppNtalaof3DaYLSAAQkJ/XfJGzOtLt7J0qWZtC8=",
+        "lastModified": 1707414210,
+        "narHash": "sha256-MJ4deL9tTzowkGpW9Iq+k3cSKo2gnvyIkIuFctNz/dQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7e62834e25dc114ed249655c4f673fe67617a4c1",
+        "rev": "f3b302dd9bb66fcdd1ed3f185068a5f1000eb863",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`f3b302dd`](https://github.com/danth/stylix/commit/f3b302dd9bb66fcdd1ed3f185068a5f1000eb863) | `` qutebrowser: improve readability (#240) `` |