### PR TITLE
chore(flake/darwin): `55034006` -> `d9ea313b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709771483,
-        "narHash": "sha256-Hjzu9nCknHLQvhdaRFfCEprH0o15KcaNu1QDr3J88DI=",
+        "lastModified": 1710281379,
+        "narHash": "sha256-uFo9hxt982L3nFJeweW4Gip2esiGrIQlbvEGrNTh4AY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "550340062c16d7ef8c2cc20a3d2b97bcd3c6b6f6",
+        "rev": "d9ea313bc4851670dc99c5cc979cb79750e7d670",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`c18685e7`](https://github.com/LnL7/nix-darwin/commit/c18685e7737ce942d94f15db4f2c80f53f1c11cd) | `` update README.md ``                                                       |
| [`66f85cb9`](https://github.com/LnL7/nix-darwin/commit/66f85cb9db2144fe6434caee80838cbf7cfd0176) | `` trezord: Add launchd user agent service module for configuring trezord `` |