### PR TITLE
chore(flake/nixpkgs): `3030f185` -> `0ad13a68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -564,11 +564,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "lastModified": 1710272261,
+        "narHash": "sha256-g0bDwXFmTE7uGDOs9HcJsfLFhH7fOsASbAuOzDC+fhQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "rev": "0ad13a6833440b8e238947e47bea7f11071dc2b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`387d513d`](https://github.com/NixOS/nixpkgs/commit/387d513df5a0337cdc222c3b77b6fbe7a7949b3f) | `` protolint: 0.47.5 -> 0.48.0 ``                                            |
| [`7ce6d540`](https://github.com/NixOS/nixpkgs/commit/7ce6d540f0325b1ca8226b62d9372047d74fa229) | `` kde/plasma: 6.0.1 -> 6.0.2 ``                                             |
| [`96e439e0`](https://github.com/NixOS/nixpkgs/commit/96e439e0291fa37103ef6c5ad91739a969fbae0d) | `` maintainers/scripts/kde/generate-sources: allow overriding sources URL `` |
| [`10a8077c`](https://github.com/NixOS/nixpkgs/commit/10a8077c2ce4d03a19da2c641438a20c7262be2b) | `` vultr-cli: 3.0.1 -> 3.0.2 ``                                              |
| [`752c3131`](https://github.com/NixOS/nixpkgs/commit/752c313110453dac267ef2ab3a3785e0f723703d) | `` dovecot_fts_xapian: 1.7.6 -> 1.7.8 ``                                     |
| [`d3e30a44`](https://github.com/NixOS/nixpkgs/commit/d3e30a442b36e808aafcbdea06942057d12d2fc5) | `` nixos/incus: fix systemd service path ``                                  |
| [`9b0b599b`](https://github.com/NixOS/nixpkgs/commit/9b0b599be582008d1ed7b5d931da10f5e8c148c2) | `` llvmPackages_git: cleanup ``                                              |
| [`ae14c75b`](https://github.com/NixOS/nixpkgs/commit/ae14c75b38d30e93be1953c0f715278e556ed5df) | `` extism-cli: 1.1.0 -> 1.2.0 ``                                             |
| [`58eb3089`](https://github.com/NixOS/nixpkgs/commit/58eb3089561b82ed4ab89c4f88d165cf76e038ae) | `` civo: 1.0.75 -> 1.0.76 ``                                                 |
| [`7dfe004f`](https://github.com/NixOS/nixpkgs/commit/7dfe004fa4de3339c3fba9b5e84a1d50c7826e58) | `` atuin: 18.0.2 -> 18.1.0 ``                                                |
| [`256dab40`](https://github.com/NixOS/nixpkgs/commit/256dab4070abe5d378402646adda5b8996572713) | `` spicetify-cli: 2.33.2 -> 2.34.0 ``                                        |
| [`deb253e0`](https://github.com/NixOS/nixpkgs/commit/deb253e060ff2c4b348bf66bd1b6a88b93e8c09c) | `` twilio-cli: 5.19.0 -> 5.19.1 ``                                           |
| [`51d879e6`](https://github.com/NixOS/nixpkgs/commit/51d879e6533624bd124a60adf8aa3c304a7f9523) | `` virtualbox: pin jdk to openjdk17 ``                                       |
| [`dc249b76`](https://github.com/NixOS/nixpkgs/commit/dc249b76849f19562cf5528d53716a155c812e20) | `` python312Packages.twilio: 9.0.0 -> 9.0.1 ``                               |
| [`3c3e76ef`](https://github.com/NixOS/nixpkgs/commit/3c3e76ef7a4184620313f429ddf0d38eb7f259ec) | `` python312Packages.rich-click: 1.7.3 -> 1.7.4 ``                           |
| [`0f1957af`](https://github.com/NixOS/nixpkgs/commit/0f1957af31ac29d469bc8e931f8b336914fbbf8a) | `` python312Packages.pytedee-async: 0.2.15 -> 0.2.16 ``                      |
| [`26ab1be2`](https://github.com/NixOS/nixpkgs/commit/26ab1be2a9de303a7257c20e958fb67ee08c8e8d) | `` python312Packages.oci: 2.124.0 -> 2.124.1 ``                              |
| [`53c1eae2`](https://github.com/NixOS/nixpkgs/commit/53c1eae20eb974ef9e11dd07d98bea840d534e49) | `` Revert "usbredir: 0.13.0 -> 0.14.0" ``                                    |
| [`6b18da38`](https://github.com/NixOS/nixpkgs/commit/6b18da3892bb049e99e84b072079311f3c23ba44) | `` qownnotes: 24.3.0 -> 24.3.1 ``                                            |
| [`636f6d37`](https://github.com/NixOS/nixpkgs/commit/636f6d379592650b5fbb6c500d6e76c5c8265cf8) | `` ddns-go: 6.2.0 -> 6.2.1 ``                                                |
| [`f31be140`](https://github.com/NixOS/nixpkgs/commit/f31be1409e7d9932e52179e1c2f6a4c4b8ffbe53) | `` teams-for-linux: add libnotify to LD_LIBRARY_PATH ``                      |
| [`9c544864`](https://github.com/NixOS/nixpkgs/commit/9c544864f0cbe13938772bce2ae512db76155b90) | `` nomad_1_7: 1.7.5 -> 1.7.6 ``                                              |
| [`77c6cf9e`](https://github.com/NixOS/nixpkgs/commit/77c6cf9ec2b5eba2987a23db37ee914f11de2814) | `` tectonic: --inherit-argv0 in the wrapper ``                               |
| [`7f40c2f3`](https://github.com/NixOS/nixpkgs/commit/7f40c2f342cb16212ec1a095a72ea95052ec5d26) | `` libcomps: 0.1.20 -> 0.1.21 ``                                             |
| [`c77ba517`](https://github.com/NixOS/nixpkgs/commit/c77ba517f406ae169a01d0f5c40adb79f6fe788a) | `` gci: 0.13.0 -> 0.13.1 ``                                                  |
| [`d72169c4`](https://github.com/NixOS/nixpkgs/commit/d72169c47e1b406d0205a0f78d397f2e9cf3e802) | `` mpvScripts.visualizer: unstable-2023-08-13 -> unstable-2024-03-10 ``      |
| [`f0f0e774`](https://github.com/NixOS/nixpkgs/commit/f0f0e7743397e30f6807ca788ccaa1e55b726337) | `` cnspec: 10.6.1 -> 10.7.0 ``                                               |
| [`77536af4`](https://github.com/NixOS/nixpkgs/commit/77536af43b4402a48b4720a6cfda90a559349a4e) | `` nixos/iso-image: extremely cursed performance optimization for Hydra ``   |
| [`1c38133c`](https://github.com/NixOS/nixpkgs/commit/1c38133c85f4b7bb74839c2716905900470d24ea) | `` container2wasm: 0.6.2 -> 0.6.3 ``                                         |
| [`2257d674`](https://github.com/NixOS/nixpkgs/commit/2257d674cef69ab4e093d9b2c1218248abd96e30) | `` astyle: 3.4.12 -> 3.4.13 ``                                               |
| [`274496de`](https://github.com/NixOS/nixpkgs/commit/274496de245bc15d26f07ecf419cb706547ba9ec) | `` intel-gmmlib: 22.3.17 -> 22.3.18 ``                                       |
| [`1075c4a9`](https://github.com/NixOS/nixpkgs/commit/1075c4a98d2cf56415accc366d9c8d6db3b01822) | `` wlroots_0_17: 0.17.1 -> 0.17.2 ``                                         |
| [`10b4c1a1`](https://github.com/NixOS/nixpkgs/commit/10b4c1a1de96dc34fb3a4f373faa6e847f4c5df0) | `` cargo-leptos: 0.2.15 -> 0.2.16 ``                                         |
| [`7da4066c`](https://github.com/NixOS/nixpkgs/commit/7da4066cce5115efbe391daded3cf658e9e15c72) | `` pulumi-bin: 3.108.1 -> 3.109.0 ``                                         |
| [`3cdaeaa3`](https://github.com/NixOS/nixpkgs/commit/3cdaeaa3980dc7d22646009ef6a4475d156c86b3) | `` linux-firmware: 20240220 -> 20240312 ``                                   |
| [`370be250`](https://github.com/NixOS/nixpkgs/commit/370be25044a28951a1155e8a8c38fa2555d37ab5) | `` helmfile: 0.161.0 -> 0.162.0 ``                                           |
| [`a044e3f4`](https://github.com/NixOS/nixpkgs/commit/a044e3f4c9b0e8d5c28baa3636273035faf719e4) | `` cni-plugins: 1.4.0 -> 1.4.1 ``                                            |
| [`3b2b0ac6`](https://github.com/NixOS/nixpkgs/commit/3b2b0ac604b394b1a51995acd7e3638005da5d09) | `` commitizen: 3.18.0 -> 3.18.3 ``                                           |
| [`4702e9d9`](https://github.com/NixOS/nixpkgs/commit/4702e9d9d130e3253f8c3d7dc86211c58416d46b) | `` syncthingtray: fix darwin build ``                                        |
| [`778180f8`](https://github.com/NixOS/nixpkgs/commit/778180f8669d638df9d136333d534a3a4c231a3e) | `` gthumb: 3.12.5 -> 3.12.6 ``                                               |
| [`033ae016`](https://github.com/NixOS/nixpkgs/commit/033ae0168a11fe8a009e417a9d2770bde48c559f) | `` compcert: add riscv-linux targets ``                                      |
| [`6ee37e45`](https://github.com/NixOS/nixpkgs/commit/6ee37e45f31065f864c672ad27b100dcdbc52b8c) | `` cffconvert: init at 2.0.0-unstable-2024-02-12 ``                          |
| [`adbf14db`](https://github.com/NixOS/nixpkgs/commit/adbf14db5cd5ff299522a9d16d0043955557e622) | `` minio-client: 2024-03-07T00-31-49Z -> 2024-03-09T06-43-06Z ``             |
| [`4d3a5ddb`](https://github.com/NixOS/nixpkgs/commit/4d3a5ddbac54f1d26a56e8c974bba83c2f6aaf8b) | `` python311Packages.types-requests: 2.31.0.20240310 -> 2.31.0.20240311 ``   |
| [`b07cdeb1`](https://github.com/NixOS/nixpkgs/commit/b07cdeb1b34503576ec4aba981740466d19cb8e5) | `` nixos/plasma6: move out of x11 ``                                         |
| [`02424c9b`](https://github.com/NixOS/nixpkgs/commit/02424c9bc8fdd99283a24cb27e587f18aaae0e1f) | `` openssl: Add configureScript entry for powerpc64-linux ``                 |
| [`71b1855a`](https://github.com/NixOS/nixpkgs/commit/71b1855a2c7de6c53bee780f0a41b2945586626f) | `` spotify-tui: remove ``                                                    |
| [`209e93bc`](https://github.com/NixOS/nixpkgs/commit/209e93bcfb2861caf43bc90434778ae7e182da09) | `` python311Packages.pylsp-rope: 0.1.11 -> 0.1.15 ``                         |
| [`1e1f9319`](https://github.com/NixOS/nixpkgs/commit/1e1f93193170adc810ff63f26e1a1d0a31d0db9f) | `` maintainers: add hsjobeki to nixdoc ``                                    |
| [`33aab00c`](https://github.com/NixOS/nixpkgs/commit/33aab00c279bf966d6ed049472e1870a2553eeeb) | `` bemenu: 0.6.19 -> 0.6.20 ``                                               |
| [`413e3a65`](https://github.com/NixOS/nixpkgs/commit/413e3a65020fb575f8265eda56df751eea432bdb) | `` ft2-clone: 1.76 -> 1.77.1 ``                                              |
| [`1f5f9e74`](https://github.com/NixOS/nixpkgs/commit/1f5f9e74798c8b1743cd464e45f6746ed2a6fa7c) | `` goxel: use libpng instead of libpng12 ``                                  |
| [`503f9982`](https://github.com/NixOS/nixpkgs/commit/503f9982595dd332db4e871d47fb89e79b36eb68) | `` dracula-theme: unstable-2024-03-02 -> unstable-2024-03-10 ``              |
| [`dbdec363`](https://github.com/NixOS/nixpkgs/commit/dbdec363d3b77c170eb6b8bd777e5cffe7e14e4c) | `` tigerbeetle: 0.14.183 -> 0.14.184 ``                                      |
| [`d3a0dea2`](https://github.com/NixOS/nixpkgs/commit/d3a0dea280495d6583516ffdad977dc8619e8836) | `` teams-for-linux: 1.4.13 -> 1.4.14 ``                                      |
| [`42f41262`](https://github.com/NixOS/nixpkgs/commit/42f41262b3417aaeb405ec2d213b8c4ed4e35002) | `` python311Packages.clarifai-grpc: 10.2.0 -> 10.2.1 ``                      |
| [`edb80383`](https://github.com/NixOS/nixpkgs/commit/edb803836d70e25dd5d6f86b4b5a140a36540c65) | `` git-cola: 4.5.0 -> 4.6.1 ``                                               |
| [`dfa578dd`](https://github.com/NixOS/nixpkgs/commit/dfa578dd22011780fde92e79ab0ce67b5d059c61) | `` git-cola: format file ``                                                  |
| [`c66736f8`](https://github.com/NixOS/nixpkgs/commit/c66736f8e0aa8410e02ccdb6a11fb72161fc13cc) | `` eigenmath: unstable-2024-03-06 -> unstable-2024-03-11 ``                  |
| [`f9546586`](https://github.com/NixOS/nixpkgs/commit/f9546586e7a3b0e3a9db80f9884efbb8c230ad26) | `` virtualboxGuestAdditions: fix location of vboxclient.desktop ``           |
| [`cf0557a0`](https://github.com/NixOS/nixpkgs/commit/cf0557a07c9259b608c768b9d3fd46c25068fe90) | `` rwpspread: 0.2.1 -> 0.2.3 ``                                              |
| [`1f859352`](https://github.com/NixOS/nixpkgs/commit/1f8593522ad1010d0c2cb04cc429566b6345c43c) | `` yamlscript: 0.1.40 -> 0.1.41 ``                                           |
| [`7d926d1f`](https://github.com/NixOS/nixpkgs/commit/7d926d1f73ed14f0a174675f6227f6c4b474dee1) | `` ligo: 1.0.0 → 1.4.0 ``                                                    |
| [`9a9a7552`](https://github.com/NixOS/nixpkgs/commit/9a9a7552431c4f1a3b2eee9398641babf7c30d0e) | `` telegraf: 1.29.5 -> 1.30.0 ``                                             |
| [`ac39a3f2`](https://github.com/NixOS/nixpkgs/commit/ac39a3f2f596d5582d549329ab749d1f97e202e9) | `` yor: 0.1.190 -> 0.1.191 ``                                                |
| [`aa688003`](https://github.com/NixOS/nixpkgs/commit/aa688003bb8e19c90430b990b5184d78cd6a3816) | `` cargo-tally: 1.0.40 -> 1.0.41 ``                                          |
| [`6e72ac6e`](https://github.com/NixOS/nixpkgs/commit/6e72ac6e54d890e4e25116fece328f0b336c3416) | `` keepassxc: 2.7.6 -> 2.7.7 ``                                              |
| [`0521702b`](https://github.com/NixOS/nixpkgs/commit/0521702b1da8c2da6d6989fb537f36aef786633a) | `` coq_8_19: 8.19.0 → 8.19.1 ``                                              |
| [`d2670732`](https://github.com/NixOS/nixpkgs/commit/d267073269cd7447bfe794641ac95ee0b0317b23) | `` terraform-ls: 0.32.7 -> 0.32.8 ``                                         |
| [`ac050096`](https://github.com/NixOS/nixpkgs/commit/ac050096a0d847c690be84b51c41f7bbfa7bbb06) | `` framac: 28.0 -> 28.1 ``                                                   |
| [`b9c72484`](https://github.com/NixOS/nixpkgs/commit/b9c72484a7570f0314d966171bc526c0121eb829) | `` terragrunt: 0.55.12 -> 0.55.13 ``                                         |
| [`43092bda`](https://github.com/NixOS/nixpkgs/commit/43092bdad4f5dfa7c7c3dab2ef182c8d4465e528) | `` ocamlPackages.camlpdf: 2.6 → 2.7 ``                                       |
| [`df7849ae`](https://github.com/NixOS/nixpkgs/commit/df7849aeb5c489b5f00bb859f6ed1866eba97b7f) | `` honk: 1.2.3 -> 1.3.1 ``                                                   |
| [`e75077f8`](https://github.com/NixOS/nixpkgs/commit/e75077f84e25823ff0a7862e31364505e7a6eeda) | `` python311Packages.types-colorama: 0.4.15.20240310 -> 0.4.15.20240311 ``   |
| [`52ff079f`](https://github.com/NixOS/nixpkgs/commit/52ff079f5133935a5adb2df45fe2bfac23362565) | `` sudo-font: 1.1 -> 1.2 ``                                                  |
| [`fa11ef50`](https://github.com/NixOS/nixpkgs/commit/fa11ef50f39b5f08e1ddbcf6c16756f34376acc3) | `` wit-bindgen: 0.21.0 -> 0.22.0 ``                                          |
| [`a89130bd`](https://github.com/NixOS/nixpkgs/commit/a89130bd5a3ef6b1169ca512aa87787f688f72ec) | `` nixdoc: 3.0.1 -> 3.0.2 ``                                                 |
| [`ceff767b`](https://github.com/NixOS/nixpkgs/commit/ceff767ba6d071f7ac36d1fdd1155330310b9223) | `` python312Packages.vallox-websocket-api: 5.1.0 -> 5.1.1 ``                 |
| [`af67cfa8`](https://github.com/NixOS/nixpkgs/commit/af67cfa87bed7fd62812aa888cd134412c9e6d75) | `` ollama: add nixos test to `passthru.tests` ``                             |
| [`efed30f9`](https://github.com/NixOS/nixpkgs/commit/efed30f903199e90be4f280c65f2f410b55835df) | `` nixos/ollama: add test for the ollama service ``                          |
| [`aed1ab5b`](https://github.com/NixOS/nixpkgs/commit/aed1ab5b88eea49f7f44c340b557dbe7e2b0ed37) | `` nanoflann: 1.5.4 -> 1.5.5 ``                                              |
| [`c12820e7`](https://github.com/NixOS/nixpkgs/commit/c12820e7a05ef6ec379e31c6e90c278d702a16f9) | `` unrar-free: 0.2.0 -> 0.3.0 ``                                             |
| [`b8561fca`](https://github.com/NixOS/nixpkgs/commit/b8561fca9c2a73bbba97dc1f5ec1221c94baac11) | `` codux: 15.21.0 -> 15.22.0 ``                                              |
| [`c68824af`](https://github.com/NixOS/nixpkgs/commit/c68824af6f7585ee48bed27ce497753c01624fc6) | `` bruno: 1.6.1 -> 1.8.0 ``                                                  |
| [`701fcd79`](https://github.com/NixOS/nixpkgs/commit/701fcd7982b6f7b6341598128f83c2c8f3444ef2) | `` nixos/incus: add openvswitch support ``                                   |
| [`cdbf1312`](https://github.com/NixOS/nixpkgs/commit/cdbf131239eda7ac390a5ae20cf5af5fbc5fc66c) | `` clash-verge-rev: 1.5.4 -> 1.5.7 ``                                        |
| [`30a459c3`](https://github.com/NixOS/nixpkgs/commit/30a459c361330e80ab4596a5b334b3ab56229780) | `` croc: 9.6.13 -> 9.6.14 ``                                                 |
| [`20bf3f75`](https://github.com/NixOS/nixpkgs/commit/20bf3f75d26880d4925898f32c3b9c0d2962d562) | `` earthly: 0.8.4 -> 0.8.5 ``                                                |
| [`9b20d9d1`](https://github.com/NixOS/nixpkgs/commit/9b20d9d122e9b46a0a0728d93c580b72ddf548be) | `` qovery-cli: 0.84.1 -> 0.84.3 ``                                           |
| [`164fd67a`](https://github.com/NixOS/nixpkgs/commit/164fd67abe254a719b4d2daf9267b0c2b6c6d4d0) | `` anytype: 0.38.0 -> 0.39.0 ``                                              |