### PR TITLE
chore(flake/nixvim-flake): `8cd4c660` -> `15ada9a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1709296388,
-        "narHash": "sha256-3pnoM2HOChlBqqRwE8SNbbGvAFrmRCtXyKt3byc4EAI=",
+        "lastModified": 1710073805,
+        "narHash": "sha256-U+EBPJ4uEPQF+uQ9a4ZeupCrgAIYhGsmT1JQPrhtN2M=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8cd4c660bb32fe996d5b1110df9e6d0a3601a5a3",
+        "rev": "b6ab4c6dab202691681092bda0177881bc15e73d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`15ada9a1`](https://github.com/alesauce/nixvim-flake/commit/15ada9a161ef2c841935c1133afd9b3ffe86ee0b) | `` chore(flake/flake-parts): b253292d -> f7b3c975 `` |