### PR TITLE
chore(flake/home-manager): `21b07830` -> `043ba285`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707683400,
-        "narHash": "sha256-Zc+J3UO1Xpx+NL8UB6woPHyttEy9cXXtm+0uWwzuYDc=",
+        "lastModified": 1707919853,
+        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "21b078306a2ab68748abf72650db313d646cf2ca",
+        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`043ba285`](https://github.com/nix-community/home-manager/commit/043ba285c6dc20f36441d48525402bcb9743c498) | `` tests: add basic integration tests ``                 |
| [`7889bfb4`](https://github.com/nix-community/home-manager/commit/7889bfb4752b27c83c8ae9ca45f63b77fff7ef7b) | `` home-manager: overrideable URLs in generated flake `` |
| [`354643e6`](https://github.com/nix-community/home-manager/commit/354643e6c1ce0762d498e5e676e7970922c89208) | `` neomutt: fix tests ``                                 |
| [`157bf712`](https://github.com/nix-community/home-manager/commit/157bf71277c92dfc4691e5e1eb88db94043e3865) | `` mpv: create doc output in tests ``                    |