### PR TITLE
chore(flake/nixpkgs): `13aff9b3` -> `9099616b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708984720,
-        "narHash": "sha256-gJctErLbXx4QZBBbGp78PxtOOzsDaQ+yw1ylNQBuSUY=",
+        "lastModified": 1709150264,
+        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "13aff9b34cc32e59d35c62ac9356e4a41198a538",
+        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                        |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| [`eb28574a`](https://github.com/NixOS/nixpkgs/commit/eb28574a33faf7bc875288cf061aadde33762ebf) | `` cargo-shuttle: 0.34.1 -> 0.39.0 ``                                                                          |
| [`ba13f3e5`](https://github.com/NixOS/nixpkgs/commit/ba13f3e5243364739d29cc4d78c7fcd0d4352b88) | `` nixos/doc: typo ``                                                                                          |
| [`c48046d2`](https://github.com/NixOS/nixpkgs/commit/c48046d2d4e11e420aa375be562bf4034dd3da72) | `` kodiPackages.youtube: 7.0.3 -> 7.0.3.2 ``                                                                   |
| [`5f1b65f7`](https://github.com/NixOS/nixpkgs/commit/5f1b65f75fd893933bcea6f74598f6990bebb115) | `` nixos/tests/incus: ensure sysctl rules apply successfully to lxc containers ``                              |
| [`f83aea70`](https://github.com/NixOS/nixpkgs/commit/f83aea707a569d3818f8b1ea80f0a5ef31df1aa8) | `` maintainers/bootstrap-files: fix two typos in README.md ``                                                  |
| [`e885ba54`](https://github.com/NixOS/nixpkgs/commit/e885ba54c7c663db84dff2bc1c3ca4783ebc4c7a) | `` hypridle: 0.1.0 -> 0.1.1 ``                                                                                 |
| [`6f28a303`](https://github.com/NixOS/nixpkgs/commit/6f28a303df0958fa15885e1eef26067d1e041873) | `` python311Packages.lxml-stubs: 0.4.0 -> 0.5.1 (#290694) ``                                                   |
| [`cdc464c0`](https://github.com/NixOS/nixpkgs/commit/cdc464c0431b4f5ffa52bad50ab53ce6444b32db) | `` audiobookshelf: 2.7.2 -> 2.8.0 ``                                                                           |
| [`6a711189`](https://github.com/NixOS/nixpkgs/commit/6a711189fc30ef1885b5cdc788f8ad89d02d81a3) | `` nixos/doc: release note for Plasma 6 ``                                                                     |
| [`4cbb0adf`](https://github.com/NixOS/nixpkgs/commit/4cbb0adf4dda6938e7ea67b31d046d361fcc502d) | `` maintainers/scripts/kde/collect-logs: rewrite in Nu ``                                                      |
| [`30c4a4b8`](https://github.com/NixOS/nixpkgs/commit/30c4a4b8f3355d0ed5031a3d10690c3deae3364b) | `` kdePackages.itinerary: hack to fix build for now ``                                                         |
| [`7d939284`](https://github.com/NixOS/nixpkgs/commit/7d939284924e0fd12163b2ebab83d40f8873a054) | `` nixos/release: add Plasma 6 ISO variant ``                                                                  |
| [`2614e408`](https://github.com/NixOS/nixpkgs/commit/2614e40893ef27d0bcda0d475cb732c47c331b78) | `` sddm: add Wayland to the wrapper if enabled ``                                                              |
| [`7b74d9a4`](https://github.com/NixOS/nixpkgs/commit/7b74d9a4acf3cad61612a83dccb115eaec06fb1a) | `` sddm: 0.20.0-unstable -> 0.21.0 ``                                                                          |
| [`ad1b1e8a`](https://github.com/NixOS/nixpkgs/commit/ad1b1e8aca00f2c932c57de21da7f7b71b1fa1eb) | `` nixos/gnupg: check for plasma 6 ``                                                                          |
| [`16f96379`](https://github.com/NixOS/nixpkgs/commit/16f963794af86f9fa53255895303d1af79cf39e0) | `` nixos/tests: add plasma6 ``                                                                                 |
| [`3f650b56`](https://github.com/NixOS/nixpkgs/commit/3f650b567f57fb8ea22a5e34e97a7f78635aa858) | `` nixos/plasma6: init ``                                                                                      |
| [`8be79e54`](https://github.com/NixOS/nixpkgs/commit/8be79e54c597eeeb0965127da236c8b7d6ac1af8) | `` nixos/pam/kwallet: rename option, allow setting package ``                                                  |
| [`606c8798`](https://github.com/NixOS/nixpkgs/commit/606c879892ba68d784f671ebef5f84c7e6e24c6a) | `` syncthingtray: support building with qt6 ``                                                                 |
| [`ce77225e`](https://github.com/NixOS/nixpkgs/commit/ce77225e21f9cf8726d197897ad9a6882a3daecc) | `` pkgs/kde: init at 6.0.0 / 24.02.0, the Nix bits ``                                                          |
| [`fc40d637`](https://github.com/NixOS/nixpkgs/commit/fc40d637fe78d717b7909e710ccb310458c2410f) | `` pkgs/kde: init at 6.0.0 / 24.02.0, the JSON bits ``                                                         |
| [`86a94a43`](https://github.com/NixOS/nixpkgs/commit/86a94a43bfce3463cbf6d2900a9931cbe606a386) | `` .editorconfig: ignore autogenerated KDE stuff ``                                                            |
| [`ea6f0162`](https://github.com/NixOS/nixpkgs/commit/ea6f0162d63d9708b9f6b8d01000cb1a0038eefc) | `` CODEOWNERS: add ownership for KDE stuff ``                                                                  |
| [`3a52750a`](https://github.com/NixOS/nixpkgs/commit/3a52750ac75d0a9bf4023b33ee37b5d332acbcc1) | `` maintainers/scripts: add kde2nix tooling ``                                                                 |
| [`2248bdfb`](https://github.com/NixOS/nixpkgs/commit/2248bdfbbcf14bebc5e2ee0d6b870b33dd3d5cf3) | `` nixos/sddm: add extraPackages option ``                                                                     |
| [`59aa3af1`](https://github.com/NixOS/nixpkgs/commit/59aa3af15dc5f8b27c7d17d60e87294c84ace3fe) | `` sddm: separate wrapping from building ``                                                                    |
| [`ff303455`](https://github.com/NixOS/nixpkgs/commit/ff303455f342360c74e6cd2df99983fa08f0e693) | `` libappimage: init at 1.0.4-5 ``                                                                             |
| [`5dee2fe5`](https://github.com/NixOS/nixpkgs/commit/5dee2fe57eae77dd29430d4d484722aa92ac233f) | `` xdg-utils-cxx: init at 1.0.1 ``                                                                             |
| [`65ae5aa8`](https://github.com/NixOS/nixpkgs/commit/65ae5aa8d8a9abd02ce3a8a8e1fc361e3c04fc35) | `` accounts-qt, signond: add Qt6 support ``                                                                    |
| [`416c9181`](https://github.com/NixOS/nixpkgs/commit/416c9181cd3fc7445f4d334146b0ee460907428b) | `` gwenview: fix build with versioned kImageAnnotator ``                                                       |
| [`f922d827`](https://github.com/NixOS/nixpkgs/commit/f922d827149d5d07f0c3cb4ac068f4220200e114) | `` ksnip: fix build with versioned kImageAnnotator ``                                                          |
| [`a06fbd06`](https://github.com/NixOS/nixpkgs/commit/a06fbd061ac7a856e692cf37441c48efd14aef52) | `` kcolorpicker, kimageannotator: update, add Qt6 support ``                                                   |
| [`470ce55e`](https://github.com/NixOS/nixpkgs/commit/470ce55e715007c33d6555d4cbb224cdba948ccb) | `` s6-rc-man-pages: 0.5.4.1.2 -> 0.5.4.2.1 ``                                                                  |
| [`25909d89`](https://github.com/NixOS/nixpkgs/commit/25909d8921d083eff8c635f2d0568bb7d029f2c1) | `` s6-networking: 2.7.0.1 -> 2.7.0.2 ``                                                                        |
| [`37366f5a`](https://github.com/NixOS/nixpkgs/commit/37366f5a40987fa75077fe24027a5941f225d9ec) | `` skalibs: 2.14.1.0 -> 2.14.1.1 ``                                                                            |
| [`cb16b92d`](https://github.com/NixOS/nixpkgs/commit/cb16b92d148ebec272e07e5fde563012970ff7a5) | `` python311Packages.python-matter-server: 5.7.0b1 -> 5.7.0b2 ``                                               |
| [`7a9958f2`](https://github.com/NixOS/nixpkgs/commit/7a9958f27f2c8ed71d87c8a7bca37c14e1ea8d37) | `` python311Packages.influxdb: ignore failing test that raises FutureWarning ``                                |
| [`e16642d1`](https://github.com/NixOS/nixpkgs/commit/e16642d1f167ee68420f78c77ba2139985d98f08) | `` home-assistant: pin aemet-opendata at 0.4.7 ``                                                              |
| [`822b9afa`](https://github.com/NixOS/nixpkgs/commit/822b9afadcfe95722859a42b6b203670182b4fe5) | `` rofi-emoji: 3.2.0 -> 3.3.0 ``                                                                               |
| [`267735f7`](https://github.com/NixOS/nixpkgs/commit/267735f78557938ec607e04d966dbac83a5a19bf) | `` doc: fix darwin-builder doc (#291518) ``                                                                    |
| [`8bd97b91`](https://github.com/NixOS/nixpkgs/commit/8bd97b917cba6e10f3ba721d98916cf725cb587d) | `` discord-canary: 0.0.282 -> 0.0.285 ``                                                                       |
| [`e495cba8`](https://github.com/NixOS/nixpkgs/commit/e495cba8dcf7378ef4a91122e072f072374b6503) | `` twitch-tui: 2.6.3 -> 2.6.4 ``                                                                               |
| [`675ad00f`](https://github.com/NixOS/nixpkgs/commit/675ad00f22543fffb7861c4cff7622784bfca799) | `` pipewire: fix wireplumber config paths ``                                                                   |
| [`3f0230cf`](https://github.com/NixOS/nixpkgs/commit/3f0230cfee579804cd4d56486292c23815aba0dd) | `` nautilus-open-any-terminal: 0.5.0 -> 0.5.1 ``                                                               |
| [`9f7f4fc6`](https://github.com/NixOS/nixpkgs/commit/9f7f4fc6d0f873dcf5daa84d1b3cec4f4be78da9) | `` python311Packages.homeassistant-stubs: 2024.2.4 -> 2024.2.5 ``                                              |
| [`1329915f`](https://github.com/NixOS/nixpkgs/commit/1329915f6be1d873c486d8a2bf215d962d6229b7) | `` python312Packages.yolink-api: 0.3.7 -> 0.3.8 ``                                                             |
| [`69186303`](https://github.com/NixOS/nixpkgs/commit/69186303729c60c64b85e4e482f0bb61b326f7fb) | `` home-assistant: 2024.2.4 -> 2024.2.5 ``                                                                     |
| [`59e3db96`](https://github.com/NixOS/nixpkgs/commit/59e3db96f9a77621aedc57c41e59da674611e0f8) | `` github-runner: 2.314.0 -> 2.314.1 (#292077) ``                                                              |
| [`db3868e6`](https://github.com/NixOS/nixpkgs/commit/db3868e64cd973fc12e7f44f5322a4ab023dd72f) | `` hexfiend: 2.16.0 -> 2.17.1 ``                                                                               |
| [`1e3ceb4e`](https://github.com/NixOS/nixpkgs/commit/1e3ceb4ef140642d3ac4f6fbb4e5e7364785b40f) | `` rauc: 1.11.1 -> 1.11.2 ``                                                                                   |
| [`9a4cba01`](https://github.com/NixOS/nixpkgs/commit/9a4cba0171e71e8820e2b5d2f8234d7e5bfe56fd) | `` python311Packages.python-matter-server: 5.5.3 -> 5.7.0b1 ``                                                 |
| [`4c2c277d`](https://github.com/NixOS/nixpkgs/commit/4c2c277d0af10097beded1e254f5fbaf5a9d6355) | `` python311Packages.home-assistant-chip-core: 2024.1.0 -> 2024.2.1 ``                                         |
| [`27aa4697`](https://github.com/NixOS/nixpkgs/commit/27aa4697519c8864f9a8a7353dd4e7b00d9c53ee) | `` python311Packages.home-assistant-chip-clusters: 2024.1.0 -> 2024.2.1 ``                                     |
| [`edf4c656`](https://github.com/NixOS/nixpkgs/commit/edf4c6561b27c7b1649ee9b4d1a209aa9f221703) | `` muffet: 2.9.3 -> 2.10.0 ``                                                                                  |
| [`fe9920d4`](https://github.com/NixOS/nixpkgs/commit/fe9920d4c1b828b517f3f70bba906ecdf7f13b02) | `` karmor: 1.1.0 -> 1.1.1 ``                                                                                   |
| [`8b487da8`](https://github.com/NixOS/nixpkgs/commit/8b487da801a9afcc16bd7cca9565f00fc2e4b8f2) | `` mise: 2024.2.18 -> 2024.2.19 ``                                                                             |
| [`8c670569`](https://github.com/NixOS/nixpkgs/commit/8c670569973b28068e490090116bfda482ab3356) | `` git-gone: 1.0.0 -> 1.1.0 ``                                                                                 |
| [`dc6eafa6`](https://github.com/NixOS/nixpkgs/commit/dc6eafa64ff99a142d06a0ea4893f0749f27925e) | `` linux_6_5: remove ``                                                                                        |
| [`62c0d92c`](https://github.com/NixOS/nixpkgs/commit/62c0d92c35a60467f407f2346c248078194037e5) | `` renode-dts2repl: unstable-2024-02-23 -> unstable-2024-02-26 ``                                              |
| [`b19ddc76`](https://github.com/NixOS/nixpkgs/commit/b19ddc76dbb7787c2eb87e78130ea325899390ab) | `` gickup: 0.10.27 -> 0.10.28 ``                                                                               |
| [`40b487c6`](https://github.com/NixOS/nixpkgs/commit/40b487c6913396468bc2a7c1fa559fba92f5cd4f) | `` python311Packages.monty: 2024.2.2 -> 2024.2.26 ``                                                           |
| [`bd5bc4bc`](https://github.com/NixOS/nixpkgs/commit/bd5bc4bcb6c6d1d0d50ddbb54196ad7abd60b202) | `` mycelium: init at 0.4.2 ``                                                                                  |
| [`88fbaf2a`](https://github.com/NixOS/nixpkgs/commit/88fbaf2ac5618eeb519fd7964cdc62311418f5f0) | `` element-desktop: 1.11.58 -> 1.11.59 ``                                                                      |
| [`bb5df569`](https://github.com/NixOS/nixpkgs/commit/bb5df569a593297401ae3a0eb6653826907f91f3) | `` cargo-tauri: 1.6.0 -> 1.6.1 ``                                                                              |
| [`7d133525`](https://github.com/NixOS/nixpkgs/commit/7d133525d31492f38bfac41a70f5d2a7109efde6) | `` lima-bin: 0.19.1 -> 0.20.1 ``                                                                               |
| [`0793cb12`](https://github.com/NixOS/nixpkgs/commit/0793cb12358c507fba82577d3478cf8578889f9d) | `` postgresql12JitPackages.pgroonga: 3.1.7 -> 3.1.8 ``                                                         |
| [`698e8907`](https://github.com/NixOS/nixpkgs/commit/698e8907bc52bc874d7a96ef9e45ce497a9ed752) | `` parallel: 20240122 -> 20240222 ``                                                                           |
| [`99bf0703`](https://github.com/NixOS/nixpkgs/commit/99bf0703a0331a6beda59903be7f5392d5f66e15) | `` python311Packages.tesla-fleet-api: 0.4.4 -> 0.4.6 ``                                                        |
| [`d1038f6b`](https://github.com/NixOS/nixpkgs/commit/d1038f6b208784184ac3192059c8f63bdae25344) | `` bpftop: add myself as maintainer ``                                                                         |
| [`d842e6bd`](https://github.com/NixOS/nixpkgs/commit/d842e6bdc62d614cd7aec14c2c8528dcfc2b6696) | `` python311Packages.wagtail-localize: refactor ``                                                             |
| [`ae192780`](https://github.com/NixOS/nixpkgs/commit/ae19278089b62227f485d27747a61818d6a416f3) | `` tigerbeetle: 0.14.180 -> 0.14.181 ``                                                                        |
| [`32f9f462`](https://github.com/NixOS/nixpkgs/commit/32f9f4626ca38383545e58d4ff58e2ba709e11bc) | `` netbird-ui: fix build failure ``                                                                            |
| [`072090b6`](https://github.com/NixOS/nixpkgs/commit/072090b624e9000dbb4e662243fbcd639dde34f7) | `` netbird: 0.26.0 -> 0.26.1 ``                                                                                |
| [`c2338e33`](https://github.com/NixOS/nixpkgs/commit/c2338e336fc644b1cc90f5c87eb765487bd5aec9) | `` eigenmath: unstable-2024-02-04 -> unstable-2024-02-25 ``                                                    |
| [`7227da65`](https://github.com/NixOS/nixpkgs/commit/7227da656152ddfe8602cbe99ab19d6b388e52a0) | `` python311Packages.langsmith: 0.1.8 -> 0.1.10 ``                                                             |
| [`2007b360`](https://github.com/NixOS/nixpkgs/commit/2007b36017667bbf1f735d42cfc841575fab5eaa) | `` python311Packages.langchain-core: 0.1.26 -> 0.1.27 ``                                                       |
| [`e4b22d1f`](https://github.com/NixOS/nixpkgs/commit/e4b22d1f92185ab5fb33db223325c2a35232a5cf) | `` python311Packages.weconnect-mqtt: 0.48.3 -> 0.48.4 ``                                                       |
| [`5b0d6593`](https://github.com/NixOS/nixpkgs/commit/5b0d65938de6c8daac1cdd9c42f0402b44fbbd9e) | `` python311Packages.weconnect: 0.60.0 -> 0.60.1 ``                                                            |
| [`009a9f86`](https://github.com/NixOS/nixpkgs/commit/009a9f869662b5ee2402d6ff1aa49d048dabae3b) | `` python311Packages.yalexs: 1.11.3 -> 1.11.4 ``                                                               |
| [`98b5a064`](https://github.com/NixOS/nixpkgs/commit/98b5a0648ddde8539d7aaadd307b097c5ec5f9ac) | `` upscayl: resolve hash mismatch for 2.9.9 ``                                                                 |
| [`7eb1e9bf`](https://github.com/NixOS/nixpkgs/commit/7eb1e9bf0a8e2ce3f553e61c8c7b4a5afcd40d9c) | `` ocamlPackages.xxhash: init at 0.2 ``                                                                        |
| [`e9e98a9d`](https://github.com/NixOS/nixpkgs/commit/e9e98a9df57c6574541b30166f75e6cbb1b76f92) | `` imgui: 1.90.3 -> 1.90.4 ``                                                                                  |
| [`bdacdc46`](https://github.com/NixOS/nixpkgs/commit/bdacdc46e4b38531cb9dd2486c1bf2821c57e72a) | `` nixos/lib/test-driver: provide legacy path for create_machine({"startCommand": "..."}) ``                   |
| [`21f474fa`](https://github.com/NixOS/nixpkgs/commit/21f474fa884e6021a0afb6873c073d4c54ee761b) | `` python311Packages.wagtail-localize: 1.8 -> 1.8.1 ``                                                         |
| [`d8db0a60`](https://github.com/NixOS/nixpkgs/commit/d8db0a6005f92ad799335cf814fcaea7eda71b8a) | `` asymptote: 2.86 -> 2.87 ``                                                                                  |
| [`1d38e14f`](https://github.com/NixOS/nixpkgs/commit/1d38e14fa863dc60e949f2449984779ffc8d1dc4) | `` python311Packages.snorkel: 0.9.9 -> 0.10.0 ``                                                               |
| [`bf6eb3b6`](https://github.com/NixOS/nixpkgs/commit/bf6eb3b658ec57aa2adb34866d0a43177cda8b88) | `` python312Packages.aioautomower: 2024.2.8 -> 2024.2.9 ``                                                     |
| [`c955a451`](https://github.com/NixOS/nixpkgs/commit/c955a451648167941dd446072242d8cbfd10c19b) | `` autotiling: 1.9 -> 1.9.1 (#291975) ``                                                                       |
| [`5c583917`](https://github.com/NixOS/nixpkgs/commit/5c5839177a0a4a6eff7883285fcdf70fdabf754b) | `` lubelogger: 1.2.2 -> 1.2.3 ``                                                                               |
| [`e7a79ad5`](https://github.com/NixOS/nixpkgs/commit/e7a79ad5fac83e8c8d5335438516083fdd637c5c) | `` typioca: 2.9.0 -> 2.10.0 ``                                                                                 |
| [`5c63e0ff`](https://github.com/NixOS/nixpkgs/commit/5c63e0ffc452dffeaaff93a2ab2d4ad7d8245358) | `` spicetify-cli: 2.32.1 -> 2.33.0 ``                                                                          |
| [`25df4045`](https://github.com/NixOS/nixpkgs/commit/25df4045e55b7bc9a7d3899b17d513850d3e5586) | `` twilio-cli: 5.18.0 -> 5.19.0 ``                                                                             |
| [`71deeead`](https://github.com/NixOS/nixpkgs/commit/71deeead432cf27be127cc47041ffbed40176225) | `` python311Packages.types-docutils: 0.20.0.20240201 -> 0.20.0.20240227 ``                                     |
| [`8fc737de`](https://github.com/NixOS/nixpkgs/commit/8fc737debfc7992709cda0658b6ade782584740d) | `` python312Packages.requests-ratelimiter: 0.4.2 -> 0.5.0 ``                                                   |
| [`e1012631`](https://github.com/NixOS/nixpkgs/commit/e1012631c0d827c6d7529bec657918700be26c47) | `` python312Packages.pyenphase: 1.19.0 -> 1.19.1 ``                                                            |
| [`398afcb0`](https://github.com/NixOS/nixpkgs/commit/398afcb01f3944bbda7d208d68094f30d7a471e6) | `` hyprlang: 0.4.0 -> 0.4.1 ``                                                                                 |
| [`b3117d37`](https://github.com/NixOS/nixpkgs/commit/b3117d37fb77b1eaa68093b583b0191258bb5cfe) | `` python311Packages.slackclient: 3.27.0 -> 3.27.1 ``                                                          |
| [`2f4ac6f8`](https://github.com/NixOS/nixpkgs/commit/2f4ac6f80307f4f66bd7491bc2cd9e690e5ee81d) | `` python3Packages.jax: add CUDA tests in passthru ``                                                          |
| [`9e8cdafe`](https://github.com/NixOS/nixpkgs/commit/9e8cdafeb8387a8f2bc3179a12d93f184b2347cd) | `` python3Packages.jaxlib-bin: cudatoolkit -> redist packages ``                                               |
| [`9dca535b`](https://github.com/NixOS/nixpkgs/commit/9dca535b0d589ce5e2494ed8d3804646b6e13b42) | `` python311Packages.nats-py: 2.7.0 -> 2.7.2 ``                                                                |
| [`ca8c5621`](https://github.com/NixOS/nixpkgs/commit/ca8c5621e22dc5d1f07a6da87f7914b50701c3d4) | `` flarectl: 0.88.0 -> 0.89.0 ``                                                                               |
| [`4631f2e1`](https://github.com/NixOS/nixpkgs/commit/4631f2e1ed2b66d099948665209409f2e8fc37ec) | `` OVMF: remove CSM support ``                                                                                 |
| [`ca630c88`](https://github.com/NixOS/nixpkgs/commit/ca630c88cf6efd4a804caecc385fc87bc4023e7a) | `` asn: 0.76.0 -> 0.76.1 ``                                                                                    |
| [`842fd5e7`](https://github.com/NixOS/nixpkgs/commit/842fd5e74a96325cb25096ac54fdc131c933ce80) | `` consul: 1.17.3 -> 1.18.0 ``                                                                                 |
| [`b3ffec12`](https://github.com/NixOS/nixpkgs/commit/b3ffec12799094f97b227d62d2b3479d11ad507b) | `` clightning: 23.11.2 -> 24.02 ``                                                                             |
| [`9f269d49`](https://github.com/NixOS/nixpkgs/commit/9f269d495c75d099d62166234c733546eaed7e42) | `` poetry: 1.7.1 -> 1.8.1 ``                                                                                   |
| [`046ea1a2`](https://github.com/NixOS/nixpkgs/commit/046ea1a290d21e4c103683a3af2ff801bb6c8424) | `` warp-terminal: 0.2023.12.05.08.02.stable_00 -> 0.2024.02.20.08.01.stable_01; added initial linux support `` |
| [`fa8651ab`](https://github.com/NixOS/nixpkgs/commit/fa8651ab96c9062382831b0abebf7199a148bde0) | `` python312Packages.oelint-parser: 3.2.2 -> 3.3.1 ``                                                          |
| [`5f6dca84`](https://github.com/NixOS/nixpkgs/commit/5f6dca8403b9af3e53e51a92393f9993aaa8fc0b) | `` nixos/pipewire: add assertions for migration to `extraConfig`/`configPackages` ``                           |
| [`5c143f03`](https://github.com/NixOS/nixpkgs/commit/5c143f03663eb59a7a1eac4b24b7c034abc4f483) | `` nixos/ollama: override kernelPackages with nvidia driver ``                                                 |
| [`58b1edd6`](https://github.com/NixOS/nixpkgs/commit/58b1edd610202191c4da0529d798dfc451b95f60) | `` ollama: 0.1.26 -> 0.1.27 ``                                                                                 |
| [`19070274`](https://github.com/NixOS/nixpkgs/commit/1907027488346b34148b0a917cf6e83db52283d1) | `` python311Packages.dnf-plugins-core: 4.4.4 -> 4.5.0 ``                                                       |
| [`d06dccfb`](https://github.com/NixOS/nixpkgs/commit/d06dccfb4d95ad10e029fd99339d4f29c9d4d9a2) | `` fcft: 3.1.7 -> 3.1.8 ``                                                                                     |
| [`3cdf5be0`](https://github.com/NixOS/nixpkgs/commit/3cdf5be0dcdc7c829de77c6e7dd519e3d72f591f) | `` gpt4all: rename `gpt4all-chat` in `gpt4all` ``                                                              |
| [`fdf83ea2`](https://github.com/NixOS/nixpkgs/commit/fdf83ea2badb17cb9a198e971a09c34d9638c6f7) | `` chromium: 122.0.6261.69 -> 122.0.6261.94 ``                                                                 |
| [`e7a302b9`](https://github.com/NixOS/nixpkgs/commit/e7a302b9aab79bfc75df08558fd0b0ce70358a59) | `` chromedriver: 122.0.6261.69 -> 122.0.6261.94 ``                                                             |
| [`34295941`](https://github.com/NixOS/nixpkgs/commit/34295941145b2df1b6c3a9b36c50ad2982227b2f) | `` lib.fileset: Fix tests on Darwin, more POSIX ``                                                             |
| [`e1327fe3`](https://github.com/NixOS/nixpkgs/commit/e1327fe3273dcb3e0abecc6a2c1596cc23c05727) | `` terrascan: 1.18.11 -> 1.18.12 ``                                                                            |
| [`feaff894`](https://github.com/NixOS/nixpkgs/commit/feaff8941597766004b819a599daa1726e5eed53) | `` python311Packages.pyrisco: 0.5.9 -> 0.5.10 ``                                                               |
| [`b5c084e1`](https://github.com/NixOS/nixpkgs/commit/b5c084e1de14f9ea9273627c56d06477994e994d) | `` litecoin, litecoind: drop redundant `disable-warnings-if-gcc13` ``                                          |