### PR TITLE
chore(flake/home-manager): `47717650` -> `cf111d1a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709725074,
-        "narHash": "sha256-xhhvktDOTDE34KHVXpaJKg7LVGPRvLftjHO1J3FGRgU=",
+        "lastModified": 1709764752,
+        "narHash": "sha256-+lM4J4JoJeiN8V+3WSWndPHj1pJ9Jc1UMikGbXLqCTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "477176502a6e099192da61984cd5be896d0b5659",
+        "rev": "cf111d1a849ddfc38e9155be029519b0e2329615",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`cf111d1a`](https://github.com/nix-community/home-manager/commit/cf111d1a849ddfc38e9155be029519b0e2329615) | `` zsh: improve `shell{,Global}Aliases` ``           |
| [`ad9254cd`](https://github.com/nix-community/home-manager/commit/ad9254cd9af9165000ecd6ef9c23c2b8ceda01c7) | `` vdirsyncer: fix verify option type (#5096) ``     |
| [`f240015a`](https://github.com/nix-community/home-manager/commit/f240015a3a2e03370cb86a820909af14ec1ed35a) | `` gallery-dl: add package option ``                 |
| [`8d9fde0f`](https://github.com/nix-community/home-manager/commit/8d9fde0fba21425729905f795fe72c2840a20442) | `` i3/sway: remove sebtm maintainer ``               |
| [`692726d2`](https://github.com/nix-community/home-manager/commit/692726d2ad5727cf14c563d0f1d2c015c021d7a5) | `` Translate using Weblate (German) ``               |
| [`d19bf3ae`](https://github.com/nix-community/home-manager/commit/d19bf3ae21686854760cfc5e81f269ea51072563) | `` Add translation using Weblate (Vietnamese) ``     |
| [`f30d23fa`](https://github.com/nix-community/home-manager/commit/f30d23faccdeb8237168525be65f55e44811e4c1) | `` Translate using Weblate (French) ``               |
| [`572b0706`](https://github.com/nix-community/home-manager/commit/572b070627c62eee20b9f0254128890a69894fc2) | `` Add translation using Weblate (Vietnamese) ``     |
| [`c7e50657`](https://github.com/nix-community/home-manager/commit/c7e50657fb167023a79d6dd3d15be577ea97baab) | `` Translate using Weblate (Chinese (Simplified)) `` |
| [`571ac919`](https://github.com/nix-community/home-manager/commit/571ac9199c80e42c8e49b9095d5a93a58a17e770) | `` Translate using Weblate (German) ``               |
| [`ae84f4fd`](https://github.com/nix-community/home-manager/commit/ae84f4fd2c56c0766c5b12c3efda102b749aed56) | `` Translate using Weblate (Italian) ``              |
| [`40c57ce0`](https://github.com/nix-community/home-manager/commit/40c57ce052cc8ef1bf0c836b87263a43b69e1fb6) | `` programs.khal: Simplify calendar setup (#5073) `` |
| [`613384a5`](https://github.com/nix-community/home-manager/commit/613384a51119ea34af58eb5e611e7f31dd3970d6) | `` tests: include a service in integration tests ``  |
| [`950673ce`](https://github.com/nix-community/home-manager/commit/950673cec79298d9a1072499e0181849545376e2) | `` pueue: always write configuration file ``         |