### PR TITLE
chore(flake/home-manager): `1b74e367` -> `1ab3cec3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710329147,
-        "narHash": "sha256-ExKfXL6PURo5VJ9bNPkOxCNBlRDoPILeCfUrMyJ20i0=",
+        "lastModified": 1710820906,
+        "narHash": "sha256-2bNMraoRB4pdw/HtxgYTFeMhEekBZeQ53/a8xkqpbZc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b74e3679e90fe7ad142bb5f66610a0d92ac0165",
+        "rev": "022464438a85450abb23d93b91aa82e0addd71fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`1ab3cec3`](https://github.com/nix-community/home-manager/commit/1ab3cec3a1bbb065b2d52b913d1431366028d5b5) | `` rbw: simplify 'pinentry' type ``                    |
| [`01e4a514`](https://github.com/nix-community/home-manager/commit/01e4a5143e92251272850a8e0fbb4518bd099087) | `` gpg-agent: migrate to 'pinentryPackage' ``          |
| [`2f0db7d4`](https://github.com/nix-community/home-manager/commit/2f0db7d418e781354d8a3c50e611e3b1cd413087) | `` joplin-desktop: fix maintainer field ``             |
| [`383296ff`](https://github.com/nix-community/home-manager/commit/383296ffa45b539c28bf79ec2a272f652838ddd1) | `` joplin-desktop: add module ``                       |
| [`a82cdd28`](https://github.com/nix-community/home-manager/commit/a82cdd288e3570ac52cffe0abaf28fac7d967b68) | `` offlineimap: disable starttls if tls is disabled `` |
| [`0906e8df`](https://github.com/nix-community/home-manager/commit/0906e8dfe7a4a530799681be4be8ac5b48fddc0b) | `` eza: use `mkDefault` for aliases ``                 |
| [`31abb4f6`](https://github.com/nix-community/home-manager/commit/31abb4f6bc540dfa82562e81312cfdc77770f001) | `` docs: fix broken link ``                            |