### PR TITLE
chore(flake/nixvim-flake): `927ea400` -> `8cd4c660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1709209988,
-        "narHash": "sha256-J/8dAwbrmORp5dGlHTHqxzWHaN3mYMYukNtMfeA1LWQ=",
+        "lastModified": 1709296388,
+        "narHash": "sha256-3pnoM2HOChlBqqRwE8SNbbGvAFrmRCtXyKt3byc4EAI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "927ea400087542a01f3b6946f333a59efbaf084a",
+        "rev": "8cd4c660bb32fe996d5b1110df9e6d0a3601a5a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`8cd4c660`](https://github.com/alesauce/nixvim-flake/commit/8cd4c660bb32fe996d5b1110df9e6d0a3601a5a3) | `` chore(flake/nixpkgs): 9099616b -> 1536926e `` |