### PR TITLE
chore(flake/nixpkgs): `f9d39fb9` -> `35ff7e87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707689078,
-        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "lastModified": 1707863367,
+        "narHash": "sha256-LdBbCSSP7VHaHA4KXcPGKqkvsowT2+7W4jlEHJj6rPg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "rev": "35ff7e87ee05199a8003f438ec11a174bcbd98ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`32c95ed9`](https://github.com/NixOS/nixpkgs/commit/32c95ed9d53bc1827fc66082c89c0aca9ee0ecba) | `` ocamlPackages.ocamlfuse: 2.7.1_cvs8 -> 2.7.1_cvs9 ``                           |
| [`c5b54492`](https://github.com/NixOS/nixpkgs/commit/c5b544922979418b8ed0d25f66fe344c9ef96fa7) | `` scitoken-cpp -> scitokens-cpp (#288390) ``                                     |
| [`b3af565a`](https://github.com/NixOS/nixpkgs/commit/b3af565a75629383085dd9e2acf2b1355c47f06c) | `` picom: 11.1 -> 11.2 ``                                                         |
| [`f8e8c48b`](https://github.com/NixOS/nixpkgs/commit/f8e8c48b6f1cbdd5f177e85f505cb033782db21e) | `` python311Packages.cloudflare: 2.18.1 -> 2.18.2 ``                              |
| [`f28e3147`](https://github.com/NixOS/nixpkgs/commit/f28e3147c07d07de297d2d5d2b9211934bc41450) | `` libretro.mame: unstable-2024-02-05 -> unstable-2024-02-13 ``                   |
| [`c0adb0b9`](https://github.com/NixOS/nixpkgs/commit/c0adb0b97be930c517820058820580e1a3dad24a) | `` dmenu-wayland: add meta.mainProgram ``                                         |
| [`5d3edd72`](https://github.com/NixOS/nixpkgs/commit/5d3edd72b30e1e6f1a66ab1b3fbf447f8d0994b2) | `` stratisd: 3.6.4 -> 3.6.5 ``                                                    |
| [`93ffa126`](https://github.com/NixOS/nixpkgs/commit/93ffa1263166a9f6c562bff1b566168b0452ee61) | `` libretro.vecx: unstable-2023-06-01 -> unstable-2024-02-10 ``                   |
| [`6ab98280`](https://github.com/NixOS/nixpkgs/commit/6ab9828082549c3442e1743734735aec76ffe98e) | `` libretro.flycast: unstable-2024-02-09 -> unstable-2024-02-09 ``                |
| [`38513315`](https://github.com/NixOS/nixpkgs/commit/38513315386e828b9d296805657726e63e338076) | `` wasm-bindgen-cli: 0.2.89 -> 0.2.91 (#286975) ``                                |
| [`aa7b9656`](https://github.com/NixOS/nixpkgs/commit/aa7b9656b8d7731a8e8b2e80f71dc337502d7ccf) | `` libretro.gpsp: unstable-2024-02-04 -> unstable-2024-02-10 ``                   |
| [`ab6434e4`](https://github.com/NixOS/nixpkgs/commit/ab6434e49b04f666e453047a7168ac295aa0650a) | `` libretro.ppsspp: unstable-2024-02-09 -> unstable-2024-02-13 ``                 |
| [`d7595f59`](https://github.com/NixOS/nixpkgs/commit/d7595f59cdc7e6ff50e3ecb19788ee9768d3f379) | `` libretro.mame2003-plus: unstable-2024-02-09 -> unstable-2024-02-13 ``          |
| [`ffc3284d`](https://github.com/NixOS/nixpkgs/commit/ffc3284d6d4021fa3c81b0246851fb1b77f05007) | `` libretro.nestopia: unstable-2024-02-03 -> unstable-2024-02-13 ``               |
| [`a14694db`](https://github.com/NixOS/nixpkgs/commit/a14694db37a6fab04244a4096c30cfcddd16d12a) | `` nvidiaCtkPackages: fix misinterpreted ldflags ``                               |
| [`412f3e72`](https://github.com/NixOS/nixpkgs/commit/412f3e720fcd886764ca8763d75f5fa3512039b1) | `` libretro.mrboom: unstable-2024-02-05 -> unstable-2024-02-09 ``                 |
| [`43a6b497`](https://github.com/NixOS/nixpkgs/commit/43a6b497543cf8b9ca7028e9b72dd30bbcaa5e26) | `` cargo-binstall: 1.6.2 -> 1.6.3 ``                                              |
| [`d6b37c91`](https://github.com/NixOS/nixpkgs/commit/d6b37c91f9f1d05060dc0db51ed4322a23abc78d) | `` matrix-synapse: 1.100.0 -> 1.101.0 ``                                          |
| [`b3af9dbd`](https://github.com/NixOS/nixpkgs/commit/b3af9dbd8a93c5275c1b117f5d26010dfea5172a) | `` python311Packages.frigidaire: 0.18.15 -> 0.18.16 ``                            |
| [`14dd47db`](https://github.com/NixOS/nixpkgs/commit/14dd47dbe7178c5bd1566547c273052431785fa3) | `` python311Packages.tesla-fleet-api: 0.4.1 -> 0.4.3 ``                           |
| [`5d1a440a`](https://github.com/NixOS/nixpkgs/commit/5d1a440a51735773ce33a759c4cbe234b3ab3f47) | `` python3Packages.vector: 1.1.1.post1 -> 1.2.0 (#288405) ``                      |
| [`c1481e7a`](https://github.com/NixOS/nixpkgs/commit/c1481e7a7d53d5b15543806b106cdf35247d5e60) | `` python311Packages.hid: 1.0.5 -> 1.0.6 ``                                       |
| [`8bdf6fac`](https://github.com/NixOS/nixpkgs/commit/8bdf6fac5c7dba14bb08f3f37e5669e758eb88f3) | `` phpPackages.phpstan: 1.10.57 -> 1.10.58 ``                                     |
| [`f59b27f3`](https://github.com/NixOS/nixpkgs/commit/f59b27f33ff8f3fc9ea100fb06a440ee19624717) | `` dmlive: 5.3.1 -> 5.3.2 ``                                                      |
| [`bc178c49`](https://github.com/NixOS/nixpkgs/commit/bc178c49b4395d6342016efb0adba5190aebd2ce) | `` python311Packages.cantools: 39.4.3 -> 39.4.4 ``                                |
| [`13f4c6ac`](https://github.com/NixOS/nixpkgs/commit/13f4c6ac4408418dc93e640031c90175c125de9d) | `` python311Packages.coinmetrics-api-client: 2024.1.17.17 -> 2024.2.6.16 ``       |
| [`de4aced6`](https://github.com/NixOS/nixpkgs/commit/de4aced6f28697c4595e493be901e1b8608a9ffc) | `` files-cli: 2.12.30 -> 2.12.31 ``                                               |
| [`ad03cc98`](https://github.com/NixOS/nixpkgs/commit/ad03cc98bb32e55948e8fa202d13740dcf961bbf) | `` knot-resolver: 5.7.0 -> 5.7.1 ``                                               |
| [`06e6a7f4`](https://github.com/NixOS/nixpkgs/commit/06e6a7f4e5b2e5d3265afb88dfe483ea71685424) | `` cue: 0.7.0 -> 0.7.1 ``                                                         |
| [`8e628a80`](https://github.com/NixOS/nixpkgs/commit/8e628a80a1beceb39657be0452ed308fc953c92c) | `` pyprland: 1.8.7 -> 1.10.2 ``                                                   |
| [`77e1ebfe`](https://github.com/NixOS/nixpkgs/commit/77e1ebfe444e1d8bef8860ebf5ab8548f6268a24) | `` gdu: 5.25.0 -> 5.26.0 ``                                                       |
| [`d7740700`](https://github.com/NixOS/nixpkgs/commit/d7740700a67604cd04a4af9120e01eedee3b6eff) | `` python311Packages.pyoverkiz: 1.13.4 -> 1.13.6 ``                               |
| [`3e55757c`](https://github.com/NixOS/nixpkgs/commit/3e55757c552c0a5161492773cf1c3366b538868f) | `` moar: 1.23.4 -> 1.23.5 ``                                                      |
| [`b1760cae`](https://github.com/NixOS/nixpkgs/commit/b1760cae75bb5ff1118922d6658e53b192f60b5c) | `` pip-audit: 2.7.0 -> 2.7.1 ``                                                   |
| [`3c3d968c`](https://github.com/NixOS/nixpkgs/commit/3c3d968c68efd340dac88f2558c6cd160b53bcce) | `` halloy: 2023.5 -> 2024.1 ``                                                    |
| [`bedb3b2c`](https://github.com/NixOS/nixpkgs/commit/bedb3b2ca427f7cfe68d1e85133b35d12ee88421) | `` cargo-deb: 2.0.5 -> 2.0.6 ``                                                   |
| [`46704a4d`](https://github.com/NixOS/nixpkgs/commit/46704a4ddda0459d5858a368e20617333bc9c1e3) | `` shopware-cli: 0.4.22 -> 0.4.23 ``                                              |
| [`a118e98f`](https://github.com/NixOS/nixpkgs/commit/a118e98f032a824c98091b65bb9b07ee0a5ed48d) | `` free42: 3.1.3 -> 3.1.4 ``                                                      |
| [`b3f1b0d4`](https://github.com/NixOS/nixpkgs/commit/b3f1b0d4c28de219af513e078ebdd077bb9f9aa7) | `` elvish: 0.19.2 -> 0.20.0 ``                                                    |
| [`bdcea43c`](https://github.com/NixOS/nixpkgs/commit/bdcea43c827f26784a3908e7e5f9a9d867cd8fad) | `` python311Packages.botocore-stubs: 1.34.39 -> 1.34.40 ``                        |
| [`99cc5383`](https://github.com/NixOS/nixpkgs/commit/99cc53834557463654cfad3eab64e0b245e229c5) | `` python311Packages.boto3-stubs: 1.34.39 -> 1.34.40 ``                           |
| [`ebb71cff`](https://github.com/NixOS/nixpkgs/commit/ebb71cff0f7be6e06af90655030c3886ff72c0f5) | `` python311Packages.jsonargparse: 4.27.4 -> 4.27.5 ``                            |
| [`afd1518c`](https://github.com/NixOS/nixpkgs/commit/afd1518cddd278015d0aedcb6b961d1dc137b30b) | `` python311Packages.meshtastic: 2.2.20 -> 2.2.21 ``                              |
| [`da9a22c1`](https://github.com/NixOS/nixpkgs/commit/da9a22c1f6e6488103bcf7e4613fee44b90f0f1e) | `` khal: 0.11.2 -> 0.11.3 ``                                                      |
| [`37f6d23f`](https://github.com/NixOS/nixpkgs/commit/37f6d23f34c3fef49b76df6da0e9e314413ffd00) | `` dovecot_fts_xapian: 1.6.0 -> 1.6.1 ``                                          |
| [`eeb1b2ff`](https://github.com/NixOS/nixpkgs/commit/eeb1b2ffec93af5e5d7ac87530e4f32ccf8926ab) | `` nvidia-container-toolkit: document the ldflags ``                              |
| [`39898219`](https://github.com/NixOS/nixpkgs/commit/39898219155b1d6ff50351f18a11e4d2ec524a75) | `` wasm-tools: 1.0.58 -> 1.0.60 ``                                                |
| [`1a92f2dd`](https://github.com/NixOS/nixpkgs/commit/1a92f2ddfc3722d1af086720bc80a0b34ee8ef5e) | `` sigtop: 0.9.0 -> 0.9.1 ``                                                      |
| [`7968bfcf`](https://github.com/NixOS/nixpkgs/commit/7968bfcf30c44361604407b003467c7d91c5ef61) | `` xeus-zmq: 1.2.0 -> 1.3.0 ``                                                    |
| [`40a7b182`](https://github.com/NixOS/nixpkgs/commit/40a7b182e0a00245d69f6b8c1dfd3ea4bfc6257c) | `` organicmaps: 2024.01.09-5 -> 2024.02.06-11 ``                                  |
| [`ea34f418`](https://github.com/NixOS/nixpkgs/commit/ea34f418d76b30282bced00d132fd970685aa377) | `` numbat: 1.9.0 -> 1.10.1 ``                                                     |
| [`300e50c1`](https://github.com/NixOS/nixpkgs/commit/300e50c13c22cdf8a5773fb11e57bb0d2117bf34) | `` python311Packages.gradio-pdf: 0.0.4 -> 0.0.5 ``                                |
| [`30625012`](https://github.com/NixOS/nixpkgs/commit/306250128f893b4426d8fd76be0c0ea9d9b67e6e) | `` python311Packages.msprime: 1.3.0 -> 1.3.1 ``                                   |
| [`58c9f5b3`](https://github.com/NixOS/nixpkgs/commit/58c9f5b31ab69210ddb617ff46918c58cdc8109d) | `` paperwork: 2.2.1 -> 2.2.2 ``                                                   |
| [`7d0624ce`](https://github.com/NixOS/nixpkgs/commit/7d0624cef9631bb3869d02efaf054b9bf816f3ef) | `` faircamp: 0.11.0 -> 0.12.0 ``                                                  |
| [`2d6d3cf8`](https://github.com/NixOS/nixpkgs/commit/2d6d3cf83fafe99e73fabad605bee12f0eb58c14) | `` dayon: 13.0.0 -> 13.0.1 ``                                                     |
| [`21cf2e42`](https://github.com/NixOS/nixpkgs/commit/21cf2e426139f31d3f7691918f407624358cd5df) | `` minder: 1.16.2 -> 1.16.3 ``                                                    |
| [`1b3b571e`](https://github.com/NixOS/nixpkgs/commit/1b3b571e53275369be8658677e38ce3112128045) | `` marcel: init at 0.22.2 ``                                                      |
| [`d0f0c5b0`](https://github.com/NixOS/nixpkgs/commit/d0f0c5b08b03d4b5f1651eeda14a5821483711e3) | `` shfmt: 3.7.0 -> 3.8.0 ``                                                       |
| [`01f43df8`](https://github.com/NixOS/nixpkgs/commit/01f43df8d8799ef085b2399d73cb7b0297e680cf) | `` python3Packages.yark: fix build by relaxing some deps ``                       |
| [`ff057da3`](https://github.com/NixOS/nixpkgs/commit/ff057da35bfa29c7ce765a71fc8925c0cbb0e4e3) | `` eduvpn-client: 4.2.0 -> 4.2.1 ``                                               |
| [`c9dda2db`](https://github.com/NixOS/nixpkgs/commit/c9dda2db28825cb690dc647b74c6cd7dde795d89) | `` virglrenderer: 1.0.0 -> 1.0.1 ``                                               |
| [`9a492fda`](https://github.com/NixOS/nixpkgs/commit/9a492fda467eca96ec72ee62bb37ab491304f248) | `` libdex: Fix updateScript ``                                                    |
| [`5d07ac63`](https://github.com/NixOS/nixpkgs/commit/5d07ac63fb08195a1fbca9df83985bd52043f8a1) | `` gnome.gnome-initial-setup: 45.0 → 45.4.1 ``                                    |
| [`f12ba361`](https://github.com/NixOS/nixpkgs/commit/f12ba3617cf276aef51dded9697e1d4b01a55849) | `` gnome.mutter: 45.3 → 45.4 ``                                                   |
| [`f0487f42`](https://github.com/NixOS/nixpkgs/commit/f0487f42e6b1d907a7ab67f16d11cdf91d687159) | `` gnome.gnome-tweaks: 45.0 → 45.1 ``                                             |
| [`8027502e`](https://github.com/NixOS/nixpkgs/commit/8027502e1791d9c003807043f7842778eef5628b) | `` gnome.gnome-shell: 45.3 → 45.4 ``                                              |
| [`a68ed7d3`](https://github.com/NixOS/nixpkgs/commit/a68ed7d3ded8d0b95c2e23c74925362fc94c8d02) | `` gnome.gnome-music: 45.0 → 45.1 ``                                              |
| [`ad9a891a`](https://github.com/NixOS/nixpkgs/commit/ad9a891acb3a8f83df59e1b963bc4e5dba4a8a9d) | `` gnome.gnome-control-center: 45.2 → 45.3 ``                                     |
| [`be412393`](https://github.com/NixOS/nixpkgs/commit/be4123939403982c4caffd3d3ba5451f74884547) | `` glauth: drop obsolete `excludedPackages` ``                                    |
| [`cb9e5222`](https://github.com/NixOS/nixpkgs/commit/cb9e52222d4fa03f1dc8afa1fb130bb12af0146e) | `` tidal-hifi: 5.8.0 -> 5.9.0 ``                                                  |
| [`9d01a9c8`](https://github.com/NixOS/nixpkgs/commit/9d01a9c802bdaf2fbc4aab8a859a264e49657c90) | `` sqlboiler: 4.16.1 -> 4.16.2 ``                                                 |
| [`faa4329e`](https://github.com/NixOS/nixpkgs/commit/faa4329e6f84a3d6f702672ea4c25f3e0aa85314) | `` satty: 0.8.3 -> 0.9.0 ``                                                       |
| [`829297ba`](https://github.com/NixOS/nixpkgs/commit/829297baf5cb4270054c656694227a5c35d0b8e4) | `` python311Packages.iminuit: 2.25.1 -> 2.25.2 ``                                 |
| [`72398088`](https://github.com/NixOS/nixpkgs/commit/72398088cfc04b069b45b7b172354c3dfed122cf) | `` grpc_cli: 1.61.0 -> 1.61.1 ``                                                  |
| [`80680623`](https://github.com/NixOS/nixpkgs/commit/8068062320b51a91f5638c3d04312d3fb039bd2a) | `` cargo-rdme: 1.4.2 -> 1.4.3 ``                                                  |
| [`bb3a527b`](https://github.com/NixOS/nixpkgs/commit/bb3a527b1be49e28307f2e7c2ee754d2542b23b8) | `` _0xproto: 1.601 -> 1.602 ``                                                    |
| [`c60a7077`](https://github.com/NixOS/nixpkgs/commit/c60a707729e5766a85401e90ba5aec0b0f11603d) | `` avrdudess: 2.16 -> 2.17 ``                                                     |
| [`ba9a2517`](https://github.com/NixOS/nixpkgs/commit/ba9a2517fe4a9773a5a8d6e529cf31e0b476296d) | `` bgpq4: 1.11 -> 1.12 ``                                                         |
| [`6fca7fea`](https://github.com/NixOS/nixpkgs/commit/6fca7fea2a36622390be171b684ac0bb7e5c6918) | `` openvpn: 2.6.8 -> 2.6.9 ``                                                     |
| [`247ec3ea`](https://github.com/NixOS/nixpkgs/commit/247ec3ea92b9b93207d4f20ec65b2e7fc859a6b4) | `` renode-unstable: 1.14.0+20240130git6e173a1bb -> 1.14.0+20240212git8eb88bb9c `` |
| [`5d6f8f2f`](https://github.com/NixOS/nixpkgs/commit/5d6f8f2fc0f4c5601fa14b3c8a3a51fd6ff59a0b) | `` starsector: 0.97a-RC8 -> 0.97a-RC9 ``                                          |
| [`cf6c61af`](https://github.com/NixOS/nixpkgs/commit/cf6c61af30adabc2a5a4ed1e6f18649e8aad9798) | `` yarn-berry: 4.0.1 -> 4.1.0 ``                                                  |
| [`3492680c`](https://github.com/NixOS/nixpkgs/commit/3492680c7307336670aa778f4ff796459d4f24a6) | `` yarn-berry: add update script ``                                               |
| [`46bdb36e`](https://github.com/NixOS/nixpkgs/commit/46bdb36ebba2a5d224c22c4e786df3f3fc25946d) | `` yarn-berry: add DimitarNestorov to maintainers ``                              |
| [`b4aa3fab`](https://github.com/NixOS/nixpkgs/commit/b4aa3fab876491888ea335dc9c342d6cfbd0b995) | `` maintainers: add DimitarNestorov ``                                            |
| [`46bb032a`](https://github.com/NixOS/nixpkgs/commit/46bb032a7ea1579af914ad9ecf68056a30f58909) | `` python311Packages.niaarm: 0.3.6 -> 0.3.7 ``                                    |
| [`8601deae`](https://github.com/NixOS/nixpkgs/commit/8601deaed1bfe5893016310fe7c25885d8f55106) | `` cryptoverif: 2.07 → 2.08pl1 ``                                                 |
| [`c9c7d2c7`](https://github.com/NixOS/nixpkgs/commit/c9c7d2c7bb72ec35d9eb1cc32b2f248ee3dae6a2) | `` reaper: 7.09 -> 7.11 ``                                                        |
| [`1c5be10c`](https://github.com/NixOS/nixpkgs/commit/1c5be10c9c3bf3dcec58c4992a17a093f02c6732) | `` terraform-ls: 0.32.6 -> 0.32.7 ``                                              |
| [`e562fdc8`](https://github.com/NixOS/nixpkgs/commit/e562fdc82bc7ff24ca855224272cca5f859914ce) | `` python311Packages.sphinx-book-theme: 1.1.0 -> 1.1.1 ``                         |
| [`bd98ec41`](https://github.com/NixOS/nixpkgs/commit/bd98ec419b61f5e25bb9888ebd869a4270e1cabb) | `` rqlite: 8.19.0 -> 8.20.0 ``                                                    |
| [`48153fcc`](https://github.com/NixOS/nixpkgs/commit/48153fccf589de646a447961fa8ab7328f7ca568) | `` python312Packages.hahomematic: 2024.2.2 -> 2024.2.3 ``                         |
| [`2147bf75`](https://github.com/NixOS/nixpkgs/commit/2147bf756de23dc31f685f42733c5ad3769eb2e5) | `` python311Packages.jc: 1.25.0 -> 1.25.1 ``                                      |
| [`927681e5`](https://github.com/NixOS/nixpkgs/commit/927681e58bc326175b9384ecc45a65bbb493610b) | `` rwpspread: 0.1.8 -> 0.1.9 ``                                                   |
| [`a855b93c`](https://github.com/NixOS/nixpkgs/commit/a855b93c0c9955bf7ead57ab9356fa52848b591d) | `` python311Packages.ocrmypdf: 16.0.4 -> 16.1.0 ``                                |
| [`0fb4434d`](https://github.com/NixOS/nixpkgs/commit/0fb4434d0e90d6466866864149895b73b751fc97) | `` menulibre: init at 2.2.3 ``                                                    |
| [`267e5c7b`](https://github.com/NixOS/nixpkgs/commit/267e5c7b854d687307c6c6ec65783c4b27ff51fd) | `` mystmd: 1.1.38 -> 1.1.40 ``                                                    |
| [`7e7357cb`](https://github.com/NixOS/nixpkgs/commit/7e7357cb287d95a24da0d0ecbb0fb232b7da7722) | `` dsda-launcher: init at 1.3.1-hotfix ``                                         |
| [`9fb56a06`](https://github.com/NixOS/nixpkgs/commit/9fb56a068dfaa8e45643f0909bca16f03935bc4a) | `` python311Packages.torchmetrics: 1.3.0.post -> 1.3.1 ``                         |
| [`f4d5a7ba`](https://github.com/NixOS/nixpkgs/commit/f4d5a7ba63d715df76ea0fb64f2dec516ea0af66) | `` tmux-sessionizer: 0.3.2 -> 0.4.0-unstable-2024-02-06 ``                        |
| [`1b71ae2a`](https://github.com/NixOS/nixpkgs/commit/1b71ae2afadc70ee65a4698c2104bd3a09a70a1a) | `` offpunk: 2.1 -> 2.2 ``                                                         |
| [`cf68af85`](https://github.com/NixOS/nixpkgs/commit/cf68af8561b4624738f10158960ce2748fa75877) | `` nixos/lxc/container: switch to networkd by default ``                          |
| [`bdc79efc`](https://github.com/NixOS/nixpkgs/commit/bdc79efc2b1e1eb4503589e6c362ccc9e10e9298) | `` nixos/lxd/vm: fix network config ``                                            |