### PR TITLE
chore(flake/nixpkgs): `f8e2ebd6` -> `d934204a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707268954,
-        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
+        "lastModified": 1707546158,
+        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
+        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`386faef6`](https://github.com/NixOS/nixpkgs/commit/386faef6e6d905abcbf9d4a85c92f60bbf5a61bb) | `` frogmouth: use same xdg package as upstream ``                            |
| [`83c5c463`](https://github.com/NixOS/nixpkgs/commit/83c5c463592d9f1d4d8d9c6775026c6e24c24448) | `` llvmPackages: cleanup orphaned files ``                                   |
| [`b2b2c220`](https://github.com/NixOS/nixpkgs/commit/b2b2c220167c6073c9f4aec32d74044dd384762d) | `` libunwind: remove incorrect badPlatforms (#286560) ``                     |
| [`e98791a2`](https://github.com/NixOS/nixpkgs/commit/e98791a204c49eb0111eef4943083ddee86b6b1b) | `` python311Packages.cloudflare: 2.17.0 -> 2.18.1 ``                         |
| [`9ce46e61`](https://github.com/NixOS/nixpkgs/commit/9ce46e61eb67e9f30e6f1035cfee382f3a13c33f) | `` nixos/hardened: fix lower bounds of hardened options ``                   |
| [`fda3c014`](https://github.com/NixOS/nixpkgs/commit/fda3c01430877ffb84e05d8feee7c75647b9e63e) | `` libsForQt5.mapbox-gl-native: mark broken (`gcc-13` build failure) ``      |
| [`f97db007`](https://github.com/NixOS/nixpkgs/commit/f97db0076776db83382483a1c9d9abcf998860c8) | `` oildev: disable libc tests failing w/ musl ``                             |
| [`c2e3bdf5`](https://github.com/NixOS/nixpkgs/commit/c2e3bdf541bc8a2a5a348c1b030815aeef8b2723) | `` material-black-colors: init at 0-unstable-2020-12-17 ``                   |
| [`4e3e3acc`](https://github.com/NixOS/nixpkgs/commit/4e3e3accfad18a9428ae85a2736ba29f0b9cb3ce) | `` kde-rounded-corners: fix source hash ``                                   |
| [`5c960e39`](https://github.com/NixOS/nixpkgs/commit/5c960e3981c52a968552934710f58f6aaf31e857) | `` srm-cuarzo: 0.5.0-1 -> 0.5.1-1 ``                                         |
| [`8d11f3e1`](https://github.com/NixOS/nixpkgs/commit/8d11f3e10122840918a46b2ea4ecffe3ba28dfd4) | `` libretro.fmsx: unstable-2023-04-17 -> unstable-2024-02-08 ``              |
| [`5c4c5048`](https://github.com/NixOS/nixpkgs/commit/5c4c50487cf97fcc8f433e225a191ee607251c1e) | `` libretro.genesis-plus-gx: unstable-2024-02-02 -> unstable-2024-02-06 ``   |
| [`fd86414a`](https://github.com/NixOS/nixpkgs/commit/fd86414aa0b7c9ebc6cc67813e85d8e7861daf78) | `` libretro.bsnes: unstable-2024-02-02 -> unstable-2024-02-09 ``             |
| [`d79a5f00`](https://github.com/NixOS/nixpkgs/commit/d79a5f00b5ec06b38d4b028eececcd9f244e9b3c) | `` libretro.gambatte: unstable-2024-02-02 -> unstable-2024-02-09 ``          |
| [`6e5b6b3d`](https://github.com/NixOS/nixpkgs/commit/6e5b6b3dd1e000a810d95796cc4e1df70fd518b1) | `` libretro.flycast: unstable-2024-02-03 -> unstable-2024-02-09 ``           |
| [`59b0ff3b`](https://github.com/NixOS/nixpkgs/commit/59b0ff3b92f980d16d749930fa0d84c056d19a5b) | `` jujutsu: provide $SHELL as positional args ``                             |
| [`671bedb5`](https://github.com/NixOS/nixpkgs/commit/671bedb5c75ecd2a2645796d773f7301d1aa259a) | `` jujutsu: 0.13.0 -> 0.14.0 ``                                              |
| [`df966328`](https://github.com/NixOS/nixpkgs/commit/df966328e0ee9183c57d6f1a409a418a4704b583) | `` libvirt: Fix broken when Kernel differs b/w current- and booted-system `` |
| [`cef87763`](https://github.com/NixOS/nixpkgs/commit/cef87763a3b4c336dba7fff325944ae28fd9c8aa) | `` libretro.fbneo: unstable-2024-01-30 -> unstable-2024-02-08 ``             |
| [`958778f7`](https://github.com/NixOS/nixpkgs/commit/958778f7fe8862823da7b7dc88eec64992da3ee2) | `` libretro.mame2003-plus: unstable-2024-02-03 -> unstable-2024-02-09 ``     |
| [`7065951e`](https://github.com/NixOS/nixpkgs/commit/7065951e177847b3d2325568071b7c0ece9957ca) | `` CODEOWNERS: add h7x4 to pkgs.formats.hocon ``                             |
| [`0e65eca7`](https://github.com/NixOS/nixpkgs/commit/0e65eca7c6c724bbddeb89ae8135c1fd67f71a84) | `` formats.hocon: add backwards compatibility ``                             |
| [`9ebcb6f5`](https://github.com/NixOS/nixpkgs/commit/9ebcb6f5dbd1a091c9b073587b6906b0c0663e08) | `` pkgs-lib: Make `lib` overlays be propagated ``                            |
| [`feadd8eb`](https://github.com/NixOS/nixpkgs/commit/feadd8ebe35bb8b4ca447490c1d080294f2bcac6) | `` libretro.ppsspp: unstable-2024-02-05 -> unstable-2024-02-09 ``            |
| [`6ed38373`](https://github.com/NixOS/nixpkgs/commit/6ed38373dc057bb5b853ea1ab9138375e4eb0acf) | `` coqPackages.mathcomp-analysis: 0.6.6 -> 1.0.0 (#285276) ``                |
| [`d12d9482`](https://github.com/NixOS/nixpkgs/commit/d12d94828285ab2ef2d83605e08c256bfc48b47d) | `` libretro.mame2003: unstable-2023-11-22 -> unstable-2024-02-08 ``          |
| [`9b6dcd65`](https://github.com/NixOS/nixpkgs/commit/9b6dcd65b36b55a4865de0a82f7979d4698d48d1) | `` krita: fix build with libjxl >= 0.9.0 ``                                  |
| [`a24ea6dd`](https://github.com/NixOS/nixpkgs/commit/a24ea6dda77e678e89a5245b0550e5de5c22ff8f) | `` libretro.beetle-supergrafx: unstable-2024-02-02 -> unstable-2024-02-09 `` |
| [`a1232992`](https://github.com/NixOS/nixpkgs/commit/a1232992ac16a1c9b094895cc3ad677bf34ee450) | `` nixos/amazon-image: Take over maintainership ``                           |
| [`2a98f1c8`](https://github.com/NixOS/nixpkgs/commit/2a98f1c84eeb6f22c956ccfa160284d91a1cb099) | `` x265: add mingw support ``                                                |
| [`8b06cac5`](https://github.com/NixOS/nixpkgs/commit/8b06cac5f8e8217ea41333fc64cb4a8d46d826fd) | `` x265: run nixpkgs-fmt ``                                                  |
| [`6babd03f`](https://github.com/NixOS/nixpkgs/commit/6babd03fa0105108e9d5e746e864904e51fe61e1) | `` cargo-espflash: rename to espflash (#286386) ``                           |
| [`e2a31fdb`](https://github.com/NixOS/nixpkgs/commit/e2a31fdb9378d830727eed39104de7ec0b89dbdc) | `` python311Packages.iminuit: 2.25.0 -> 2.25.1 ``                            |
| [`397e3e8a`](https://github.com/NixOS/nixpkgs/commit/397e3e8ae512400ae7937d0a4e7e001887bea14c) | `` libretro.beetle-pce: unstable-2024-02-02 -> unstable-2024-02-09 ``        |
| [`4cbc031b`](https://github.com/NixOS/nixpkgs/commit/4cbc031bcb5b6b50ce8bfe009ce397542a38f2fb) | `` libretro.beetle-pce-fast: unstable-2024-02-02 -> unstable-2024-02-09 ``   |
| [`c42b5432`](https://github.com/NixOS/nixpkgs/commit/c42b54322e6ab996e0443d9e79ed881e382870b8) | `` plantuml: 1.2024.0 -> 1.2024.1 ``                                         |
| [`e56258dd`](https://github.com/NixOS/nixpkgs/commit/e56258dd2903f5d40def8ae77bf84c048e05bb1d) | `` torsocks: fix build on darwin ``                                          |
| [`c67619f8`](https://github.com/NixOS/nixpkgs/commit/c67619f8239756e5c980f311e021591e1a6910a6) | `` libretro.pcsx-rearmed: unstable-2024-02-04 -> unstable-2024-02-07 ``      |
| [`817d2017`](https://github.com/NixOS/nixpkgs/commit/817d20170dc6b7b2c195a6c3271d88789f206b0b) | `` curl.tests.static: init ``                                                |
| [`6f0607e3`](https://github.com/NixOS/nixpkgs/commit/6f0607e3b0d774e4eb2456db4edd022de24723df) | `` libretro.snes9x: unstable-2024-01-28 -> unstable-2024-02-08 ``            |
| [`f8bc18fe`](https://github.com/NixOS/nixpkgs/commit/f8bc18fe30a58966a0ed77f82df4bdd9a5f40031) | `` libretro.beetle-psx-hw: unstable-2024-02-02 -> unstable-2024-02-09 ``     |
| [`4ae08276`](https://github.com/NixOS/nixpkgs/commit/4ae0827699ae0b3b412b5683bddb23d251b529c9) | `` pkgsStatic.curl: fix build ``                                             |
| [`39a779e2`](https://github.com/NixOS/nixpkgs/commit/39a779e269b012c721b34eee74f76afca3d03d7d) | `` treewide: use `formats.hocon` ``                                          |
| [`b6cdfec1`](https://github.com/NixOS/nixpkgs/commit/b6cdfec16ce7ce7c0d837b05ed3ad99aa6223647) | `` formats.hocon: add tests ``                                               |
| [`2554eba2`](https://github.com/NixOS/nixpkgs/commit/2554eba2ca05a1c3bbd7aaaa443b50b2a7ae4430) | `` formats.hocon: init ``                                                    |
| [`6dafc6f4`](https://github.com/NixOS/nixpkgs/commit/6dafc6f4e75a08095ac1b8356346ff0c6d8447b1) | `` libretro.mupen64plus: unstable-2024-01-30 -> unstable-2024-02-06 ``       |
| [`91d9c159`](https://github.com/NixOS/nixpkgs/commit/91d9c159da33cee81db80eca5643493ce2c65522) | `` nixos/matrix-synapse: fix recursive filtering of null values ``           |
| [`143d266f`](https://github.com/NixOS/nixpkgs/commit/143d266f0db386af987d19e0de79128bc8669714) | `` nixos/matrix-synapse: add UNIX domain socket listener support ``          |
| [`07a3e1b7`](https://github.com/NixOS/nixpkgs/commit/07a3e1b735e491a7bb7378578a7903940482dd6e) | `` ocenaudio: fix url ``                                                     |
| [`a59991b7`](https://github.com/NixOS/nixpkgs/commit/a59991b77b4d9d16b25f7f1c9db8309d8ae207c2) | `` python311Packages.chacha20poly1305-reuseable: 0.12.0 -> 0.12.1 ``         |
| [`7278e451`](https://github.com/NixOS/nixpkgs/commit/7278e451df90a7edc20550c536ed9f168b51d64f) | `` recoll: 1.36.2 -> 1.37.2 ``                                               |
| [`ae800735`](https://github.com/NixOS/nixpkgs/commit/ae8007359e7d93b606481995c1ec075fcc434b94) | `` ccache: 4.9 -> 4.9.1 ``                                                   |
| [`1bbad171`](https://github.com/NixOS/nixpkgs/commit/1bbad171d047923009063a517e52e0075c0566ed) | `` ccache: move to pkgs/by-name ``                                           |
| [`8dc17298`](https://github.com/NixOS/nixpkgs/commit/8dc1729833bba4ccdc8a4d785bed891a6a92dd75) | `` nimlangserver: init at 1.2.0 ``                                           |
| [`3f3a7478`](https://github.com/NixOS/nixpkgs/commit/3f3a74782d6da0d0c29256dafbddcf1d0ceaa1dd) | `` maintainers: add daylinmorgan ``                                          |
| [`5054d128`](https://github.com/NixOS/nixpkgs/commit/5054d1282f96f108ccd8a75e653bb7a2dcec334e) | `` amphetype: add desktop item ``                                            |
| [`1a72ea77`](https://github.com/NixOS/nixpkgs/commit/1a72ea772242923cc8d13b063ab1b224391dabf3) | `` ehmry: reduce maintainership ``                                           |
| [`3489aa0f`](https://github.com/NixOS/nixpkgs/commit/3489aa0fc864fc964920cc9c35e6ceb8330dd331) | `` baresip: 3.8.1 -> 3.9.0 ``                                                |
| [`6b99ea2e`](https://github.com/NixOS/nixpkgs/commit/6b99ea2eea6a6341bbe1fa32d7e596aa53a875f3) | `` postgresqlPackages.postgis: 3.4.1 -> 3.4.2 ``                             |
| [`fa9ba5ad`](https://github.com/NixOS/nixpkgs/commit/fa9ba5ade973ea16d03acc9c1cc5841483577552) | `` baresip: move to pkgs/by-name ``                                          |
| [`af7c41bf`](https://github.com/NixOS/nixpkgs/commit/af7c41bf1cdfb6cf2ea8c8fab4cec456afd91148) | `` python311Packages.pyorthanc: 1.16.0 -> 1.16.1 ``                          |
| [`bab00e00`](https://github.com/NixOS/nixpkgs/commit/bab00e00deeb9b802e7feabfc4c95b90b445cfa4) | `` Update pkgs/games/dxx-rebirth/default.nix ``                              |
| [`c20f87f0`](https://github.com/NixOS/nixpkgs/commit/c20f87f00d445849b0149698884b893e4ac61cec) | `` dxx-rebirth: unstable-2023-03-23 -> unstable-2024-01-13 ``                |
| [`e94f7aef`](https://github.com/NixOS/nixpkgs/commit/e94f7aef0907e0f6a3dd5b2cae1492e6db030287) | `` plzip: 1.10 -> 1.11 ``                                                    |
| [`c85d9eed`](https://github.com/NixOS/nixpkgs/commit/c85d9eeda9d1c6fb5a9e173f2944c40ce4929720) | `` plzip: pkgs/tools/compression/plzip -> pkgs/by-name/pl/plzip ``           |
| [`9ecc05d7`](https://github.com/NixOS/nixpkgs/commit/9ecc05d7bf38eb80cdde699e2dc4d10b30318846) | `` lzlib: 1.13 -> 1.14 ``                                                    |
| [`c863ce3a`](https://github.com/NixOS/nixpkgs/commit/c863ce3ae2976a7f565d5621a75bb3c6cdcfb177) | `` lzlib: pkgs/development/libraries/lzlib -> pkgs/by-name/lz/lzlib ``       |
| [`464fe928`](https://github.com/NixOS/nixpkgs/commit/464fe9284b77d2ce73d04801715787d70455a9e7) | `` ledfx: 2.0.90 -> 2.0.92 ``                                                |
| [`2c8d7739`](https://github.com/NixOS/nixpkgs/commit/2c8d7739548f1b3a21e21bc49cbad93216be919c) | `` higan: 115+unstable=2021-08-18 -> 115-unstable-2023-11-13 ``              |
| [`67c8dd75`](https://github.com/NixOS/nixpkgs/commit/67c8dd7508de39457fc83f43de795a98d5d2fbff) | `` dnf5: 5.1.10 -> 5.1.12 ``                                                 |
| [`85f4b05e`](https://github.com/NixOS/nixpkgs/commit/85f4b05e39b55de136ff04745059ff250451ad9c) | `` doc: add link to QEMU reference documentation in QEMU module ``           |
| [`14d722d5`](https://github.com/NixOS/nixpkgs/commit/14d722d5672b1620c72c58dd470b7624707339e3) | `` lite-xl: 2.1.1 -> 2.1.3 ``                                                |
| [`5d18c5fb`](https://github.com/NixOS/nixpkgs/commit/5d18c5fbcea2e8b7062b1befad495d00c8a86b37) | `` Revert "python311Packages.py-aosmith: 1.0.6 -> 1.0.8" ``                  |
| [`48820eed`](https://github.com/NixOS/nixpkgs/commit/48820eedfcff80405d195b6c6be6c6c1dc874b24) | `` redpanda-client: 23.3.4 -> 23.3.5 ``                                      |
| [`b1f6e081`](https://github.com/NixOS/nixpkgs/commit/b1f6e081777d7b601771a3cf0c40ca41b9b215c7) | `` doc: add link to Nix manual ``                                            |
| [`d9dacad8`](https://github.com/NixOS/nixpkgs/commit/d9dacad8a3cae75a319e176ffe462983747312b4) | `` openjfx17: fix `withWebKit  = true` build ``                              |
| [`4d32c5a9`](https://github.com/NixOS/nixpkgs/commit/4d32c5a9041a8bf8d69105ccc573fa72981f03d8) | `` fheroes2: 1.0.11 -> 1.0.12 ``                                             |
| [`98f6d2d5`](https://github.com/NixOS/nixpkgs/commit/98f6d2d5c43f4318ab89c9db676aa2856c56bdf0) | `` bkcrack: 1.6.0 -> 1.6.1 ``                                                |
| [`2897fe56`](https://github.com/NixOS/nixpkgs/commit/2897fe56d7a26f64b82e6a631dccca1015949e23) | `` mympd: 14.0.0 -> 14.0.1 ``                                                |
| [`e0cf782e`](https://github.com/NixOS/nixpkgs/commit/e0cf782eb41ae79111431148304fed4e42a934b7) | `` cyberchef: 10.6.0 -> 10.7.0 ``                                            |
| [`c2cbe752`](https://github.com/NixOS/nixpkgs/commit/c2cbe752d35e7989c626392480341d9051323363) | `` nixosTests.freetube: mark as broken on aarch64-linux ``                   |
| [`cd81223a`](https://github.com/NixOS/nixpkgs/commit/cd81223afcd07b350c57627ef575925ce1d8359a) | `` gokey: init at 0.1.2-unstable-2023-11-16 ``                               |
| [`bffdd5bc`](https://github.com/NixOS/nixpkgs/commit/bffdd5bcf58d54e03e941e7a1521693a71113397) | `` python311Packages.pymicrobot: 0.0.10 -> 0.0.12 ``                         |
| [`565f186c`](https://github.com/NixOS/nixpkgs/commit/565f186c833fb83a08b67ebb0c8f136e2831177e) | `` python311Packages.py-aosmith: 1.0.6 -> 1.0.8 ``                           |
| [`a66a9840`](https://github.com/NixOS/nixpkgs/commit/a66a98401112ddc12690dbbba6b7544313215f2c) | `` freetube: make compatible with NIXOS_OZONE_WL ``                          |
| [`09e6cac7`](https://github.com/NixOS/nixpkgs/commit/09e6cac71aff461a8f349bba75a183de707702f6) | `` python311Packages.pymodbus: 3.5.4 -> 3.6.4 ``                             |
| [`c6e46679`](https://github.com/NixOS/nixpkgs/commit/c6e46679703f4072ff46c0d1cdba2c7a0b2a05f3) | `` cfripper: 1.15.2 -> 1.15.3 ``                                             |
| [`1c04fd26`](https://github.com/NixOS/nixpkgs/commit/1c04fd269fb0ccbaa3ef913a229e9cdb33996b50) | `` python311Packages.pycfmodel: 0.21.2 -> 0.22.0 ``                          |
| [`ab6b1440`](https://github.com/NixOS/nixpkgs/commit/ab6b144049644e7ee1577933c7081672f378dc37) | `` python311Packages.griffe: 0.40.0 -> 0.40.1 ``                             |