### PR TITLE
chore(flake/home-manager): `bfd0ae29` -> `21b07830`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707607386,
-        "narHash": "sha256-hj/RgQMTvCWQVInkZwiMMieumkfOjHXhtWhfuXHop/8=",
+        "lastModified": 1707683400,
+        "narHash": "sha256-Zc+J3UO1Xpx+NL8UB6woPHyttEy9cXXtm+0uWwzuYDc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bfd0ae29a86eff4603098683b516c67e22184511",
+        "rev": "21b078306a2ab68748abf72650db313d646cf2ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`21b07830`](https://github.com/nix-community/home-manager/commit/21b078306a2ab68748abf72650db313d646cf2ca) | `` flake.lock: Update ``                    |
| [`a09cfdba`](https://github.com/nix-community/home-manager/commit/a09cfdbaf11c821340cff24d9ad1c264708ee12e) | `` neomutt: Initial IMAP support (#4597) `` |