### PR TITLE
chore(flake/home-manager): `5b9156fa` -> `bfd0ae29`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707467182,
-        "narHash": "sha256-/Bw/xgCXfj4nXDd8Xq+r1kaorfsYkkomMf5w5MpsDyA=",
+        "lastModified": 1707607386,
+        "narHash": "sha256-hj/RgQMTvCWQVInkZwiMMieumkfOjHXhtWhfuXHop/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5b9156fa9a8b8beba917b8f9adbfd27bf63e16af",
+        "rev": "bfd0ae29a86eff4603098683b516c67e22184511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`bfd0ae29`](https://github.com/nix-community/home-manager/commit/bfd0ae29a86eff4603098683b516c67e22184511) | `` emacs: use `overrideScope` instead of `overrideScope'` ``                 |
| [`d1d6ca9b`](https://github.com/nix-community/home-manager/commit/d1d6ca9b6552fc93032b76661c83061f1cd4e6e8) | `` flake.lock: Update ``                                                     |
| [`fb0196ad`](https://github.com/nix-community/home-manager/commit/fb0196ad9d18554e035de27d4f2a906ba050b407) | `` imapnotify: enable STARTTLS if enabled in email account config (#5013) `` |
| [`4c0357ff`](https://github.com/nix-community/home-manager/commit/4c0357ff874f8250fcae621d5626aba1c7161710) | `` sway: fix workspace 10 missing from default config (#4636) ``             |