### PR TITLE
chore(flake/nixpkgs): `faf912b0` -> `f8e2ebd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707092692,
-        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "lastModified": 1707268954,
+        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`f8e2ebd6`](https://github.com/NixOS/nixpkgs/commit/f8e2ebd66d097614d51a56a755450d4ae1632df1) | `` camunda-modeler: 5.18.0 -> 5.19.0 (#282648) ``                                          |
| [`b39d11c4`](https://github.com/NixOS/nixpkgs/commit/b39d11c4a438138893fe1999e74754dc2c734eb9) | `` home-assistant: support blue_current component ``                                       |
| [`588e5f80`](https://github.com/NixOS/nixpkgs/commit/588e5f80bf691de6d89f587253e57bbdf21b6770) | `` esphome: remove reference to test inputs ``                                             |
| [`0b9427cf`](https://github.com/NixOS/nixpkgs/commit/0b9427cf71692882a063a395554fe1cc5e0ede4b) | `` snakemake: 8.3.2 -> 8.4.4 ``                                                            |
| [`724b8ca5`](https://github.com/NixOS/nixpkgs/commit/724b8ca51ee57b5d89de063b48ed11d21bb2e1ae) | `` python311Packages.bluecurrent-api: init at 1.0.6 ``                                     |
| [`df951021`](https://github.com/NixOS/nixpkgs/commit/df9510216f94f1b0a29537b6591eaf42f2c09caa) | `` home-assistant: support aosmith component ``                                            |
| [`e3f28575`](https://github.com/NixOS/nixpkgs/commit/e3f2857596c35a00346908c47bf92daa9602860c) | `` python311Packages.py-aosmith: init at 1.0.6 ``                                          |
| [`f7a897b9`](https://github.com/NixOS/nixpkgs/commit/f7a897b9feac95c0e7559acb1e549f688c37c755) | `` terraform-providers.slack: init at 1.2.2 ``                                             |
| [`a6224e70`](https://github.com/NixOS/nixpkgs/commit/a6224e70a84d2b418228d007d6ef604477c74b18) | `` graphite-cli: add fish completion ``                                                    |
| [`ff5b2d7d`](https://github.com/NixOS/nixpkgs/commit/ff5b2d7d00327321496052c87608b6d3f7f6d1ad) | `` lua.tests: add test for relative import ``                                              |
| [`aa866f51`](https://github.com/NixOS/nixpkgs/commit/aa866f5189da9c10698bdedac63973bd388474a1) | `` rPackages.rhdf5: fix build on aarch64-darwin ``                                         |
| [`250078ce`](https://github.com/NixOS/nixpkgs/commit/250078ceba19d576437e46f8e1c1d19acf5dfa78) | `` frigate: 0.12.1 -> 0.13.1 ``                                                            |
| [`7f050900`](https://github.com/NixOS/nixpkgs/commit/7f0509008e91da364ba5691dd7b8e4b93a8cee05) | `` maintainers: add matrix tag for tomasajt ``                                             |
| [`407c10aa`](https://github.com/NixOS/nixpkgs/commit/407c10aacc12290acf69a2fba4dbdf82039269b0) | `` celeste64: 0-unstable-2024-02-02 -> 1.1.1 ``                                            |
| [`c380de25`](https://github.com/NixOS/nixpkgs/commit/c380de25143ce64eef227f14e1e68d9c6c2994ee) | `` llvmPackages_git: 18.0.0-unstable-2023-10-04 -> 18.0.0-unstable-2023-12-13 (#286525) `` |
| [`1ba11e55`](https://github.com/NixOS/nixpkgs/commit/1ba11e55555f3161b3a13e2baf65989ad94d1041) | `` python3Packages.mkdocs-redoc-tag: init at 0.1.0 ``                                      |
| [`3dd7a8e7`](https://github.com/NixOS/nixpkgs/commit/3dd7a8e79244a5d34a2eaa4bcf497a952da1fa8c) | `` maintainers: add benhiemer ``                                                           |
| [`bd70128f`](https://github.com/NixOS/nixpkgs/commit/bd70128f0800b42226801299cb3cd15fac8d47b0) | `` python311Packages.qpsolvers: 4.2.0 -> 4.3.1 ``                                          |
| [`8a52876c`](https://github.com/NixOS/nixpkgs/commit/8a52876c66a6a99130d82dc688a77dfc9d8b5059) | `` python311Packages.pyvista: 0.43.2 -> 0.43.3 ``                                          |
| [`01c35392`](https://github.com/NixOS/nixpkgs/commit/01c35392582cbf3596bf44c9781b13d09572c753) | `` microsoft-edge: 121.0.2277.98 -> 121.0.2277.106 ``                                      |
| [`8e285cb2`](https://github.com/NixOS/nixpkgs/commit/8e285cb2083bd47ba1ddc687f0b996ed1ac099c2) | `` eigenmath: unstable-2024-01-23 -> unstable-2024-02-04 ``                                |
| [`2d807ffd`](https://github.com/NixOS/nixpkgs/commit/2d807ffd5b66fa3fba0e81e059951fac6195f300) | `` kubernetes-helmPlugins.helm-unittest: 0.3.5 -> 0.4.1 ``                                 |
| [`b22be86a`](https://github.com/NixOS/nixpkgs/commit/b22be86afe1cc540ba242e9abb9c80c6d10382ed) | `` python311Packages.stravalib: 1.5 -> 1.6 ``                                              |
| [`371d28e2`](https://github.com/NixOS/nixpkgs/commit/371d28e24b227691a89eb390ff30b3a4a290917f) | `` python311Packages.yolink-api: 0.3.6 -> 0.3.7 ``                                         |
| [`bb1cf083`](https://github.com/NixOS/nixpkgs/commit/bb1cf0832f1ba2a22a335d1e9458f8fb45d1d11e) | `` snowflake: 2.8.1 -> 2.9.0 ``                                                            |
| [`4a2935ce`](https://github.com/NixOS/nixpkgs/commit/4a2935ce6547e0f0e3363ea974e5b7d0ba368b68) | `` signal-export: 1.8.0 -> 1.8.1 ``                                                        |
| [`4a01c01c`](https://github.com/NixOS/nixpkgs/commit/4a01c01c337d13087a2c1aacff7aa33a10a43890) | `` python312Packages.pyzipper: refactor ``                                                 |
| [`cde314b0`](https://github.com/NixOS/nixpkgs/commit/cde314b0c64c64db642e56b129ce90e1d176c841) | `` nix: add myself (ma27) as maintainer & codeowner ``                                     |
| [`aa5cb9b0`](https://github.com/NixOS/nixpkgs/commit/aa5cb9b04d3c7f7cbbb84653b38baa59861f1caf) | `` python311Packages.ring-doorbell: 0.8.6 -> 0.8.7 ``                                      |
| [`0ba87719`](https://github.com/NixOS/nixpkgs/commit/0ba87719a5f7b71cdcab78bbc87718372cdd253b) | `` python311Packages.django_5: 5.0.1 -> 5.0.2 ``                                           |
| [`fab1080a`](https://github.com/NixOS/nixpkgs/commit/fab1080a3e529ecc73bac8e34cc08f6614a03df5) | `` python311Packages.django_3: 3.2.23 -> 3.2.24 ``                                         |
| [`0085e9b6`](https://github.com/NixOS/nixpkgs/commit/0085e9b678660f322410b2bb042048e89b363b29) | `` flacon: Add sox utility for flacon to bin path (#281829) ``                             |
| [`c2b359cd`](https://github.com/NixOS/nixpkgs/commit/c2b359cd1faded08c62c93a1d04ac28cee7b61b2) | `` javaPackages.mavenfod: drop ``                                                          |
| [`32e3bc93`](https://github.com/NixOS/nixpkgs/commit/32e3bc93d63cae4a5ea2c3164bbbe8cf08a43ba7) | `` terragrunt: 0.55.0 -> 0.55.1 ``                                                         |
| [`844196d1`](https://github.com/NixOS/nixpkgs/commit/844196d12682fe68eb953cd8e20d830ea6c23fd1) | `` nodePackages: update to latest ``                                                       |
| [`901d939a`](https://github.com/NixOS/nixpkgs/commit/901d939a228125ea040a651e2aa5604d1bdcbe43) | `` androidStudioPackages.canary: 2023.3.1.7 -> 2023.3.1.8 ``                               |
| [`fbbddfa2`](https://github.com/NixOS/nixpkgs/commit/fbbddfa205e2a1bb2651b23a8c53a8bc0aca3ae3) | `` androidStudioPackages.beta: 2023.2.1.20 -> 2023.2.1.21 ``                               |
| [`d2e50e9a`](https://github.com/NixOS/nixpkgs/commit/d2e50e9a693bb4dd7d059d8f157fa0e18c43c0cc) | `` python311Packages.awkward: 2.6.0 -> 2.6.1 ``                                            |
| [`300bdf97`](https://github.com/NixOS/nixpkgs/commit/300bdf97fc6b1d2a777c7f22f8f67eaf0056e424) | `` gpu-viewer: 2.32 -> 3.02 ``                                                             |
| [`1fe9d826`](https://github.com/NixOS/nixpkgs/commit/1fe9d826c8f9c9d69c9edf7c69c9af50cd5f7001) | `` python311Packages.pyfronius: refactor ``                                                |
| [`cffd8dfc`](https://github.com/NixOS/nixpkgs/commit/cffd8dfc16c421d9a4c6778306394d5648a46b90) | `` python311Packages.pyfronius: 0.7.2 -> 0.7.3 ``                                          |
| [`13f69157`](https://github.com/NixOS/nixpkgs/commit/13f691577549b15da69e6c0c631546f4e0531a79) | `` openrefine: set meta.mainProgram ``                                                     |
| [`2870ee77`](https://github.com/NixOS/nixpkgs/commit/2870ee7765fe4ada27358bf83a765b84425b5ecd) | `` mstflint: fix compilation with gcc 13 ``                                                |
| [`507aa326`](https://github.com/NixOS/nixpkgs/commit/507aa326d57ab87c7c0e2c51c6e7fcafe7d746fa) | `` tetragon: init at 0.11.0 ``                                                             |
| [`df3d8e8c`](https://github.com/NixOS/nixpkgs/commit/df3d8e8cb2c1f9192264a4980496d9c7bc685b05) | `` python311Packages.python-homewizard-energy: 4.2.2 -> 4.3.0 ``                           |
| [`eb657c45`](https://github.com/NixOS/nixpkgs/commit/eb657c45f99e64b326ad21eab76df1afb347953b) | `` wireless-regdb: add `crda` to tests ``                                                  |
| [`a6c043b3`](https://github.com/NixOS/nixpkgs/commit/a6c043b35a0963baf985dd7dbfacd68b2faee1b3) | `` python311Packages.pygitguardian: update changelog entry ``                              |
| [`b8ce6343`](https://github.com/NixOS/nixpkgs/commit/b8ce63432fad195acea98476eb8f2957a5c4da20) | `` ggshield: 1.23.0 -> 1.24.0 ``                                                           |
| [`b6797755`](https://github.com/NixOS/nixpkgs/commit/b6797755d51d016113a1f9ab95973f04ddcfb1e0) | `` python311Packages.pygitguardian: 1.12.0 -> 1.13.0 ``                                    |
| [`b08cb499`](https://github.com/NixOS/nixpkgs/commit/b08cb4999f43210e35bbab07fb73cbfa4f384cf1) | `` wireless-regdb: revert "2023.09.01 -> 2024.01.23 (#286012)" ``                          |
| [`2be9bc92`](https://github.com/NixOS/nixpkgs/commit/2be9bc9230b0ef9494269479ee099419589f344d) | `` qgis-ltr: 3.28.14 -> 3.28.15 ``                                                         |
| [`98a319b7`](https://github.com/NixOS/nixpkgs/commit/98a319b7c7e98a9bbf9cd02018a879e450fbfe04) | `` tectonic: add passthru.tests.workspace ``                                               |
| [`771e06e9`](https://github.com/NixOS/nixpkgs/commit/771e06e9eedbcb25664563fdec5592bcf9cad707) | `` tectonic: wrap with a correct `--web-bundle` ``                                         |
| [`90e92eb6`](https://github.com/NixOS/nixpkgs/commit/90e92eb67edaa4db7a6513287aec122f90ee3c01) | `` lua51Packages.xml2lua: init at 1.5-2 ``                                                 |
| [`37fc3823`](https://github.com/NixOS/nixpkgs/commit/37fc382367942b2447ac54e65f72bc652177f5d2) | `` python311Packages.mdformat-gfm: 0.3.5 -> 0.3.6 ``                                       |
| [`6cafb118`](https://github.com/NixOS/nixpkgs/commit/6cafb1180243b86e306fcea50fc62b1be2ff99d5) | `` python311Packages.ldfparser: 0.22.0 -> 0.23.0 ``                                        |
| [`5ae1c67c`](https://github.com/NixOS/nixpkgs/commit/5ae1c67cd17553f4faab1eb109e374c173a62051) | `` python311Packages.nats-py: refactor ``                                                  |
| [`813abb4e`](https://github.com/NixOS/nixpkgs/commit/813abb4e06202f9cf0a33c1b9f483adafade7a9c) | `` python311Packages.types-colorama: 0.4.15.20240106 -> 0.4.15.20240205 ``                 |
| [`b8e667f8`](https://github.com/NixOS/nixpkgs/commit/b8e667f88a337b8b95ec99e88b5409243bed75a0) | `` ruff-lsp: 0.0.51 -> 0.0.52 ``                                                           |
| [`76353c89`](https://github.com/NixOS/nixpkgs/commit/76353c89a283a0edd50af4f100bce1413dc649ab) | `` clickhouse-backup: 2.4.25 -> 2.4.27 ``                                                  |
| [`c8007548`](https://github.com/NixOS/nixpkgs/commit/c8007548d1d43a2ad764629184ca50f138dabac2) | `` python311Packages.nats-py: 2.6.0 -> 2.7.0 ``                                            |
| [`3008c242`](https://github.com/NixOS/nixpkgs/commit/3008c242237ffedff30eda393ef779c145eb3a84) | `` theharvester: 4.5.0 -> 4.5.1 ``                                                         |
| [`e61112ca`](https://github.com/NixOS/nixpkgs/commit/e61112ca0218375dd7dbd5bb8c3cc531545e5e34) | `` qovery-cli: 0.82.0 -> 0.82.1 ``                                                         |
| [`4e620866`](https://github.com/NixOS/nixpkgs/commit/4e620866ad31a6a1be2176cfd192b55c09587b57) | `` trufflehog: 3.66.3 -> 3.67.2 ``                                                         |
| [`5cbf47f0`](https://github.com/NixOS/nixpkgs/commit/5cbf47f0053afa644dc56b7d2a1a4d8209412e52) | `` python311Packages.afdko: drop psautohint ``                                             |
| [`502d29a4`](https://github.com/NixOS/nixpkgs/commit/502d29a4676a5bf7dfcf9dd64f39a396973621a8) | `` python311Packages.pymicrobot: refactor ``                                               |
| [`6afb05e2`](https://github.com/NixOS/nixpkgs/commit/6afb05e2d740230bd6d5b877e419c5229a637cbd) | `` python311Packages.pymicrobot: 0.0.9 -> 0.0.10 ``                                        |
| [`360ba47d`](https://github.com/NixOS/nixpkgs/commit/360ba47d404658e9d59373aaa182cd229c2f8c0f) | `` python311Packages.pontos: 24.1.2 -> 24.2.0 ``                                           |
| [`ccf3a679`](https://github.com/NixOS/nixpkgs/commit/ccf3a6798df9f18f92d85cea4f5130425faea7f2) | `` python311Packages.botocore-stubs: 1.34.34 -> 1.34.35 ``                                 |
| [`6d6901ff`](https://github.com/NixOS/nixpkgs/commit/6d6901ffcd8b864d0561f3a0e3e04ef6c2dcf047) | `` python311Packages.nibe: 2.7.0 -> 2.8.0 ``                                               |
| [`94f8c119`](https://github.com/NixOS/nixpkgs/commit/94f8c119e3c5d36a1a6c25fed1c0e0c7c5c78956) | `` python311Packages.plugwise: 0.36.3 -> 0.37.0 ``                                         |
| [`b3afa52e`](https://github.com/NixOS/nixpkgs/commit/b3afa52e779afa6d19bd439178b18e2de66b15f4) | `` python311Packages.aioecowitt: 2023.5.0 -> 2024.2.0 ``                                   |
| [`de1050c3`](https://github.com/NixOS/nixpkgs/commit/de1050c378abe6d3e9d124de69d45be09b7a6fe2) | `` python311Packages.aiocomelit: 0.8.2 -> 0.8.3 ``                                         |
| [`21c6a21a`](https://github.com/NixOS/nixpkgs/commit/21c6a21a5cecaa2bcb94e654d9b7c6d8cffb41e5) | `` exploitdb: 2024-02-03 -> 2024-02-06 ``                                                  |
| [`e9a01814`](https://github.com/NixOS/nixpkgs/commit/e9a01814199dbf4e55c0d1fbf4a4ff48a5fc881e) | `` civo: 1.0.73 -> 1.0.75 ``                                                               |
| [`1ffd5e8c`](https://github.com/NixOS/nixpkgs/commit/1ffd5e8c157eb9790984cf59f0220c92007a6350) | `` cnspec: 10.1.4 -> 10.2.0 ``                                                             |
| [`8fa986bc`](https://github.com/NixOS/nixpkgs/commit/8fa986bc1ff6b09ebe59feb3dacee34b907ba6e9) | `` sentry-cli: 2.27.0 -> 2.28.0 ``                                                         |
| [`f00da402`](https://github.com/NixOS/nixpkgs/commit/f00da402fb5919044a63f06e698a48207c54a2ec) | `` lint-staged: 15.2.1 -> 15.2.2 ``                                                        |
| [`31f8693c`](https://github.com/NixOS/nixpkgs/commit/31f8693c31130e6935a8d2d6d32d4c003d75f820) | `` cargo-deny: 0.14.10 -> 0.14.11 ``                                                       |