### PR TITLE
chore(flake/nixpkgs): `b98a4e17` -> `0e74ca98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708296515,
-        "narHash": "sha256-FyF489fYNAUy7b6dkYV6rGPyzp+4tThhr80KNAaF/yY=",
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b98a4e1746acceb92c509bc496ef3d0e5ad8d4aa",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`c82d4213`](https://github.com/NixOS/nixpkgs/commit/c82d4213f76cfe68c6b1de43f560e362a7a86ad1) | `` python311Packages.langchain: 0.1.6 -> 0.1.8 ``                                 |
| [`74214026`](https://github.com/NixOS/nixpkgs/commit/742140265720b43e39af6aea3c3730f5840b430a) | `` python311Packages.langchain-community: 0.0.19 -> 0.0.21 ``                     |
| [`339deb3b`](https://github.com/NixOS/nixpkgs/commit/339deb3b56295e5a56fbddd910e00405f1bd9063) | `` python311Packages.langchain-core: 0.1.22 -> 0.1.24 ``                          |
| [`2a51fcdd`](https://github.com/NixOS/nixpkgs/commit/2a51fcdd9133f1f2d8e20eb6214dbd355897811e) | `` python311Packages.langsmith: 0.0.90 -> 0.1.3 ``                                |
| [`8a4a9584`](https://github.com/NixOS/nixpkgs/commit/8a4a9584df62039b79a2cc35728b8261dad4dfbb) | `` python311Packages.a2wsgi: 1.10.0 -> 1.10.2 (#290255) ``                        |
| [`39658734`](https://github.com/NixOS/nixpkgs/commit/3965873493d8f90b9c69efca880a592fb6dacdf4) | `` zigpy-cli: init at 1.0.4 (#289805) ``                                          |
| [`b07727ca`](https://github.com/NixOS/nixpkgs/commit/b07727ca2a3b14d0e5153026b39aed99088b6871) | `` python311Packages.boto3-stubs: 1.34.45 -> 1.34.46 ``                           |
| [`1e07f1ce`](https://github.com/NixOS/nixpkgs/commit/1e07f1cebdf16637face73fd3b51da337b63e3f7) | `` python312Packages.posthog: 3.4.1 -> 3.4.2 ``                                   |
| [`6383ee54`](https://github.com/NixOS/nixpkgs/commit/6383ee544aead80659bb4cca6ad0cc8ab62a2495) | `` cxxopts: 3.2.0 -> 3.2.1 ``                                                     |
| [`65ac553a`](https://github.com/NixOS/nixpkgs/commit/65ac553a62323237c709d7b10ed853b8885741d5) | `` ldeep: refactor ``                                                             |
| [`7e8e07ed`](https://github.com/NixOS/nixpkgs/commit/7e8e07ed121d7bdae66fd8048bb7ad4271a3fa39) | `` ldeep: 1.0.51 -> 1.0.52 ``                                                     |
| [`3fedc5e1`](https://github.com/NixOS/nixpkgs/commit/3fedc5e1196144f065bba27378095575b4a5ad2e) | `` dns2tcp: init at 0.5.2 ``                                                      |
| [`9911cf21`](https://github.com/NixOS/nixpkgs/commit/9911cf21285153ed5f3d5735c5f03847527d9c86) | `` _1password-gui-beta: 8.10.26-1 → 8.10.26-38 ``                                 |
| [`703a1007`](https://github.com/NixOS/nixpkgs/commit/703a10072a6169203c90fdfe864c3c78a898ec90) | `` phpPackages.phpstan: 1.10.58 -> 1.10.59 ``                                     |
| [`3a3bd77f`](https://github.com/NixOS/nixpkgs/commit/3a3bd77f0930861de647af0d94904e0ae31e0e7e) | `` paratest: 7.4.2 -> 7.4.3 ``                                                    |
| [`3098c175`](https://github.com/NixOS/nixpkgs/commit/3098c175189ad2c68fe074cb520ba095b34ea6b7) | `` pleroma: 2.6.1 -> 2.6.2 ``                                                     |
| [`62005d1d`](https://github.com/NixOS/nixpkgs/commit/62005d1d74c57e79ca48d5190d1a406be6cbaeea) | `` python311Packages.plotnine: 0.12.4 -> 0.13.0 ``                                |
| [`821d134e`](https://github.com/NixOS/nixpkgs/commit/821d134eefc449e8406ae1de214996bb7ad30733) | `` python311Packages.mizani: 0.9.3 -> 0.11.0 ``                                   |
| [`8363e965`](https://github.com/NixOS/nixpkgs/commit/8363e9657fe4333e9f728cb32bedbb3762debd64) | `` linux-firmware: 20240115 -> 20240220 ``                                        |
| [`bf678bf2`](https://github.com/NixOS/nixpkgs/commit/bf678bf29f073229f0d663fc1781b44e345fb4b5) | `` libretro.puae: unstable-2024-02-03 -> unstable-2024-02-20 ``                   |
| [`82a3fb3c`](https://github.com/NixOS/nixpkgs/commit/82a3fb3c1b9f951c7ea63aa497fe1842f2fec3d7) | `` libretro.fbneo: unstable-2024-02-16 -> unstable-2024-02-18 ``                  |
| [`298ec407`](https://github.com/NixOS/nixpkgs/commit/298ec407d44d2aae0fe2fcba574de62428e17160) | `` libretro.nestopia: unstable-2024-02-13 -> unstable-2024-02-18 ``               |
| [`a0fcc6d8`](https://github.com/NixOS/nixpkgs/commit/a0fcc6d8c6bab8da376a9b15d23e5c61a707acf4) | `` libretro.mrboom: unstable-2024-02-09 -> unstable-2024-02-17 ``                 |
| [`61e947dd`](https://github.com/NixOS/nixpkgs/commit/61e947ddbf5fced46e26193d13e656955d263d0e) | `` libretro.play: unstable-2024-02-14 -> unstable-2024-02-19 ``                   |
| [`21ef4746`](https://github.com/NixOS/nixpkgs/commit/21ef47463dcf417570c2f1b090e8155bc557238c) | `` python3Packages.pyannote-database: init at 5.0.1 ``                            |
| [`5c30adc7`](https://github.com/NixOS/nixpkgs/commit/5c30adc7e450b039bdea829638dfd61115f1d815) | `` python3Packages.pyannote-metrics: init at 3.2.1 ``                             |
| [`efcaeb0f`](https://github.com/NixOS/nixpkgs/commit/efcaeb0f5cf0a077a4a35cf7854a13ec1fe4b8f6) | `` python3Packages.pyannote-pipeline: init at 3.0.1 ``                            |
| [`658df6b5`](https://github.com/NixOS/nixpkgs/commit/658df6b55a8762ad116483eb08c537c37dc22804) | `` python3Packages.pyannote-core: init at 5.0.0 ``                                |
| [`ccbf330c`](https://github.com/NixOS/nixpkgs/commit/ccbf330ccc1868c3af7e954ba958df0c022f3f84) | `` python3Packages.pyannote-audio: init at 3.1.1 ``                               |
| [`d4af3fa9`](https://github.com/NixOS/nixpkgs/commit/d4af3fa92901bc632d71b1b446a2e949da45c004) | `` python3Packages.pyscaffoldext-django: init at 0.2 ``                           |
| [`3c5aed34`](https://github.com/NixOS/nixpkgs/commit/3c5aed34337632498e410f527ab06d37356a1f79) | `` python3Packages.torch-audiomentations: init at 0.11.0 ``                       |
| [`eb98127c`](https://github.com/NixOS/nixpkgs/commit/eb98127cc0a0522b64d11b239be602224c7e8160) | `` python3Packages.pyscaffoldext-travis: init at 0.3 ``                           |
| [`dcd7a4c8`](https://github.com/NixOS/nixpkgs/commit/dcd7a4c81a6c0108d47362ea1f881d3672b07540) | `` python3Packages.pyscaffoldext-markdown: init at 0.5 ``                         |
| [`8a1d1b78`](https://github.com/NixOS/nixpkgs/commit/8a1d1b78b386cc8684cd1f3b02cc38a315e6b8c0) | `` python3Packages.pyscaffoldext-dsproject: init at 0.7.2 ``                      |
| [`eb504d1b`](https://github.com/NixOS/nixpkgs/commit/eb504d1b58d0a9d48cb9c10232833f66abe40cd0) | `` python3Packages.pyscaffoldext-custom-extension: init at 0.6.3 ``               |
| [`1a9fea0c`](https://github.com/NixOS/nixpkgs/commit/1a9fea0ce6126cd51d73a01966c4af9880c3febf) | `` python3Packages.pyscaffoldext-cookiecutter: init at 0.1 ``                     |
| [`8359c197`](https://github.com/NixOS/nixpkgs/commit/8359c19723334ea22b46de9f4254492b44875bcf) | `` python3Packages.pyscaffold: init at 4.5 ``                                     |
| [`63917a6f`](https://github.com/NixOS/nixpkgs/commit/63917a6f98e986e058c01cf6245578369d9042d9) | `` python3Packages.torch-pitch-shift: init at 1.2.4 ``                            |
| [`acfe7eeb`](https://github.com/NixOS/nixpkgs/commit/acfe7eeb33c6b8d6a5ee3d34fd4236a5b69e0e6f) | `` python3Packages.primepy: init at 1.3 ``                                        |
| [`ac8f48df`](https://github.com/NixOS/nixpkgs/commit/ac8f48df38f529619bbfb853f61dd183f7cbb502) | `` python3Packages.julius: init at 0.2.7 ``                                       |
| [`dc4fb506`](https://github.com/NixOS/nixpkgs/commit/dc4fb5062ac2f3952a26a20d5f495decbdeffe66) | `` python3Packages.asteroid-filterbanks: init at 0.4.0 ``                         |
| [`3c515003`](https://github.com/NixOS/nixpkgs/commit/3c515003b85da79453d295039fd80272fa4616dc) | `` libpsl: add windows to supported platforms ``                                  |
| [`6e5b80bc`](https://github.com/NixOS/nixpkgs/commit/6e5b80bc7dd78ad6da5b67df063a6bfa651ade7b) | `` lighttpd: 1.4.73 -> 1.4.74 ``                                                  |
| [`70f35f50`](https://github.com/NixOS/nixpkgs/commit/70f35f507bd30b6dc95f12caea5490bc621666b2) | `` double-conversion: add windows to supported platforms ``                       |
| [`d3537a00`](https://github.com/NixOS/nixpkgs/commit/d3537a0016bfc11b928e1ffd0953595b486f7f89) | `` weaviate: 1.23.9 -> 1.23.10 ``                                                 |
| [`ca79af32`](https://github.com/NixOS/nixpkgs/commit/ca79af322bd401b4c798a89510d9b41d4aaca3f0) | `` kor: 0.3.4 -> 0.3.5 ``                                                         |
| [`80dd4475`](https://github.com/NixOS/nixpkgs/commit/80dd44759c8dcb85af4f7358d63219fa808195ed) | `` qbe: 1.1 -> 1.2 (#289276) ``                                                   |
| [`2b7b1ddc`](https://github.com/NixOS/nixpkgs/commit/2b7b1ddc3a7cc7eba20740103ef68161e3aaa7d8) | `` vimPlugins: multiple vim and neovim themes ``                                  |
| [`2d689ae1`](https://github.com/NixOS/nixpkgs/commit/2d689ae1d343a090e6a0b33b74944125317d4a04) | `` stochas: 1.3.9 -> 1.3.10 ``                                                    |
| [`fa1a13ca`](https://github.com/NixOS/nixpkgs/commit/fa1a13caaa73092ddda8cc7623b0644e45ba4238) | `` witness: 0.2.0 -> 0.3.0 ``                                                     |
| [`4585e37a`](https://github.com/NixOS/nixpkgs/commit/4585e37aef32e32e2f52063cca45c2ffa6e3da91) | `` vimPlugins.none-ls-nvim: add plenary-nvim dependency ``                        |
| [`b39f7c05`](https://github.com/NixOS/nixpkgs/commit/b39f7c0598aae7a9abbcac27ec7186ab34dcd487) | `` jwx: 2.0.19 -> 2.0.20 ``                                                       |
| [`459346db`](https://github.com/NixOS/nixpkgs/commit/459346dbc2298c4458fa8e81a37afee29137d83d) | `` octodns-providers.gandi: 0.0.2 -> 0.0.3 ``                                     |
| [`2d78e1b2`](https://github.com/NixOS/nixpkgs/commit/2d78e1b237efe322141b3ad8df009d9c7f84b90d) | `` keepassxc-go: init at 1.5.1 ``                                                 |
| [`68ee8839`](https://github.com/NixOS/nixpkgs/commit/68ee88392cb3150e3be1c0cbf1303288e2fdaa13) | `` cargo-tally: 1.0.36 -> 1.0.38 ``                                               |
| [`20c9b09e`](https://github.com/NixOS/nixpkgs/commit/20c9b09e65156a73641f3274d308c0b80ab9b4f7) | `` cargo-mobile2: 0.9.1 -> 0.10.0 ``                                              |
| [`d901eb68`](https://github.com/NixOS/nixpkgs/commit/d901eb688334c50eeb6f579ffe0a2466b7dd6bb0) | `` dovecot_fts_xapian: 1.6.2 -> 1.6.5 ``                                          |
| [`7984ed37`](https://github.com/NixOS/nixpkgs/commit/7984ed37777793341add230f52e891a72791698a) | `` qownnotes: 24.2.3 -> 24.2.5 ``                                                 |
| [`e6f62b22`](https://github.com/NixOS/nixpkgs/commit/e6f62b227e943988dd8fa6fcf9bc8da1ad6c6fc5) | `` python311Packages.wheel-inspect: refactor ``                                   |
| [`e8373792`](https://github.com/NixOS/nixpkgs/commit/e8373792a354204683da1960b4778e114c5f12a3) | `` python311Packages.openaiauth: update input ``                                  |
| [`8fce2390`](https://github.com/NixOS/nixpkgs/commit/8fce2390579dceefa2710dfca72be7ccce082fe7) | `` python311Packages.tls-client: init at 1.0.1 ``                                 |
| [`3a252af5`](https://github.com/NixOS/nixpkgs/commit/3a252af5b61d992393b90943821f72248522eb10) | `` python311Packages.openaiauth: refactor ``                                      |
| [`fe85853a`](https://github.com/NixOS/nixpkgs/commit/fe85853abeabdd441d4b21c56ab695e4dd312a48) | `` python311Packages.objax: disable failing tests ``                              |
| [`506f5754`](https://github.com/NixOS/nixpkgs/commit/506f5754ee959ec4f1ff2b35a0f0e03bbca0bb37) | `` python311Packages.objax: refactor ``                                           |
| [`2a876140`](https://github.com/NixOS/nixpkgs/commit/2a876140a8442b1ae56e437a6286f1e45dc71933) | `` openmolcas: 23.10 -> 24.02 ``                                                  |
| [`13983221`](https://github.com/NixOS/nixpkgs/commit/13983221d1bf86fa65e5c1f35601303cc5769911) | `` python311Packages.mobi: relax loguru ``                                        |
| [`3ac43992`](https://github.com/NixOS/nixpkgs/commit/3ac439921fbf4014fd8602b82395664cca9e7462) | `` geoserver: add extensions and update script ``                                 |
| [`db39126f`](https://github.com/NixOS/nixpkgs/commit/db39126fe72a7558273c1b7b565e0adc8db065e7) | `` swagger-codegen3: 3.0.53 -> 3.0.54 ``                                          |
| [`fdf21c70`](https://github.com/NixOS/nixpkgs/commit/fdf21c70f972c13ffd45d455726da68335a7d367) | `` python312Packages.botocore-stubs: 1.34.44 -> 1.34.45 ``                        |
| [`134827f6`](https://github.com/NixOS/nixpkgs/commit/134827f61cbe960ac4a321658fc5b59145441413) | `` python312Packages.boto3-stubs: 1.34.44 -> 1.34.45 ``                           |
| [`48a75133`](https://github.com/NixOS/nixpkgs/commit/48a751332615af24fe825d3809f1f4ae3d692c1d) | `` python312Packages.motionblinds: 0.6.20 -> 0.6.21 ``                            |
| [`457531cc`](https://github.com/NixOS/nixpkgs/commit/457531ccb92f578aaac7e1f14cd6740cd01087a7) | `` paratest: 7.4.1 -> 7.4.2 ``                                                    |
| [`75f1170a`](https://github.com/NixOS/nixpkgs/commit/75f1170a4907cd364d2d396d440fd1d7ef59a351) | `` bazarr: 1.4.1 -> 1.4.2 ``                                                      |
| [`e1c25993`](https://github.com/NixOS/nixpkgs/commit/e1c2599321c02d2085067047f8cb6ef3636430ed) | `` purescm: init at 1.8.2 ``                                                      |
| [`6c0be846`](https://github.com/NixOS/nixpkgs/commit/6c0be8466e8f36c91ad522b9fa67bd7cb3f35d0b) | `` apx-gui: init at 0.1.1 ``                                                      |
| [`e2ecec9d`](https://github.com/NixOS/nixpkgs/commit/e2ecec9d30e1e6f1c4b66536668d1b9d36c54a81) | `` python312Packages.aioautomower: 2024.2.6 -> 2024.2.7 ``                        |
| [`7edaa2be`](https://github.com/NixOS/nixpkgs/commit/7edaa2be6f20b34950753aa0f0f6ed814425ae57) | `` python312Packages.pyvlx: 0.2.21 -> 0.2.22 ``                                   |
| [`e3788427`](https://github.com/NixOS/nixpkgs/commit/e3788427bf817bee0f81fc39fbc5b9255f908e4c) | `` exploitdb: 2024-02-17 -> 2024-02-20 ``                                         |
| [`f29636e5`](https://github.com/NixOS/nixpkgs/commit/f29636e5c20b73a809b25dc575caaa170a6054b0) | `` recoverdm: init at 0.20 ``                                                     |
| [`99fe038c`](https://github.com/NixOS/nixpkgs/commit/99fe038cae30d7317f717eb9589921e1c944ce04) | `` oculante: 0.8.7 -> 0.8.8 ``                                                    |
| [`769a9543`](https://github.com/NixOS/nixpkgs/commit/769a9543e05f80b9d4babb4f139eac5079ee4f6b) | `` trurl: 0.9 -> 0.10 ``                                                          |
| [`a3c55cc4`](https://github.com/NixOS/nixpkgs/commit/a3c55cc4fa5b9d8a3cdeae5c74df98b1699cb417) | `` python312Packages.reolink-aio: 0.8.7 -> 0.8.8 ``                               |
| [`73e91556`](https://github.com/NixOS/nixpkgs/commit/73e915563950dc682aa2f7a47b9abd138a660d06) | `` qt6: replace stdenv.is* with stdenv.hostPlatform.is* ``                        |
| [`5e0aafc8`](https://github.com/NixOS/nixpkgs/commit/5e0aafc8627effb562e50ec4e3b9f44276d045b2) | `` jffi: 1.3.12 -> 1.3.13 ``                                                      |
| [`c088dd03`](https://github.com/NixOS/nixpkgs/commit/c088dd03fe3ee97b9e8cf9eac3affedab6fd3c09) | `` ast-grep: 0.19.0 -> 0.19.1 ``                                                  |
| [`7bafc6ad`](https://github.com/NixOS/nixpkgs/commit/7bafc6ade6408db69a9830d31967749e9acab464) | `` python311Packages.timm: 0.9.12 -> 0.9.16 ``                                    |
| [`2d5464bf`](https://github.com/NixOS/nixpkgs/commit/2d5464bf082e6304508aed815209dcb032f65c79) | `` ocamlPackages.magic-mime: 1.2.0 → 1.3.1 ``                                     |
| [`ba5d054a`](https://github.com/NixOS/nixpkgs/commit/ba5d054aed99ea68a58acad902c814107e2302d5) | `` goldwarden: 0.2.10 -> 0.2.12 ``                                                |
| [`4099c7fb`](https://github.com/NixOS/nixpkgs/commit/4099c7fbc705b3f5af5a644b1cfb947230d7521d) | `` teams-for-linux: 1.4.11 -> 1.4.12 ``                                           |
| [`1412a3b5`](https://github.com/NixOS/nixpkgs/commit/1412a3b511e5014f19c8dfc9787516331224472b) | `` wtfis: 0.7.1 -> 0.8.0 ``                                                       |
| [`3019a96d`](https://github.com/NixOS/nixpkgs/commit/3019a96df0df507b24a3f2d8150f0f593f14e4f1) | `` python311Packages.types-psycopg2: 2.9.21.20240201 -> 2.9.21.20240218 ``        |
| [`3c4ce2f1`](https://github.com/NixOS/nixpkgs/commit/3c4ce2f1d3b5b74e49c51673e4d40224d7fd020c) | `` wyoming-openwakeword: 1.9.0 -> 1.10.0 ``                                       |
| [`a725d72c`](https://github.com/NixOS/nixpkgs/commit/a725d72ca650d398dffab3d78186dc1aa65e853d) | `` pkgs.gptscript: init at 0.1.1 ``                                               |
| [`0df0b1b7`](https://github.com/NixOS/nixpkgs/commit/0df0b1b743f002dd6a7eb9e1a248abd46b21f005) | `` wyoming-faster-whisper: relax wyoming constraint ``                            |
| [`60e7030a`](https://github.com/NixOS/nixpkgs/commit/60e7030a4f3f2bd8f70afd7f43c4565fd735c298) | `` gh-dash: 3.13.1 -> 3.14.0 ``                                                   |
| [`a650fd35`](https://github.com/NixOS/nixpkgs/commit/a650fd355cfa0af7899f5c4d6529b7607cf00a9a) | `` crun: 1.14.2 -> 1.14.3 ``                                                      |
| [`942f8e2b`](https://github.com/NixOS/nixpkgs/commit/942f8e2b38a4d2f28473549a6a651b0e8ccca886) | `` python311Packages.wyoming: 1.5.2 -> 1.5.3 ``                                   |
| [`af0462fe`](https://github.com/NixOS/nixpkgs/commit/af0462fe9f53b2c8352d8cdc4d3adda9d01deb9d) | `` api-linter: 1.63.4 -> 1.63.5 ``                                                |
| [`4b433780`](https://github.com/NixOS/nixpkgs/commit/4b433780d2a8ba0a3417bed00826f0a26a9c46b4) | `` croc: 9.6.10 -> 9.6.11 ``                                                      |
| [`256f2c6f`](https://github.com/NixOS/nixpkgs/commit/256f2c6fceef0cf24ca2d97afad4abbe202d35ec) | `` Revert "python311Packages.ical: 6.1.1 -> 7.0.0" ``                             |
| [`2af49615`](https://github.com/NixOS/nixpkgs/commit/2af496159e45a0f171e3bfc57fe8f5e1ed5d0999) | `` wyoming-piper: 1.4.0 -> 1.5.0 ``                                               |
| [`cdd0027f`](https://github.com/NixOS/nixpkgs/commit/cdd0027f6cda709eaade76b6f1d171e30e8866f0) | `` dunst: 1.9.2 -> 1.10.0 ``                                                      |
| [`dfe38fa3`](https://github.com/NixOS/nixpkgs/commit/dfe38fa3b80d837f920be75f06f5d94afd490391) | `` renode-unstable: 1.14.0+20240215git10667c665 -> 1.14.0+20240219gitea2784757 `` |
| [`a381dba2`](https://github.com/NixOS/nixpkgs/commit/a381dba2b1db04d909c685187027a83852f946fb) | `` dunst: switch to finalAttrs pattern over rec expression ``                     |
| [`259ee39d`](https://github.com/NixOS/nixpkgs/commit/259ee39dcd3ba6264e3ff97b0dd486b807a728b6) | `` dunst: migrate to pkgs/by-name ``                                              |
| [`db196c4c`](https://github.com/NixOS/nixpkgs/commit/db196c4c30c470299e2d28425ef9c29ff099e3b6) | `` jql: 7.1.4 -> 7.1.5 ``                                                         |
| [`daf3f934`](https://github.com/NixOS/nixpkgs/commit/daf3f9343428896f4d1340e1d27d96e1a38457d5) | `` python311Packages.scikit-misc: 0.3.0 -> 0.3.1 ``                               |
| [`6ac6e5cf`](https://github.com/NixOS/nixpkgs/commit/6ac6e5cfc8b167535906b076b268a38055b5a3ac) | `` python312Packages.snakemake-interface-common: 1.16.0 -> 1.17.0 ``              |
| [`19ae4021`](https://github.com/NixOS/nixpkgs/commit/19ae40216c0699c7c4fea1eb93adbc72bb312919) | `` starsector: 0.97a-RC10 -> 0.97a-RC11 ``                                        |