### PR TITLE
chore(flake/home-manager): `017b12de` -> `49a266d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710164657,
-        "narHash": "sha256-l64+ZjaQAVkHDVaK0VHwtXBdjcBD6nLBD+p7IfyBp/w=",
+        "lastModified": 1710281778,
+        "narHash": "sha256-bvWr9vvBrAxb44kHM3H3cY/uQg+4pYP1BM/Nu3e/7V8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "017b12de5b899ef9b64e2c035ce257bfe95b8ae2",
+        "rev": "49a266d2ca59df8a03249550e73a54626181b65d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`49a266d2`](https://github.com/nix-community/home-manager/commit/49a266d2ca59df8a03249550e73a54626181b65d) | `` hyprland: add option for per-input device configs ``   |
| [`a500de54`](https://github.com/nix-community/home-manager/commit/a500de54b2e3067201a40cefa5f210f719423ddf) | `` eza: replace enableAliases with integration options `` |