### PR TITLE
chore(flake/nixvim-flake): `8cb2d496` -> `fff62c0b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1710333211,
-        "narHash": "sha256-VNFS5kWQo9eN8Hp4J00f1uRCBha7F1bR/GWX94YfqkQ=",
+        "lastModified": 1710505966,
+        "narHash": "sha256-ic6Kvx9FwiSlvRAw0GjbDUP+hBvJHqdDUbvQBmabRGE=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8cb2d49688e80a072272c286bf6badf0adbab3df",
+        "rev": "fff62c0b261d3f9da19b1d58d181ec9ec11e81e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`fff62c0b`](https://github.com/alesauce/nixvim-flake/commit/fff62c0b261d3f9da19b1d58d181ec9ec11e81e9) | `` chore(flake/nixpkgs): 0ad13a68 -> d691274a `` |