### PR TITLE
chore(flake/nix-index-database): `93554c04` -> `94a1e464`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709435391,
-        "narHash": "sha256-s4itTkIVxn5lYeTzwkbAgl99atnjdZv1idI1118vdzA=",
+        "lastModified": 1710120787,
+        "narHash": "sha256-tlLuB73OCOKtU2j83bQzSYFyzjJo3rjpITZE5MoofG8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "93554c04c2f1c02f4a383538e8848d511c3129e9",
+        "rev": "e76ff2df6bfd2abe06abd8e7b9f217df941c1b07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                              |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c46d85da`](https://github.com/nix-community/nix-index-database/commit/c46d85da736e6b2563cf1f284f7e054bd87b9b38) | `` readme: Mic92 -> nix-community `` |