### PR TITLE
chore(flake/home-manager): `043ba285` -> `1d085ea4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -447,11 +447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707919853,
-        "narHash": "sha256-qxmBGDzutuJ/tsX4gp+Mr7fjxOZBbeT9ixhS5o4iFOw=",
+        "lastModified": 1708988456,
+        "narHash": "sha256-RCz7Xe64tN2zgWk+MVHkzg224znwqknJ1RnB7rVqUWw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "043ba285c6dc20f36441d48525402bcb9743c498",
+        "rev": "1d085ea4444d26aa52297758b333b449b2aa6fca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`1d085ea4`](https://github.com/nix-community/home-manager/commit/1d085ea4444d26aa52297758b333b449b2aa6fca) | `` yazi: update shell integrations (#5048) ``           |
| [`4ee704cb`](https://github.com/nix-community/home-manager/commit/4ee704cb13a5a7645436f400b9acc89a67b9c08a) | `` xscreensaver: add package option ``                  |
| [`ae7a3b51`](https://github.com/nix-community/home-manager/commit/ae7a3b5137ca3522f2802b3183de8fe5287b13d2) | `` hyprland: fix reloading ``                           |
| [`4e6d25a5`](https://github.com/nix-community/home-manager/commit/4e6d25a51bb3035af7db54cc8f7fcac23e9467dc) | `` lorri: systemd allow access to cache directories ``  |
| [`0e0e9669`](https://github.com/nix-community/home-manager/commit/0e0e9669547e45ea6cca2de4044c1a384fd0fe55) | `` zsh: fix broken ZDOTDIR when path contains spaces `` |
| [`0b69d574`](https://github.com/nix-community/home-manager/commit/0b69d574162cfa6eb7919d5614a48d0185550891) | `` Translate using Weblate (Spanish) ``                 |
| [`3dda8e79`](https://github.com/nix-community/home-manager/commit/3dda8e795f12a4f67c287cef155939e1c5fbd0a3) | `` river: add module ``                                 |
| [`517601b3`](https://github.com/nix-community/home-manager/commit/517601b37c6d495274454f63c5a483c8e3ca6be1) | `` jujutsu: remove shell completion ``                  |
| [`a54e05bc`](https://github.com/nix-community/home-manager/commit/a54e05bc12d88ff2df941d0dc1183cb5235fa438) | `` tealdeer: module improvements ``                     |
| [`738527f8`](https://github.com/nix-community/home-manager/commit/738527f866e7848fa9fcef174ee78ec262fd00e5) | `` darwin: fonts: speed up font installation ``         |
| [`11edf9ca`](https://github.com/nix-community/home-manager/commit/11edf9cad78cce49d09436c8d725ae36b65671dc) | `` flake.lock: Update ``                                |
| [`309465d2`](https://github.com/nix-community/home-manager/commit/309465d20993095a1c6ee2d7eda6ef3588f165ff) | `` Translate using Weblate (Ukrainian) ``               |
| [`7671ec19`](https://github.com/nix-community/home-manager/commit/7671ec1931daee86161c8da1115515447667545e) | `` Translate using Weblate (Swedish) ``                 |
| [`5aec43bc`](https://github.com/nix-community/home-manager/commit/5aec43bc0f647eba521c2fb82135f7c10e2ea500) | `` Translate using Weblate (Turkish) ``                 |
| [`f41f54fb`](https://github.com/nix-community/home-manager/commit/f41f54fb224fd47bd19f0786ebed282f241dc71f) | `` Translate using Weblate (Czech) ``                   |
| [`bb69e1d4`](https://github.com/nix-community/home-manager/commit/bb69e1d43ea052aa69d884ae751cb9d1999bd8b8) | `` Update translation files ``                          |
| [`3d6791b3`](https://github.com/nix-community/home-manager/commit/3d6791b3897b526c82920a2ab5f61d71985b3cf8) | `` home-manager: add Nix sanity check ``                |
| [`07fd4117`](https://github.com/nix-community/home-manager/commit/07fd41171ff8f263a9e4a95e17a3db1ff8a000c9) | `` home-manager: fix incorrect log message ``           |