### PR TITLE
chore(flake/nixpkgs): `d934204a` -> `f9d39fb9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707546158,
-        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
+        "lastModified": 1707689078,
+        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
+        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7cea566f`](https://github.com/NixOS/nixpkgs/commit/7cea566f2571fcec7d69c84e04d066ba809d730b) | `` home-assistant: pin python-slugify at 8.0.1 ``                            |
| [`9c164371`](https://github.com/NixOS/nixpkgs/commit/9c164371865549575c5ca3eb4454f477fed88d6a) | `` python311Packages.correctionlib: fix build ``                             |
| [`016be1d8`](https://github.com/NixOS/nixpkgs/commit/016be1d8b30166a4b4d8e2f6864f1575be74fe0e) | `` lean3: fix `gcc-13` build failure) ``                                     |
| [`4a4904c2`](https://github.com/NixOS/nixpkgs/commit/4a4904c2b223351f85cee3127180406edce76eb3) | `` nixos/fwupd: make test option internal, be explicit about removal ``      |
| [`b93d987a`](https://github.com/NixOS/nixpkgs/commit/b93d987a8441384a6bac336318b1582d52305412) | `` maintainers: remove das-g from geospatial team ``                         |
| [`2a5ea884`](https://github.com/NixOS/nixpkgs/commit/2a5ea884f9d5d265032c890c652bb3b2d404adac) | `` josm: 18940 → 18969 ``                                                    |
| [`01cac444`](https://github.com/NixOS/nixpkgs/commit/01cac4444b40e0cc3a6237a5c8d12da973721334) | `` python311Packages.holidays: fix hash ``                                   |
| [`db0f864f`](https://github.com/NixOS/nixpkgs/commit/db0f864fcdca9971cdab14e114d79c8f6f838ebd) | `` qovery-cli: 0.83.1 -> 0.84.0 ``                                           |
| [`8579f700`](https://github.com/NixOS/nixpkgs/commit/8579f700f8cdf0f43cb13791509cd8aae41bfaab) | `` python311Packages.identify: refactor ``                                   |
| [`9687bedc`](https://github.com/NixOS/nixpkgs/commit/9687bedc4c89d8ec12ab2cd2a8fc142f63511259) | `` sgx-azure-dcap-client: fix `gcc-13` build failure ``                      |
| [`1128be27`](https://github.com/NixOS/nixpkgs/commit/1128be27756c08da5556852634a9b4717ba22029) | `` openrefine: 3.7.7 -> 3.7.9 ``                                             |
| [`e05648ed`](https://github.com/NixOS/nixpkgs/commit/e05648ed37cf79ba55babb70a22909d370e84c29) | `` vimPlugins.ultimate-autopair: init at 2024-02-10 (#287913) ``             |
| [`652d8b87`](https://github.com/NixOS/nixpkgs/commit/652d8b87e24548a6b18bc4e96e117fc99c1d2a48) | `` python311Packages.identify: 2.5.33 -> 2.5.34 ``                           |
| [`45b4c6f5`](https://github.com/NixOS/nixpkgs/commit/45b4c6f5eb46bd9e51b54be9672ab69b20e7e18a) | `` python311Packages.google-ai-generativelanguage: 0.5.1 -> 0.5.2 ``         |
| [`7786bf75`](https://github.com/NixOS/nixpkgs/commit/7786bf7565c5c4247fffaf50c24fc8dc5e7510b8) | `` docfd: change long description ``                                         |
| [`8afc7811`](https://github.com/NixOS/nixpkgs/commit/8afc781161d3e814ca75a4d3c0bdab0adcbceb24) | `` docfd: add fzf support ``                                                 |
| [`3882e555`](https://github.com/NixOS/nixpkgs/commit/3882e555592f258bde36adaa93d997f6f31ba349) | `` pixelfed: use php.buildComposerProject ``                                 |
| [`0980fcad`](https://github.com/NixOS/nixpkgs/commit/0980fcadf51fd01d30ce1463e18f1e59a1e104d4) | `` python311Packages.google-cloud-os-config: 1.17.0 -> 1.17.1 ``             |
| [`2d015e9b`](https://github.com/NixOS/nixpkgs/commit/2d015e9b6e05761b36b288a1ac773dd804f85552) | `` nodePackages.vscode-json-languageserver: set meta.mainProgram ``          |
| [`f33867be`](https://github.com/NixOS/nixpkgs/commit/f33867beacaafb36d89c4f06e959d368841cc23c) | `` emplace: 1.5.2 -> 1.5.3 ``                                                |
| [`af61ca6c`](https://github.com/NixOS/nixpkgs/commit/af61ca6cdd78b6790625babb0efd7677980657cb) | `` palemoon-bin: 32.5.2 -> 33.0.0 ``                                         |
| [`089f45ce`](https://github.com/NixOS/nixpkgs/commit/089f45ce691aa3b26d52f9b718a205af2493a455) | `` buildLuarocksPackage: remove rockspecDir (#288036) ``                     |
| [`052491f3`](https://github.com/NixOS/nixpkgs/commit/052491f384b60a7e8d983947f1459ed22f4b32f5) | `` CODEOWNERS: add raitobezarius on the linux kernel ``                      |
| [`685fe895`](https://github.com/NixOS/nixpkgs/commit/685fe89584ee417079788fb6d72e47a47533ff9f) | `` python311Packages.brotli-asgi: fix build ``                               |
| [`e0174c26`](https://github.com/NixOS/nixpkgs/commit/e0174c26688ee24472e238447f8a81bc8dc26ed9) | `` ghfetch: init at 0.0.19 ``                                                |
| [`a41d4390`](https://github.com/NixOS/nixpkgs/commit/a41d4390390708f13c1809ffae94f4d5702ca345) | `` python311Packages.google-cloud-artifact-registry: 1.10.0 -> 1.11.1 ``     |
| [`4ccedfae`](https://github.com/NixOS/nixpkgs/commit/4ccedfae09b7873b353a285e6073d616bac8fa51) | `` paper-plane: init at 0.1.0-beta.5 ``                                      |
| [`0966e830`](https://github.com/NixOS/nixpkgs/commit/0966e830addec328b0a5aea668028d1ac5766e45) | `` obs-do: 0.1.0 -> 0.1.1 ``                                                 |
| [`8f5f180f`](https://github.com/NixOS/nixpkgs/commit/8f5f180f99a747a182231fd4f5330b8ada134366) | `` home-manager: unstable-2024-02-06 -> unstable-2024-02-11 ``               |
| [`73145ca8`](https://github.com/NixOS/nixpkgs/commit/73145ca8948a6c2adf4e1f1d436b2926d998dfae) | `` putty: add desktop item ``                                                |
| [`30dae7ef`](https://github.com/NixOS/nixpkgs/commit/30dae7ef218d6166829c145d42ec1a80423906db) | `` phrase-cli: 2.21.2 -> 2.22.0 ``                                           |
| [`2e4073c0`](https://github.com/NixOS/nixpkgs/commit/2e4073c0c6b523f4c073db578c2b8e249e1ccca9) | `` xcbuild: fix `gcc-13` build failure ``                                    |
| [`80e18728`](https://github.com/NixOS/nixpkgs/commit/80e187287de0e1c7307cd3df4708a227425030b1) | `` gImageReader: 3.4.1 -> 3.4.2 ``                                           |
| [`14f9faad`](https://github.com/NixOS/nixpkgs/commit/14f9faadd047afcfcfdd9572a83c10c080673097) | `` vowpal-wabbit: fix `gcc-13` build failure ``                              |
| [`29753a7c`](https://github.com/NixOS/nixpkgs/commit/29753a7cdff01eacbba57ff855527f8b521c3a01) | `` vkmark: unstable-2022-09-09 -> 2017.08-unstable-2023-04-12 ``             |
| [`b5bf528e`](https://github.com/NixOS/nixpkgs/commit/b5bf528ee0fe465e581d78b5c8ce5093153850b8) | `` vibrantlinux: fix revision to contain `v` prefix ``                       |
| [`d8c17b8a`](https://github.com/NixOS/nixpkgs/commit/d8c17b8a684ec778a43225f734be0f18735bb248) | `` ghostunnel: 1.7.1 -> 1.7.3 ``                                             |
| [`cfd945e5`](https://github.com/NixOS/nixpkgs/commit/cfd945e54a1a8f52887a27674c396ca04812ed1c) | `` semantic-release: 23.0.1 -> 23.0.2 ``                                     |
| [`a37f74e6`](https://github.com/NixOS/nixpkgs/commit/a37f74e679623b84c6d916711c1b63de22ccc683) | `` vcpkg-tool: 2024-02-05 -> 2024-02-07 ``                                   |
| [`c6d168d0`](https://github.com/NixOS/nixpkgs/commit/c6d168d0b431160addbe7340f3d81eb8ad5aac7e) | `` pixelfed: 0.11.8 -> 0.11.11 ``                                            |
| [`9d218962`](https://github.com/NixOS/nixpkgs/commit/9d218962754f19e43e082c0ba219b766ca773395) | `` runme: 2.2.5 -> 2.2.6 ``                                                  |
| [`86509d3b`](https://github.com/NixOS/nixpkgs/commit/86509d3bf5e983eb611f7c852cdbccad3ec9715d) | `` croc: 9.6.8 -> 9.6.9 ``                                                   |
| [`158767db`](https://github.com/NixOS/nixpkgs/commit/158767db6a35153c39cdb017725ec04ec759c70b) | `` gnomeExtensions.no-title-bar: drop self from maintainers ``               |
| [`3cedce95`](https://github.com/NixOS/nixpkgs/commit/3cedce9593e80d24ee241914b8d0e8e323ad6a64) | `` yaru: drop self from maintainers ``                                       |
| [`f18db890`](https://github.com/NixOS/nixpkgs/commit/f18db8905dd9a805be67ed0bd0545a7a05b98d9e) | `` docker: drop self from maintainers ``                                     |
| [`e38d3d6c`](https://github.com/NixOS/nixpkgs/commit/e38d3d6c37abdc5ddc1cde1c53a419fb461caa84) | `` vscode: drop self from maintainers ``                                     |
| [`2f76c2ee`](https://github.com/NixOS/nixpkgs/commit/2f76c2ee8bfa8d2ed412b6d14fc4f5c43a61a973) | `` the-powder-toy: fix `gcc-13` build failure ``                             |
| [`d15e6302`](https://github.com/NixOS/nixpkgs/commit/d15e6302d629766edc8f98aa0244f39df45062c9) | `` tensorflow-lite: fix `gcc-13` build failure ``                            |
| [`12a238cd`](https://github.com/NixOS/nixpkgs/commit/12a238cd4466a93daa80846ee26cc7e95746be28) | `` yamlfmt: 0.10.0 -> 0.11.0 ``                                              |
| [`8d624d2e`](https://github.com/NixOS/nixpkgs/commit/8d624d2e797bf1b41edebe6cdcbd28bb45beb0e2) | `` xmousepasteblock: 1.3 -> 1.4 ``                                           |
| [`11078ca4`](https://github.com/NixOS/nixpkgs/commit/11078ca4eea808b75d3fd1d167e9c995b2f76c4b) | `` spglib: 2.3.0 -> 2.3.1 ``                                                 |
| [`88b64fa7`](https://github.com/NixOS/nixpkgs/commit/88b64fa73471ed9fcb2eaf5537f5c1f78a20912b) | `` python311Packages.python-gvm: enable darwin support ``                    |
| [`21d113f1`](https://github.com/NixOS/nixpkgs/commit/21d113f17866c636c3b632cde979a14e504fd36f) | `` python311Packages.python-gvm: refactor ``                                 |
| [`480010b7`](https://github.com/NixOS/nixpkgs/commit/480010b786c1234235726c758e74e0f9e3ad4ae2) | `` Revert "stlink: fix stlink build for macos" ``                            |
| [`70e792d6`](https://github.com/NixOS/nixpkgs/commit/70e792d65eb1f334a75a2e2e707c21a4bc58bd41) | `` qlog: 0.31.0 -> 0.32.0 ``                                                 |
| [`c05249b1`](https://github.com/NixOS/nixpkgs/commit/c05249b102538330f8f6fa1ab1e1899d1ecc398c) | `` kubedock: 0.15.2 -> 0.15.3 ``                                             |
| [`8744f66e`](https://github.com/NixOS/nixpkgs/commit/8744f66ee51c7adbe37d249d44f10c15ac3c0c38) | `` stone-phaser: fix `gcc-13` build failure ``                               |
| [`19aef49f`](https://github.com/NixOS/nixpkgs/commit/19aef49f46b4f0180c56ca5f51853183d9817e9c) | `` boxed-cpp: 1.2.2 -> 1.3.0 ``                                              |
| [`62de2796`](https://github.com/NixOS/nixpkgs/commit/62de2796c34b2769d8ff1be069a15baf7927a2aa) | `` gotestwaf: 0.4.11 -> 0.4.12 ``                                            |
| [`1093971c`](https://github.com/NixOS/nixpkgs/commit/1093971c6125dec955cba541973c4c996ba073d2) | `` bacon: 2.14.1 -> 2.14.2 ``                                                |
| [`6810156f`](https://github.com/NixOS/nixpkgs/commit/6810156f7df0d1de951596967519ab9127dd6e68) | `` stenc: fix `gcc-13` build failure ``                                      |
| [`df4b36d0`](https://github.com/NixOS/nixpkgs/commit/df4b36d09256c8f3dbc3f075816cf99cd7e100a5) | `` whitesur-gtk-theme: add additional options ``                             |
| [`d569d776`](https://github.com/NixOS/nixpkgs/commit/d569d776c215ed768b38d6b989a09de7b1d2e44e) | `` whitesur-gtk-theme: fix color variant option names ``                     |
| [`b1b0325b`](https://github.com/NixOS/nixpkgs/commit/b1b0325b84cd03477223386d298a7278e14fa3ab) | `` youtrack: 2023.3.23390 -> 2023.3.24329 ``                                 |
| [`bdc57436`](https://github.com/NixOS/nixpkgs/commit/bdc57436da855500d44e9c1ce7450c0772e1cfa1) | `` kdiff3: fix build ``                                                      |
| [`02e8a982`](https://github.com/NixOS/nixpkgs/commit/02e8a982ffb7dc2577ae501665f8d65dbca4e07a) | `` sqlcheck: fix `gcc-13` build failure ``                                   |
| [`3bdb98ca`](https://github.com/NixOS/nixpkgs/commit/3bdb98ca15373e4f56a9bdbf2342af29f5936c50) | `` nixpacks: 1.21.0 -> 1.21.1 ``                                             |
| [`b7ccd61c`](https://github.com/NixOS/nixpkgs/commit/b7ccd61c2235666eb63f4c5855ddbf78368bd5ce) | `` parallel-disk-usage: 0.9.0 -> 0.9.1 ``                                    |
| [`c2232d06`](https://github.com/NixOS/nixpkgs/commit/c2232d06150e55de45f24249510d79e28a19648f) | `` cargo-hack: 0.6.17 -> 0.6.18 ``                                           |
| [`d7a1c3e8`](https://github.com/NixOS/nixpkgs/commit/d7a1c3e87584213436b772bab1b85851c6c40caa) | `` gotestwaf: 0.4.11 -> 0.4.12 ``                                            |
| [`33c7b128`](https://github.com/NixOS/nixpkgs/commit/33c7b128a3aee943ac405b4e9781dec19d9c5cc7) | `` monkeysAudio: 10.48 -> 10.49 ``                                           |
| [`fa365616`](https://github.com/NixOS/nixpkgs/commit/fa365616d40e312c2d6b86411c4f6248481c4b81) | `` pict-rs: 0.5.1 -> 0.5.6 ``                                                |
| [`206813f8`](https://github.com/NixOS/nixpkgs/commit/206813f86a248d366a8af42c22112643822c0036) | `` python312Packages.plantuml-markdown: 3.9.2 -> 3.9.3 ``                    |
| [`47044950`](https://github.com/NixOS/nixpkgs/commit/470449507052162a7dd6f1bd1ac9752fb88d7ba7) | `` flix: 0.43.0 -> 0.44.0 ``                                                 |
| [`7a66f7aa`](https://github.com/NixOS/nixpkgs/commit/7a66f7aabedb834e9302e1232db71905272b4f7f) | `` python312Packages.pygit2: 1.14.0 -> 1.14.1 ``                             |
| [`1dd0975b`](https://github.com/NixOS/nixpkgs/commit/1dd0975bed064319d96096483d340fda4c154bf4) | `` rshijack: 0.5.0 -> 0.5.1 ``                                               |
| [`09c3056f`](https://github.com/NixOS/nixpkgs/commit/09c3056fa7e52ca968e1c1f7710251518b3482d3) | `` waycheck: 1.0.0 -> 1.1.0 ``                                               |
| [`e0a0f7a2`](https://github.com/NixOS/nixpkgs/commit/e0a0f7a2a66b3f593df8cfb432bc8fb2f6525f92) | `` cockpit: 308 -> 310.2 ``                                                  |
| [`e6339862`](https://github.com/NixOS/nixpkgs/commit/e63398629601560924e5db9b48bf38da24b62047) | `` python311Packages.google-cloud-texttospeech: 2.16.0 -> 2.16.1 ``          |
| [`9f549c2f`](https://github.com/NixOS/nixpkgs/commit/9f549c2f3cff13808fa445f184d483c91d723cd2) | `` postgresqlPackages.pg_squeeze: 1.5.2 -> 1.6.2 ``                          |
| [`f432130f`](https://github.com/NixOS/nixpkgs/commit/f432130f0f1f7f379df141a5bb45b147431997ba) | `` tootle: remove ``                                                         |
| [`0da7226c`](https://github.com/NixOS/nixpkgs/commit/0da7226c31d93e6696decf59dd8a1fb114bc7bd6) | `` tuxclocker: 1.5.0 -> 1.5.1 ``                                             |
| [`1a73b72e`](https://github.com/NixOS/nixpkgs/commit/1a73b72e5377c93610cfb738c6cb7193e747a6b3) | `` eask: 0.9.3 -> 0.9.5 ``                                                   |
| [`cce3b464`](https://github.com/NixOS/nixpkgs/commit/cce3b464197616f55aaad6e4f89e071630880912) | `` oterm: fix build ``                                                       |
| [`3bb28861`](https://github.com/NixOS/nixpkgs/commit/3bb28861ad5d571c9162529ca2a58b5d07dca404) | `` python311Packages.mitmproxy: fix build ``                                 |
| [`2ffb6c1d`](https://github.com/NixOS/nixpkgs/commit/2ffb6c1d1832c324fd6a070e6b608a53d76e913e) | `` msolve: 0.6.3 -> 0.6.4 ``                                                 |
| [`055a8f70`](https://github.com/NixOS/nixpkgs/commit/055a8f709ad75bec0aa723e7b413a695d24d7e3a) | `` nixos/home-assistant: always add dependencies for default integrations `` |