### PR TITLE
chore(flake/nix-fast-build): `4376b8a3` -> `ef8f59a0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -529,11 +529,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1703607026,
-        "narHash": "sha256-Emh0BPoqlS4ntp2UJrwydXfIP4qIMF0VBB2FUE3/M/E=",
+        "lastModified": 1709911523,
+        "narHash": "sha256-XNutwbRI6h57ybeKy0yYupfngWYcfcIqE0b0LgXnyxs=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4376b8a33b217ee2f78ba3dcff01a3e464d13a46",
+        "rev": "692fe3e98f36b60c678d637235271b57910a7f80",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`ef8f59a0`](https://github.com/Mic92/nix-fast-build/commit/ef8f59a0fdec1801ddc86a8c834f5802d1947b7f) | `` Update cachix/install-nix-action action to v25 `` |
| [`48342fee`](https://github.com/Mic92/nix-fast-build/commit/48342fee0bc1515e26211896ab9d7b6b09c81598) | `` renovate: also update lockfiles ``                |
| [`aad3672d`](https://github.com/Mic92/nix-fast-build/commit/aad3672d6085cccf88dcd77848edda5dc035b73a) | `` Add renovate.json ``                              |