### PR TITLE
chore(flake/home-manager): `49a266d2` -> `1b74e367`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710281778,
-        "narHash": "sha256-bvWr9vvBrAxb44kHM3H3cY/uQg+4pYP1BM/Nu3e/7V8=",
+        "lastModified": 1710329147,
+        "narHash": "sha256-ExKfXL6PURo5VJ9bNPkOxCNBlRDoPILeCfUrMyJ20i0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "49a266d2ca59df8a03249550e73a54626181b65d",
+        "rev": "1b74e3679e90fe7ad142bb5f66610a0d92ac0165",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`1b74e367`](https://github.com/nix-community/home-manager/commit/1b74e3679e90fe7ad142bb5f66610a0d92ac0165) | `` docs: update home-manager-option-search URL `` |
| [`dab2437c`](https://github.com/nix-community/home-manager/commit/dab2437ca0aa0b91bbb0ea72a9f10ee494833593) | `` flake.lock: Update ``                          |