### PR TITLE
chore(flake/nix-index-database): `f070c7ee` -> `93554c04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708830466,
-        "narHash": "sha256-nGKe3Y1/jkLR2eh1aRSVBtKadMBNv8kOnB52UXqRy6A=",
+        "lastModified": 1709435391,
+        "narHash": "sha256-s4itTkIVxn5lYeTzwkbAgl99atnjdZv1idI1118vdzA=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f070c7eeec3bde8c8c8baa9c02b6d3d5e114d73b",
+        "rev": "93554c04c2f1c02f4a383538e8848d511c3129e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`93554c04`](https://github.com/nix-community/nix-index-database/commit/93554c04c2f1c02f4a383538e8848d511c3129e9) | `` update packages.nix to release 2024-03-03-030835 `` |
| [`9f3299f2`](https://github.com/nix-community/nix-index-database/commit/9f3299f2e00d045242fca52c059d01019da6d0f2) | `` flake.lock: Update ``                               |