### PR TITLE
chore(flake/stylix): `32a79692` -> `1d51ce1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -793,11 +793,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710193282,
-        "narHash": "sha256-cwyXYYxkp+OaUKjfth2ASZvRcvZhAMy0hjl6TSvXW1g=",
+        "lastModified": 1710774666,
+        "narHash": "sha256-ZkaYqxHcSBlSpehz7PTO8KP47YoLuUU4/4RfDm3VR1Y=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "32a796929226869542b29c0031848f6dc392a3bd",
+        "rev": "2221c7d61b2e10b17df6c6795b4678fb59a0a92a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`1d51ce1d`](https://github.com/danth/stylix/commit/1d51ce1de46ea0ee8738831a1d48b7824b0200b9) | `` ci: also build on master and release branches (#281) `` |
| [`1adbaaf4`](https://github.com/danth/stylix/commit/1adbaaf45c166a79c9f089d2224cb27fb25b6bbf) | `` ci: checkout via Nix rather than action (#280) ``       |
| [`d0b264e2`](https://github.com/danth/stylix/commit/d0b264e216a1e80c16415af635c5b07b2d6606a0) | `` ci: use Magic Nix Cache (#279) ``                       |