### PR TITLE
chore(flake/pre-commit-hooks): `e8dc1b4f` -> `c75cea79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -745,11 +745,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1710843117,
-        "narHash": "sha256-b6iKQeHegzpc697rxTPA3bpwGN3m50eLCgdQOmceFuE=",
+        "lastModified": 1710897503,
+        "narHash": "sha256-3tgm+kofe6YWIkkFn9DAcyPblWD6HQyw5rdd5EEAZZU=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "e8dc1b4fe80c6fcededde7700e6a23bcdf7f3347",
+        "rev": "c75cea79141996c7da9e31187c238ad04de5e88f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                             |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`21307b20`](https://github.com/cachix/pre-commit-hooks.nix/commit/21307b20b0f24ae8738e1771ac0b4a026756b85c) | `` Rename deprecated flake outputs ``               |
| [`cbb3524c`](https://github.com/cachix/pre-commit-hooks.nix/commit/cbb3524cd65a4e71165c77842ac1c5827321cf64) | `` Remove treefmt package in the all-hooks check `` |
| [`8a980910`](https://github.com/cachix/pre-commit-hooks.nix/commit/8a9809104fbb6b8c829b95852fdce87a1f5c183a) | `` Fix treefmt flake-parts integration ``           |
| [`d43e4853`](https://github.com/cachix/pre-commit-hooks.nix/commit/d43e4853f578739ac2264eadcd18faa5aeb41889) | `` rustfmt: Support multi package projects ``       |