### PR TITLE
chore(flake/nixpkgs): `5863c273` -> `b98a4e17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708118438,
-        "narHash": "sha256-kk9/0nuVgA220FcqH/D2xaN6uGyHp/zoxPNUmPCMmEE=",
+        "lastModified": 1708296515,
+        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5863c27340ba4de8f83e7e3c023b9599c3cb3c80",
+        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`70adeec2`](https://github.com/NixOS/nixpkgs/commit/70adeec24f6686fdbbba17d5d79a290b427367c2) | `` plots: refactor ``                                                                       |
| [`8ac91490`](https://github.com/NixOS/nixpkgs/commit/8ac914904ebe68d0f6be4ac2bc60165afc46979b) | `` pdfid: init at 0.2.8 ``                                                                  |
| [`9df44b1c`](https://github.com/NixOS/nixpkgs/commit/9df44b1c9d6cb1f35484eee4b651eecfc8a947c4) | `` shadowsocks-rust: 1.18.0 -> 1.18.1 ``                                                    |
| [`25c04ecb`](https://github.com/NixOS/nixpkgs/commit/25c04ecb3d205055520f9a5a525fe83de75c0e93) | `` normcap: disable flaky test ``                                                           |
| [`8b4e08d8`](https://github.com/NixOS/nixpkgs/commit/8b4e08d82280f79e5492061ef9626fa73d3f7d4f) | `` normcap: mark broken on darwin ``                                                        |
| [`11ec8e40`](https://github.com/NixOS/nixpkgs/commit/11ec8e40ef34440e6319925897f0a60474e87623) | `` normcap: 0.5.2 -> 0.5.4 ``                                                               |
| [`d0836910`](https://github.com/NixOS/nixpkgs/commit/d0836910add12fad3795523679098eba7f4731ba) | `` normcap: 0.4.4 -> 0.5.2 ``                                                               |
| [`26efa75e`](https://github.com/NixOS/nixpkgs/commit/26efa75ee6ff7dad41f585996da4d749d13b6f64) | `` ethq: 0.6.2 -> 0.6.3 ``                                                                  |
| [`21a671c1`](https://github.com/NixOS/nixpkgs/commit/21a671c1acd2225c3d4defcdd6298d83b6b89b40) | `` nixosTests.prometheus-exporters.dnsmasq: wait for DNSMasq before testing the exporter `` |
| [`0481f07d`](https://github.com/NixOS/nixpkgs/commit/0481f07d16da8561cc0f06c4ef5735d489dffd06) | `` gotools: 0.17.0 -> 0.18.0 ``                                                             |
| [`2991a24e`](https://github.com/NixOS/nixpkgs/commit/2991a24e7f61fd2be0b838d796a44120edf8c6e6) | `` gotools: 0.16.1 -> 0.17.0 ``                                                             |
| [`49301882`](https://github.com/NixOS/nixpkgs/commit/49301882acee4feb4e448d6462ca69788187895e) | `` codeium: 1.6.36 -> 1.6.38 ``                                                             |
| [`df626561`](https://github.com/NixOS/nixpkgs/commit/df62656187459785860c95c42422a24d4aa88f87) | `` python311Packages.tplink-omada-client: 1.3.7 -> 1.3.8 ``                                 |
| [`7734335b`](https://github.com/NixOS/nixpkgs/commit/7734335b9b1a62620262ae7919f5d9f9d748997e) | `` python311Packages.pyoverkiz: 1.13.6 -> 1.13.7 ``                                         |
| [`e0a2f43c`](https://github.com/NixOS/nixpkgs/commit/e0a2f43c4bda16a818c1ae7a18914de247cd00e1) | `` gdu: refactor ``                                                                         |
| [`3c6d8fda`](https://github.com/NixOS/nixpkgs/commit/3c6d8fdaaf65f36b2f98f8f1d3baca8fbcaa6cff) | `` gdu: 5.26.0 -> 5.27.0 ``                                                                 |
| [`1c3ef24e`](https://github.com/NixOS/nixpkgs/commit/1c3ef24eaa9b2122e9fd610bf18c8c35d7417f64) | `` beeper: 3.95.26 -> 3.96.30 ``                                                            |
| [`5ac765dd`](https://github.com/NixOS/nixpkgs/commit/5ac765dd4c8ce6e617573eda6ccfaf0188ec96be) | `` python312Packages.requests-cache: update disabled ``                                     |
| [`ea37f187`](https://github.com/NixOS/nixpkgs/commit/ea37f187ec71f71020dd7de4725e3e2992d6b2eb) | `` ad-miner: fix typo ``                                                                    |
| [`e99535b1`](https://github.com/NixOS/nixpkgs/commit/e99535b12d39d1873e4ce7147378fb7d8608bbbc) | `` ad-miner: 1.0.0 -> 1.1.0 ``                                                              |
| [`7dfa5ad0`](https://github.com/NixOS/nixpkgs/commit/7dfa5ad068902a88b20c16cabdbb534bd6936c38) | `` recoll: 1.37.2 -> 1.37.4 ``                                                              |
| [`3b5a6341`](https://github.com/NixOS/nixpkgs/commit/3b5a63418925cb3481ae13dc74a671ac89088a44) | `` sigma-cli: 1.0.0 -> 1.0.1 ``                                                             |
| [`6d34de70`](https://github.com/NixOS/nixpkgs/commit/6d34de70f4e869951d341cfad3f56ca25a2ce862) | `` vscode-extensions.karunamurti.haml: init at 1.4.1 ``                                     |
| [`e233bf6c`](https://github.com/NixOS/nixpkgs/commit/e233bf6c3130f43ed3b5d6a1492f331ecb2e9faa) | `` bloop: 1.5.13 -> 1.5.15 ``                                                               |
| [`7ea8d2b2`](https://github.com/NixOS/nixpkgs/commit/7ea8d2b2bef1a1e315dd618bf7edc5c0dff546ca) | `` nfs-ganesha: add tools output for mount.9P helper ``                                     |
| [`a24b9a09`](https://github.com/NixOS/nixpkgs/commit/a24b9a0959ef8f4ba56c991c7838010031fd0249) | `` cloc: 1.98 -> 2.00 ``                                                                    |
| [`9f2d51a4`](https://github.com/NixOS/nixpkgs/commit/9f2d51a4e7adac81e6dfcbbdacac0a498591a663) | `` nixos/transmission: fix log level bounds to match the transmission wiki ``               |
| [`1ae02f52`](https://github.com/NixOS/nixpkgs/commit/1ae02f52a5892b1cbca3b0132afbde43385bf580) | `` discordo: unstable-2024-01-25 -> unstable-2024-02-16 ``                                  |
| [`79352621`](https://github.com/NixOS/nixpkgs/commit/79352621875e3c12953d077046425f1a1d62c6f8) | `` python311Packages.zigpy-deconz: 0.23.0 -> 0.23.1 ``                                      |
| [`44c1bc1e`](https://github.com/NixOS/nixpkgs/commit/44c1bc1e4234ffd1e86d5e3a08afb6568f7912af) | `` treedome: 0.3.3 -> 0.4 ``                                                                |
| [`cd3a9fc5`](https://github.com/NixOS/nixpkgs/commit/cd3a9fc59a72a0ab177d671418ab2f60a3ed7b0b) | `` pasco: init at 20040505_1 ``                                                             |
| [`f42b16bb`](https://github.com/NixOS/nixpkgs/commit/f42b16bb43dbdea6c4bec4eae030e6b9e25e1417) | `` myrescue: init at 0.9.8 ``                                                               |
| [`b31810a7`](https://github.com/NixOS/nixpkgs/commit/b31810a7c789c5b6bfd83c25e0bcd19e9b2057af) | `` vale: 3.0.7 -> 3.1.0 ``                                                                  |
| [`c1b6218c`](https://github.com/NixOS/nixpkgs/commit/c1b6218c96ef20f6a687d7d78f24b023d1a6c829) | `` solaar: 1.1.10 -> 1.1.11 ``                                                              |
| [`68b10cb8`](https://github.com/NixOS/nixpkgs/commit/68b10cb8dc9c0bfbc94a7736202bce3c8d0d104e) | `` drawio: 22.1.8 -> 23.1.5 ``                                                              |
| [`7cecf3ea`](https://github.com/NixOS/nixpkgs/commit/7cecf3eae12799f79cfcf845805df5b015cf13b5) | `` bitcoin-abc: 0.26.2 -> 0.28.9 ``                                                         |
| [`703691ab`](https://github.com/NixOS/nixpkgs/commit/703691abb2477d9fce7aa078d12fd122e53645ff) | `` python311Packages.aiowebostv: 0.3.3 -> 0.4.0 ``                                          |
| [`bfdbb6cf`](https://github.com/NixOS/nixpkgs/commit/bfdbb6cf725c5a0d0d12d1976cf6a2a372ee7ad0) | `` homebank: add frlan as maintainer ``                                                     |
| [`0cdfd793`](https://github.com/NixOS/nixpkgs/commit/0cdfd7932ffd662b4dcdaa29e343eb663a43d595) | `` pdepend: 2.15.1 -> 2.16.2 ``                                                             |
| [`36e3a65a`](https://github.com/NixOS/nixpkgs/commit/36e3a65aff706631fbafd6f1518ab95a3f5f1769) | `` minio: 2024-02-14T21-36-02Z -> 2024-02-17T01-15-57Z ``                                   |
| [`3d44a445`](https://github.com/NixOS/nixpkgs/commit/3d44a4452940782551f09ad3dd4afd2d5e0c22b4) | `` python311Packages.django-pattern-library: 1.1.0 -> 1.2.0 ``                              |
| [`42c0ca3b`](https://github.com/NixOS/nixpkgs/commit/42c0ca3b7db7adf4c4ea9259d8fd66480bcbab50) | `` cfonts: 1.1.2 -> 1.1.3 ``                                                                |
| [`a02037ec`](https://github.com/NixOS/nixpkgs/commit/a02037ec69b5b8a689cd12336339643cddfb2c7e) | `` grype: 0.74.5 -> 0.74.6 ``                                                               |
| [`d1f801c7`](https://github.com/NixOS/nixpkgs/commit/d1f801c743590ae3cd41cd514e8fbbf63ff07fa6) | `` goaccess: 1.8.1 -> 1.9.1 ``                                                              |
| [`212d1b86`](https://github.com/NixOS/nixpkgs/commit/212d1b86113cc685fb3c4f690c28e92ae1dbfd23) | `` gh: 2.44.0 -> 2.44.1 ``                                                                  |
| [`a6ed66bd`](https://github.com/NixOS/nixpkgs/commit/a6ed66bd115a9fd6161f4967a29c3ef073c3deab) | `` python311Packages.tuf: refactor ``                                                       |
| [`f65ed092`](https://github.com/NixOS/nixpkgs/commit/f65ed09251947892cefd070d6c9f6521d82c4ae6) | `` python311Packages.tuf: 3.1.0 -> 3.1.1 ``                                                 |
| [`2ae5b21b`](https://github.com/NixOS/nixpkgs/commit/2ae5b21bebe8f0abafacc893d2e54858647e6248) | `` bun: 1.0.26 -> 1.0.27 ``                                                                 |
| [`c709432e`](https://github.com/NixOS/nixpkgs/commit/c709432ee1f59f66f5d405cf795b8e8a387e86e6) | `` python311Packages.meshtastic: 2.2.21 -> 2.2.22 ``                                        |
| [`af080c9c`](https://github.com/NixOS/nixpkgs/commit/af080c9cdebc7aa48570e574a780aae117b32b05) | `` python311Packages.md-toc: refactor ``                                                    |
| [`18981e68`](https://github.com/NixOS/nixpkgs/commit/18981e689cccec5dd119a280d83d17eaf98c2dd8) | `` python311Packages.fpyutils: refactor ``                                                  |
| [`0bf342e4`](https://github.com/NixOS/nixpkgs/commit/0bf342e43a3f94fc6821459d7ccc5819ccb6133a) | `` python311Packages.fpyutils: 3.0.1 -> 4.0.1 ``                                            |
| [`093ed6ce`](https://github.com/NixOS/nixpkgs/commit/093ed6ce86553861f7378d03bbf729b7b94ab977) | `` python311Packages.md-toc: 8.2.2 -> 8.2.3 ``                                              |
| [`d989e81e`](https://github.com/NixOS/nixpkgs/commit/d989e81eb04a0f1499ccfa8feabc27ca38bd7c3a) | `` python311Packages.hahomematic: 2024.2.3 -> 2024.2.4 ``                                   |
| [`9a975eeb`](https://github.com/NixOS/nixpkgs/commit/9a975eeb39a4169f13f61cf317d1d61fd1a7dd1f) | `` python311Packages.sagemaker: 2.207.1 -> 2.208.0 ``                                       |
| [`25b85780`](https://github.com/NixOS/nixpkgs/commit/25b85780d26a771e38b111bdf5392a08d0d4e4f2) | `` exploitdb: 2024-02-16 -> 2024-02-17 ``                                                   |
| [`22033572`](https://github.com/NixOS/nixpkgs/commit/220335727d68a025ee6e501f79c872a8bc1eb064) | `` exploitdb: 2024-02-14 -> 2024-02-16 ``                                                   |
| [`ed9dcf12`](https://github.com/NixOS/nixpkgs/commit/ed9dcf128623e711c41dda81c12895a8843b27e5) | `` plantuml: 1.2024.2 -> 1.2024.3 ``                                                        |
| [`beb3c3b7`](https://github.com/NixOS/nixpkgs/commit/beb3c3b76fd6d8e5dc59aab1213e2031068f4c8b) | `` python311Packages.oelint-parser: 3.2.0 -> 3.2.1 ``                                       |
| [`33ad74f5`](https://github.com/NixOS/nixpkgs/commit/33ad74f54929aaa278af8097e59d3e9d633f261a) | `` cvehound: 1.1.0 -> 1.2.0 ``                                                              |
| [`f1bc8cd2`](https://github.com/NixOS/nixpkgs/commit/f1bc8cd22e26f7b6195099f30f04a7eecc2049da) | `` linuxKernel.kernels.linux_lqx: 6.7.4-lqx1 -> 6.7.5-lqx1 ``                               |
| [`3ff4ce2e`](https://github.com/NixOS/nixpkgs/commit/3ff4ce2eb8eada65252f458b368dc23c320b9609) | `` home-manager: unstable-2024-02-14 -> unstable-2024-02-15 ``                              |
| [`cf9b9554`](https://github.com/NixOS/nixpkgs/commit/cf9b9554e6f9967865f0489820802d3a3cafe189) | `` wander: 1.0.2 -> 1.1.0 ``                                                                |
| [`d72763b3`](https://github.com/NixOS/nixpkgs/commit/d72763b368629f60c08302451ad7a616805cafe8) | `` python312Packages.types-requests: 2.31.0.20240125 -> 2.31.0.20240218 ``                  |
| [`f6b73c47`](https://github.com/NixOS/nixpkgs/commit/f6b73c476f5c7c5c18aa4d739301cb9e310254c1) | `` python312Packages.requests-cache: 1.1.1 -> 1.2.0 ``                                      |
| [`feca3d99`](https://github.com/NixOS/nixpkgs/commit/feca3d9963b327420ae68cdcf9229f6b12e84019) | `` linuxKernel.kernels.linux_zen: 6.7.4-zen1 -> 6.7.5-zen1 ``                               |
| [`30bd8c92`](https://github.com/NixOS/nixpkgs/commit/30bd8c92a8a6cb5294d43a4a7f15925e669111fb) | `` python312Packages.types-redis: 4.6.0.20240106 -> 4.6.0.20240218 ``                       |
| [`33b559ce`](https://github.com/NixOS/nixpkgs/commit/33b559ce7d9d5e5abef75129ee9e01e7fbae4d21) | `` libcef: 117.2.4 -> 121.3.13 ``                                                           |
| [`b1093e0b`](https://github.com/NixOS/nixpkgs/commit/b1093e0ba00c4d9dbece45e3c17463b1d156f630) | `` open-in-mpv: 2.1.0-unstable-2023-05-13 -> 2.2.0 ``                                       |
| [`8b249d3e`](https://github.com/NixOS/nixpkgs/commit/8b249d3ea33deee8274befa1e47eb636c0427880) | `` runme: 3.0.0 -> 3.0.1 ``                                                                 |
| [`a2234613`](https://github.com/NixOS/nixpkgs/commit/a2234613e8b2bc3a8408337fa45787d150c91efd) | `` plantuml-server: 1.2024.2 -> 1.2024.3 ``                                                 |
| [`418d37e2`](https://github.com/NixOS/nixpkgs/commit/418d37e22f2b88186d5ba630d9dd0de556cb114a) | `` cotp: 1.4.1 -> 1.4.4 ``                                                                  |
| [`f8fc909d`](https://github.com/NixOS/nixpkgs/commit/f8fc909deb7194102159856e7758ad2a3b95ff85) | `` cirrus-cli: 0.110.4 -> 0.112.0 ``                                                        |
| [`e8962004`](https://github.com/NixOS/nixpkgs/commit/e8962004cd0d44f705253b634cc38570903e68a5) | `` bdf2psf: 1.225 -> 1.226 ``                                                               |
| [`ac637ef2`](https://github.com/NixOS/nixpkgs/commit/ac637ef21ecc2f0a1a0987fe9ce1d7f0d7f42fca) | `` Revert "openobserve: 0.7.2 -> 0.8.1" ``                                                  |
| [`c1415dd4`](https://github.com/NixOS/nixpkgs/commit/c1415dd4b713f69fae12343a56fbe03a70a0977e) | `` openscad-unstable: 2024-01-22 -> 2024-02-18 ``                                           |
| [`7b1506bb`](https://github.com/NixOS/nixpkgs/commit/7b1506bb9b7e7b560e5786ec07a61ad92beba99e) | `` waylyrics: add aleksana as maintainer ``                                                 |
| [`c98a5bb9`](https://github.com/NixOS/nixpkgs/commit/c98a5bb979c8d633e6c9c0da232adaeff4ec1205) | `` waylyrics: unstable-2023-05-14 -> 0.2.4 ``                                               |
| [`51e918d4`](https://github.com/NixOS/nixpkgs/commit/51e918d474e2a69e5de0c2295556c32b84a57c8b) | `` uv: 0.1.3 -> 0.1.4 ``                                                                    |
| [`d19ef2a0`](https://github.com/NixOS/nixpkgs/commit/d19ef2a03c1f97af0c7d3b55f11933ad1c8f5346) | `` ruff: 0.2.1 -> 0.2.2 ``                                                                  |
| [`acda0fbc`](https://github.com/NixOS/nixpkgs/commit/acda0fbc9e670f140c4b48a9674cf8dc7a23dc2e) | `` mise: 2024.2.15 -> 2024.2.16 ``                                                          |
| [`94cce576`](https://github.com/NixOS/nixpkgs/commit/94cce57664084defbb9d955ab4a651a7c9c46cd0) | `` zfs-replicate: update pyproject format ``                                                |
| [`08a48457`](https://github.com/NixOS/nixpkgs/commit/08a48457f950ec1910b68e2e9bf4b2a2c4d41111) | `` wimlib: fix fuse3 darwin dependency ``                                                   |
| [`54c160c7`](https://github.com/NixOS/nixpkgs/commit/54c160c74ff215bb974e52704d403a4d2b77834c) | `` agdaPackages.cubical: add maintainer phijor ``                                           |
| [`6a98458f`](https://github.com/NixOS/nixpkgs/commit/6a98458f0f9f49ba4fdf6b3d37e86f9db536d203) | `` maintainers: add phijor ``                                                               |
| [`811da6b0`](https://github.com/NixOS/nixpkgs/commit/811da6b02c34a3cb57846f0656f3fdba15f49660) | `` renode-dts2repl: unstable-2024-02-14 -> unstable-2024-02-16 ``                           |
| [`675a6c1e`](https://github.com/NixOS/nixpkgs/commit/675a6c1edfcf37ab55e11f48a2dc9ee4e2bacb25) | `` komikku: 1.37.1 -> 1.38.1 ``                                                             |
| [`4fd97d0d`](https://github.com/NixOS/nixpkgs/commit/4fd97d0da606fa06982a664baa929aa53dd1fd94) | `` python311Packages.pypandoc: 1.10 -> 1.13 ``                                              |
| [`dac6982f`](https://github.com/NixOS/nixpkgs/commit/dac6982f9125e47da274f5827cd46228252157d8) | `` python3Packages.vllm: add lach to maintainers ``                                         |
| [`85306e27`](https://github.com/NixOS/nixpkgs/commit/85306e27d6858edf441614d24f4d6296519909d7) | `` python311Packages.vllm: init at v0.3.1 ``                                                |
| [`361c543f`](https://github.com/NixOS/nixpkgs/commit/361c543f9eb7720c03a2f6ee76370e075847efc5) | `` ispc: remove -DLLVM_DIS_EXECUTABLE flag ``                                               |
| [`8a131f25`](https://github.com/NixOS/nixpkgs/commit/8a131f25c85084c544af62152e9fcbbc648a8949) | `` libcifpp: 6.1.0 -> 7.0.0 ``                                                              |
| [`213ee58d`](https://github.com/NixOS/nixpkgs/commit/213ee58dec600101dfc30275679a3b411373a2b1) | `` endless-sky: 0.10.4 -> 0.10.6 ``                                                         |
| [`cb6f36e8`](https://github.com/NixOS/nixpkgs/commit/cb6f36e8ffabf98238240106cbe5b3f6f1fae854) | `` xrootd: fix plugin loading on Linux (#289140) ``                                         |
| [`6ffd74b5`](https://github.com/NixOS/nixpkgs/commit/6ffd74b5365403c7cc1b2f670f89ba52d7303baf) | `` python3Packages.rerun-sdk: init at 0.13.0 ``                                             |
| [`135fd532`](https://github.com/NixOS/nixpkgs/commit/135fd532b758d9f113df64acf8b735a02582a30a) | `` rerun: init at 0.13.0 ``                                                                 |
| [`1234093a`](https://github.com/NixOS/nixpkgs/commit/1234093ac6f10e77e24aa482379d68c06cf50ebc) | `` tokyo-night-gtk: fix version number ``                                                   |
| [`a61fe84e`](https://github.com/NixOS/nixpkgs/commit/a61fe84e8854b7191652ae073f13cbc7f1fda041) | `` tokyo-night-gtk: change package name ``                                                  |
| [`c8d47d0b`](https://github.com/NixOS/nixpkgs/commit/c8d47d0be31e110321c7a36d15527c72053acdbf) | `` circleci-cli: 0.1.30084 -> 0.1.30163 ``                                                  |
| [`10ad1f16`](https://github.com/NixOS/nixpkgs/commit/10ad1f16520094ad0bb7f79ef3c04c986e4812ad) | `` minio-client: 2024-02-09T22-18-24Z -> 2024-02-16T11-05-48Z ``                            |
| [`0622dc3d`](https://github.com/NixOS/nixpkgs/commit/0622dc3d27d969b49dd07ed9b16d23199548445a) | `` resvg: 0.39.0 -> 0.40.0 ``                                                               |
| [`5486165e`](https://github.com/NixOS/nixpkgs/commit/5486165eea37c867ef5a56a61dc1683dc3486fe5) | `` door-knocker: 0.4.3 -> 0.4.4 ``                                                          |