### PR TITLE
chore(flake/stylix): `fcff15ac` -> `32a79692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708896938,
-        "narHash": "sha256-oMjkMjeNhDUEpKIofo9+9RdUnmmZ4h0sm+kf6XKdy6k=",
+        "lastModified": 1710193282,
+        "narHash": "sha256-cwyXYYxkp+OaUKjfth2ASZvRcvZhAMy0hjl6TSvXW1g=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fcff15ac5ffbe81f1c66e352f3167c270d79cdab",
+        "rev": "32a796929226869542b29c0031848f6dc392a3bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                 |
| --------------------------------------------------------------------------------------------- | ----------------------- |
| [`32a79692`](https://github.com/danth/stylix/commit/32a796929226869542b29c0031848f6dc392a3bd) | `` yazi: init (#229) `` |