### PR TITLE
chore(flake/darwin): `314a36d9` -> `bbde06be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708655464,
-        "narHash": "sha256-dhi3XXT662o1FtP/Li2dIwcQCco6nhT+Yv71dptTlSw=",
+        "lastModified": 1708737761,
+        "narHash": "sha256-sR/1cYjpgr71ZSrt6Kp5Dg4Ul3mo6pZIG400tuzYks8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "314a36d99b507892b598da72d0f9d78db084cec9",
+        "rev": "bbde06bed1b72eddff063fa42f18644e90a0121e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                             |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
| [`f1a0d68a`](https://github.com/LnL7/nix-darwin/commit/f1a0d68a8fe99342677a078f7e93eaea1b7b44f2) | `` etc: add known hash for `/etc/zshenv` and `/etc/nix/nix.conf` `` |