### PR TITLE
chore(flake/darwin): `283d5977` -> `70d162d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709112925,
-        "narHash": "sha256-5y8Dhw1HYdc+BWv+qQjJUIwc+ByoudtoGaHEcrXYlXw=",
+        "lastModified": 1709771483,
+        "narHash": "sha256-Hjzu9nCknHLQvhdaRFfCEprH0o15KcaNu1QDr3J88DI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "283d59778e6b8c41cac4bdeac5b2512d6de51150",
+        "rev": "550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`ad98aebc`](https://github.com/LnL7/nix-darwin/commit/ad98aebc0f900fa9bef8dfa8f5bdb328ab93ccd3) | `` Fix doc render problem ``                          |
| [`2ffb75f9`](https://github.com/LnL7/nix-darwin/commit/2ffb75f9423eb85c4ba5fa043b356f83e0586163) | `` defaults: Add options for dragOnGesture feature `` |
| [`9090c6f8`](https://github.com/LnL7/nix-darwin/commit/9090c6f8973a0eb5285a64c4af1bdde333d4f22d) | `` nix-darwin/programs.direnv: init ``                |