### PR TITLE
chore(flake/nixpkgs): `a4d4fe8c` -> `5863c273`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707956935,
-        "narHash": "sha256-ZL2TrjVsiFNKOYwYQozpbvQSwvtV/3Me7Zwhmdsfyu4=",
+        "lastModified": 1708118438,
+        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a4d4fe8c5002202493e87ec8dbc91335ff55552c",
+        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                           |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`bcd1f4cd`](https://github.com/NixOS/nixpkgs/commit/bcd1f4cd63c9cf51cddeea8e79bb4a6413320a89) | `` seclists: 2023.4 -> 2024.1 ``                                                                                  |
| [`eb6f5177`](https://github.com/NixOS/nixpkgs/commit/eb6f517764dd57e5750ca969f9f8c084a94191af) | `` b4: 0.12.4 -> 0.13.0 ``                                                                                        |
| [`a2f71e11`](https://github.com/NixOS/nixpkgs/commit/a2f71e1161b4c99207d04da7512387055491685a) | `` cargo-generate: Fix description ``                                                                             |
| [`a951f8dc`](https://github.com/NixOS/nixpkgs/commit/a951f8dc07ceafeed41dc41baaf826e28d110d9f) | `` linuxPackages.nvidiaPackages.vulkan_beta: 535.43.25 -> 535.43.28 ``                                            |
| [`fbb324d6`](https://github.com/NixOS/nixpkgs/commit/fbb324d6f1b3ac2abfe995779d436050acd15603) | `` cppcheck: update the hash for the 2.13.4 release. ``                                                           |
| [`89c71907`](https://github.com/NixOS/nixpkgs/commit/89c719072e83be70b0754e7bf231042fdc95b1aa) | `` kubernetes-helmPlugins.helm-diff: 3.9.2 -> 3.9.4 ``                                                            |
| [`55883724`](https://github.com/NixOS/nixpkgs/commit/5588372485191f4eeae13e91b658598aeaf82be7) | `` renode-unstable: 1.14.0+20240212git8eb88bb9c -> 1.14.0+20240215git10667c665 ``                                 |
| [`e1d5229c`](https://github.com/NixOS/nixpkgs/commit/e1d5229cc9c90b7fd96e1651e2e526de2313d3d2) | `` python311Packages.django-pattern-library: fix build ``                                                         |
| [`93ee3a96`](https://github.com/NixOS/nixpkgs/commit/93ee3a961d72660872a83a084bc36c68896bd779) | `` python311Packages.cohere: fix build ``                                                                         |
| [`785ec14c`](https://github.com/NixOS/nixpkgs/commit/785ec14cd0260d2227570e0bae6f4ce0b7380bc1) | `` preserves-tools: 4.992.2 -> 4.994.0 ``                                                                         |
| [`cf62e325`](https://github.com/NixOS/nixpkgs/commit/cf62e3257f098cdabc9fe967f2844e0f2ddf7bdb) | `` nixos/mastodon: redis now uses unix socket by default ``                                                       |
| [`e36423c2`](https://github.com/NixOS/nixpkgs/commit/e36423c2cdb70939986e1c296788acc30dc8e1c8) | `` rqlite: 8.20.0 -> 8.20.1 ``                                                                                    |
| [`bd53b183`](https://github.com/NixOS/nixpkgs/commit/bd53b183aff3877d6b6528640732c05c945462a5) | `` python311Packages.pytest-testinfra: 10.0.0 -> 10.1.0 ``                                                        |
| [`4625f865`](https://github.com/NixOS/nixpkgs/commit/4625f86517a80b8904aacf6e74cfd5fce700fe34) | `` qownnotes: 24.2.0 -> 24.2.3 ``                                                                                 |
| [`61acce0c`](https://github.com/NixOS/nixpkgs/commit/61acce0cb596050f5fa1c6ebf3f339a893361028) | `` mastodon: 4.2.6 -> 4.2.7 ``                                                                                    |
| [`c0339d37`](https://github.com/NixOS/nixpkgs/commit/c0339d37d14c1052be2a2c4037ce48ae0c4a7c2f) | `` python312Packages.fakeredis: 2.21.0 -> 2.21.1 ``                                                               |
| [`d983ddf8`](https://github.com/NixOS/nixpkgs/commit/d983ddf89bf3fd2eab1d21e57cfd0ce5721eaec7) | `` kubeshark: 52.1.30 -> 52.1.45 ``                                                                               |
| [`e910a0bc`](https://github.com/NixOS/nixpkgs/commit/e910a0bc4d225736a71b391514a096a9eb9a837d) | `` koka: 3.0.4 -> 3.1.0 ``                                                                                        |
| [`b92ea571`](https://github.com/NixOS/nixpkgs/commit/b92ea571aa00dff6b2680ce1ce9276904027a98a) | `` eris-go: 20231219 -> 20240128 ``                                                                               |
| [`44bee06d`](https://github.com/NixOS/nixpkgs/commit/44bee06d90d444d26903fb967811f5c0b29c2ab1) | `` python311Packages.aiopvapi: 3.0.1 -> 3.0.2 ``                                                                  |
| [`9621e4e0`](https://github.com/NixOS/nixpkgs/commit/9621e4e0eaec78a71f2d0cce9fbef3e0e159c748) | `` python311Packages.optimum: 1.16.2 -> 1.17.0 ``                                                                 |
| [`833beecd`](https://github.com/NixOS/nixpkgs/commit/833beecd8b1b730ff517a7dc6edbc5623e18e51c) | `` qcad: fix builds on Darwin ``                                                                                  |
| [`a9c16529`](https://github.com/NixOS/nixpkgs/commit/a9c165296baa748abd48d4a02e3dd84b8078d5b7) | `` qcad: minor syntax refactoring ``                                                                              |
| [`06ed0ca3`](https://github.com/NixOS/nixpkgs/commit/06ed0ca39bfe62c175cb0959d508676554793be1) | `` appdaemon: migrate to pythonRelaxDepsHook ``                                                                   |
| [`cc681d5d`](https://github.com/NixOS/nixpkgs/commit/cc681d5dc64185fab562c0d5e9c545f895c25996) | `` firecracker: 1.5.0 -> 1.6.0 ``                                                                                 |
| [`dc56aa79`](https://github.com/NixOS/nixpkgs/commit/dc56aa792f3d0c2346b408f878ee9b110346e065) | `` rye: 0.23.0 -> 0.24.0 ``                                                                                       |
| [`8398a209`](https://github.com/NixOS/nixpkgs/commit/8398a209b65c4bba20c17e51d20f048b527f2ab8) | `` coqPackages.{serapi,coq-lsp}: {8.18.0+0.18.0,0.1.8+8.18.0} -> {8.19.0+0.19.0,0.1.8+8.19.0} (#288185) ``        |
| [`59cc6526`](https://github.com/NixOS/nixpkgs/commit/59cc65262f66dd00faaaf1f5d141fe4f775aacf0) | `` python311Packages.fakeredis: refactor ``                                                                       |
| [`07538cfd`](https://github.com/NixOS/nixpkgs/commit/07538cfddf00780802f0780f1fae6e805deeccfe) | `` python311Packages.pyprobables: init at 0.6.0 ``                                                                |
| [`0adbce5f`](https://github.com/NixOS/nixpkgs/commit/0adbce5f2a58970e52d33e3c0da103da857e5dd9) | `` tailscale: 1.58.2 -> 1.60.0 ``                                                                                 |
| [`81391bd2`](https://github.com/NixOS/nixpkgs/commit/81391bd22fe9c33c556563bab062da95ecdc15c0) | `` nixos/kubernetes: set k8 home permissions correctly ``                                                         |
| [`7070404b`](https://github.com/NixOS/nixpkgs/commit/7070404b96bfdadbd872ae22eb9949ef557221f0) | `` uv: 0.1.0 -> 0.1.2 ``                                                                                          |
| [`26493178`](https://github.com/NixOS/nixpkgs/commit/26493178e34c259f07b7ef97b16af56aa0bedd06) | `` python312Packages.uqbar: 0.7.1 -> 0.7.2 ``                                                                     |
| [`1fedee9a`](https://github.com/NixOS/nixpkgs/commit/1fedee9a3465a0fe4d5025db30abba9f9ce63db2) | `` tippecanoe: 2.43.0 -> 2.45.0 ``                                                                                |
| [`a9c4c97a`](https://github.com/NixOS/nixpkgs/commit/a9c4c97afc5c8ea7c7dedd34c56584dd21dcee4c) | `` atmos: 1.60.0 -> 1.63.0 ``                                                                                     |
| [`ce77ed0b`](https://github.com/NixOS/nixpkgs/commit/ce77ed0b59634248f11a51f9d5bb881d3043d69f) | `` qq: 3.2.5-21159 -> 3.2.5-21453 ``                                                                              |
| [`26e937c9`](https://github.com/NixOS/nixpkgs/commit/26e937c9658b03068dfc348780ffb354c527e144) | `` portfolio-filemanager: set meta.mainProgram ``                                                                 |
| [`c3496b72`](https://github.com/NixOS/nixpkgs/commit/c3496b72ca4c4d99878240806a5d4780e57d47ca) | `` python311Packages.pyprecice: 2.5.0.4 -> 3.0.0.0 ``                                                             |
| [`3ccba805`](https://github.com/NixOS/nixpkgs/commit/3ccba805f7cb8d83b362a22fcc3adf5c04bae20d) | `` haproxy: 2.9.4 -> 2.9.5 ``                                                                                     |
| [`36cb2fc0`](https://github.com/NixOS/nixpkgs/commit/36cb2fc0eb3437a0c7f5dfae40fdf1555408a5b5) | `` miriway: unstable-2024-01-30 -> unstable-2024-02-14 ``                                                         |
| [`44d2030e`](https://github.com/NixOS/nixpkgs/commit/44d2030ecb389eb8e3fc0fd927b783e0d3e9ac1f) | `` yq-go: 4.40.7 -> 4.41.1 ``                                                                                     |
| [`13973b5c`](https://github.com/NixOS/nixpkgs/commit/13973b5cf77c85e7fe2f6ec62df4906f88e4f1de) | `` python311Packages.accelerate: fix build on linux ``                                                            |
| [`05b4d353`](https://github.com/NixOS/nixpkgs/commit/05b4d353c30768b85720fae4b0a42ea38c00f933) | `` zed: 1.13.0 -> 1.14.0 ``                                                                                       |
| [`e2351c1c`](https://github.com/NixOS/nixpkgs/commit/e2351c1c52258a72477b285c106a54b789d57898) | `` qtrvsim: 0.9.6 -> 0.9.7 ``                                                                                     |
| [`0edc7387`](https://github.com/NixOS/nixpkgs/commit/0edc73876a83bea5f2cdb2072f77817e58692592) | `` ctlptl: 0.8.26 -> 0.8.27 ``                                                                                    |
| [`863c383d`](https://github.com/NixOS/nixpkgs/commit/863c383d01af6bf85e568d134a1c0fe76bfd55d8) | `` mainsail: 2.9.1 -> 2.10.0 ``                                                                                   |
| [`85c1c266`](https://github.com/NixOS/nixpkgs/commit/85c1c2664d8e9489038aa1d0caa1d637b92bd4ce) | `` okta-aws-cli: 2.0.1 -> 2.1.0 ``                                                                                |
| [`f9fc9264`](https://github.com/NixOS/nixpkgs/commit/f9fc9264dbc6de617ee8201f16a09bf18f87c1fd) | `` cel-go: 0.19.0 -> 0.20.0 ``                                                                                    |
| [`c4c3aae1`](https://github.com/NixOS/nixpkgs/commit/c4c3aae1db3bdf4237c2c56948fbf9f0bb0ff9ec) | `` wire: 0.5.0 -> 0.6.0 ``                                                                                        |
| [`76f9f813`](https://github.com/NixOS/nixpkgs/commit/76f9f813aa7a736949d677667a17efbb5ba16460) | `` kubeseal: 0.25.0 -> 0.26.0 ``                                                                                  |
| [`69c4e3af`](https://github.com/NixOS/nixpkgs/commit/69c4e3af3a750f12209a6a3b7507292b924d3f4e) | `` github-cli: 2.43.1 -> 2.44.0 ``                                                                                |
| [`f2678105`](https://github.com/NixOS/nixpkgs/commit/f267810520ff61e4cb43131a587c5e69c2663a0a) | `` dqlite: 1.16.0 -> 1.16.2 ``                                                                                    |
| [`a8edd167`](https://github.com/NixOS/nixpkgs/commit/a8edd1672461d124783a30cfa1f2d3cda94bd8c4) | `` dasel: 2.5.0 -> 2.6.0 ``                                                                                       |
| [`4a50c60a`](https://github.com/NixOS/nixpkgs/commit/4a50c60a85a53f20724d04afa4ea22ec54f64c8c) | `` docfd: 2.1.0 -> 2.2.0 ``                                                                                       |
| [`210bb8da`](https://github.com/NixOS/nixpkgs/commit/210bb8dad28b55124c098fb7618c64902cbc5b74) | `` doppler: 3.66.5 -> 3.67.0 ``                                                                                   |
| [`ac0579e7`](https://github.com/NixOS/nixpkgs/commit/ac0579e7c9bf5e949fb06c6b7010cceacfd786be) | `` clingo: 5.6.2 -> 5.7.0 ``                                                                                      |
| [`bb41ff7b`](https://github.com/NixOS/nixpkgs/commit/bb41ff7beaca1a3c31968598b97435d42f8e131c) | `` python311Packages.mplhep: 0.3.32 -> 0.3.33 ``                                                                  |
| [`96cc70a2`](https://github.com/NixOS/nixpkgs/commit/96cc70a2a095ab562a7a0670edc516e1f2dca64f) | `` arkade: 0.10.20 -> 0.11.0 ``                                                                                   |
| [`76c0b6b3`](https://github.com/NixOS/nixpkgs/commit/76c0b6b36e53042acf903e0f09fc6ca108104b1d) | `` python311Packages.peaqevcore: 19.6.6 -> 19.6.10 ``                                                             |
| [`0e66c8e1`](https://github.com/NixOS/nixpkgs/commit/0e66c8e1a4f76ea6de922303c167c0605c178626) | `` werf: 1.2.289 -> 1.2.290 ``                                                                                    |
| [`ace0a3bd`](https://github.com/NixOS/nixpkgs/commit/ace0a3bdddb9cfd56017fda756632630400e65cf) | `` vscode: 1.86.1 -> 1.86.2 ``                                                                                    |
| [`5f1b1a60`](https://github.com/NixOS/nixpkgs/commit/5f1b1a60c49f4ea6b5637ad34b9d5b6ef2971d04) | `` python311Packages.pyformlang: 1.0.6 -> 1.0.7 ``                                                                |
| [`5fb29ed4`](https://github.com/NixOS/nixpkgs/commit/5fb29ed40fb64349497724205de597c9fc8fee65) | `` libretro: update cores ``                                                                                      |
| [`e5c09857`](https://github.com/NixOS/nixpkgs/commit/e5c0985730dd7c9484c0d7db11bcd9396745e8b0) | `` libretro: improve update_cores.py script ``                                                                    |
| [`43b802fd`](https://github.com/NixOS/nixpkgs/commit/43b802fded8c06f2f2228c582d231211a50e2019) | `` nss_latest: 3.97 -> 3.98 ``                                                                                    |
| [`3a35d0c2`](https://github.com/NixOS/nixpkgs/commit/3a35d0c2506a0bd0d0e9023bee7396c2f57fa042) | `` kubectl-klock: 0.5.0 -> 0.5.1 ``                                                                               |
| [`4f6de75a`](https://github.com/NixOS/nixpkgs/commit/4f6de75a95b07472abb17ea9762dddbea5d30b17) | `` kubectl-klock: add completion script ``                                                                        |
| [`8b3bf860`](https://github.com/NixOS/nixpkgs/commit/8b3bf8604d84a486014586c5328aa7480eebb344) | `` portfolio-filemanager: 1.0.0 -> 1.0.1 ``                                                                       |
| [`6c574adc`](https://github.com/NixOS/nixpkgs/commit/6c574adc0e25523e83fe70d4d6a3dcddd8e00e57) | `` python311Packages.deluge-client: 1.9.0 -> 1.10.0 ``                                                            |
| [`7f0abdc3`](https://github.com/NixOS/nixpkgs/commit/7f0abdc3ecb3fd53a1ea95b4bfda720db3e35dd0) | `` python311Packages.openwebifpy: 4.2.1 -> 4.2.4 ``                                                               |
| [`d1ee8af6`](https://github.com/NixOS/nixpkgs/commit/d1ee8af620dd96cb410625810b5399677ccddf77) | `` python3Packages.nix-prefetch-github: v7.0.0 -> v7.1.0 ``                                                       |
| [`f0ba48d6`](https://github.com/NixOS/nixpkgs/commit/f0ba48d6153c599e0735d026ec2377d38319226d) | `` golangci-lint: 1.56.1 -> 1.56.2 ``                                                                             |
| [`1122f538`](https://github.com/NixOS/nixpkgs/commit/1122f53814335a328caa493ffacc0e5a9607a571) | `` plow: init at 1.3.1 ``                                                                                         |
| [`18ff9047`](https://github.com/NixOS/nixpkgs/commit/18ff9047fd3520169eac4df688c8f9ae7ce21044) | `` phel: replace `postCheckInstall` with `postInstallCheck` ``                                                    |
| [`4dfb2b24`](https://github.com/NixOS/nixpkgs/commit/4dfb2b2405bb5f179dafbab9eedfbc2f7187c38c) | `` build-support/php: replace `preCheckInstall`, `postCheckInstall` with `preInstallCheck`, `postInstallCheck` `` |
| [`44275c8b`](https://github.com/NixOS/nixpkgs/commit/44275c8b864008080168ad7933eb19fc2798a200) | `` plantuml: use `finalAttrs` pattern ``                                                                          |
| [`1d286d58`](https://github.com/NixOS/nixpkgs/commit/1d286d588b59a2fcfa84b226a09323addb850014) | `` graylog-5_0: remove ``                                                                                         |
| [`7323b4ae`](https://github.com/NixOS/nixpkgs/commit/7323b4ae7257295f802c692de5c9f83b64eec283) | `` php83: 8.3.2 -> 8.3.3 ``                                                                                       |
| [`a14ca6fc`](https://github.com/NixOS/nixpkgs/commit/a14ca6fcde2a62a353dd517c8174fc9e613fa2cc) | `` fastly: 10.8.1 -> 10.8.2 ``                                                                                    |
| [`728d5991`](https://github.com/NixOS/nixpkgs/commit/728d5991d9b09effef73072e4d37cda7e05837ad) | `` php82: 8.2.15 -> 8.2.16 ``                                                                                     |
| [`80861fb0`](https://github.com/NixOS/nixpkgs/commit/80861fb03279dc0b391b1336079fb205b2c3a953) | `` lemmy-server: fix tests by waiting until backend is ready with 10s timeout ``                                  |
| [`13fae614`](https://github.com/NixOS/nixpkgs/commit/13fae6142cea263714198e815dfdcb8fe72e1a57) | `` lemmy-server/ui: 0.18.5 -> 0.19.3 ``                                                                           |
| [`df6a946c`](https://github.com/NixOS/nixpkgs/commit/df6a946cf34e2484393bd06b54bae6b8b2abaa11) | `` vscode-extensions.ecmel.vscode-html-css: init at 2.0.9 ``                                                      |
| [`d11c768a`](https://github.com/NixOS/nixpkgs/commit/d11c768a57000597cfd0441043efe0b3bd684de1) | `` links2: Use fqdn instead of meta.homepage in src.url ``                                                        |