### PR TITLE
chore(flake/home-manager): `23ff9821` -> `47717650`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709578243,
-        "narHash": "sha256-hF96D+c2PBmAFhymMw3z8hou++lqKtZ7IzpFbYeL1/Y=",
+        "lastModified": 1709725074,
+        "narHash": "sha256-xhhvktDOTDE34KHVXpaJKg7LVGPRvLftjHO1J3FGRgU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "23ff9821bcaec12981e32049e8687f25f11e5ef3",
+        "rev": "477176502a6e099192da61984cd5be896d0b5659",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`47717650`](https://github.com/nix-community/home-manager/commit/477176502a6e099192da61984cd5be896d0b5659) | `` flake.lock: Update ``                          |
| [`1d717f58`](https://github.com/nix-community/home-manager/commit/1d717f581b7b001b2a1293277a1d3386fca5b87e) | `` gpg-agent: Fix nushell integration ``          |
| [`3c7bacf1`](https://github.com/nix-community/home-manager/commit/3c7bacf1d42e533299c5e3baf74556a0e0ac3d0e) | `` ci: remove cachix action ``                    |
| [`9daee941`](https://github.com/nix-community/home-manager/commit/9daee941ab013b057df34ebb7f1c41cafabfea95) | `` gpg: fix immutable keyfile test ``             |
| [`c386fde5`](https://github.com/nix-community/home-manager/commit/c386fde594c016865ecc98235a0454bea782ecc7) | `` bemenu: stub package in tests ``               |
| [`bdea159f`](https://github.com/nix-community/home-manager/commit/bdea159ffab9865f808b8d92fd2bef33521867b2) | `` fcitx5: fix reference to fcitx5-with-addons `` |