### PR TITLE
chore(flake/home-manager): `02246443` -> `6ebe7be2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -502,11 +502,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710820906,
-        "narHash": "sha256-2bNMraoRB4pdw/HtxgYTFeMhEekBZeQ53/a8xkqpbZc=",
+        "lastModified": 1714981474,
+        "narHash": "sha256-b3/U21CJjCjJKmA9WqUbZGZgCvospO3ArOUTgJugkOY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "022464438a85450abb23d93b91aa82e0addd71fb",
+        "rev": "6ebe7be2e67be7b9b54d61ce5704f6fb466c536f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`6ebe7be2`](https://github.com/nix-community/home-manager/commit/6ebe7be2e67be7b9b54d61ce5704f6fb466c536f) | `` gnome-shell: add module ``                                       |
| [`2b87a111`](https://github.com/nix-community/home-manager/commit/2b87a11125f988a9f67ee63eeaa3682bc841d9b5) | `` git: add realName inside From field ``                           |
| [`3dfe05aa`](https://github.com/nix-community/home-manager/commit/3dfe05aa9b5646995ace887931fa60269a039777) | `` wlsunset: update options ``                                      |
| [`fdaaf543`](https://github.com/nix-community/home-manager/commit/fdaaf543bad047639ef0b356ea2e6caec2f1215c) | `` hypridle: add module ``                                          |
| [`f69bf670`](https://github.com/nix-community/home-manager/commit/f69bf670d29d3921e00cc626d174654769d743c6) | `` cliphist: add extraOptions option ``                             |
| [`2a44f4d0`](https://github.com/nix-community/home-manager/commit/2a44f4d09f891d8a9d72b9a7331fa8d94b066119) | `` flake.lock: Update ``                                            |
| [`e0825ea2`](https://github.com/nix-community/home-manager/commit/e0825ea2112d09d9f0680833cd716f6aee3b973f) | `` swaync: fix style path ``                                        |
| [`9036fe9e`](https://github.com/nix-community/home-manager/commit/9036fe9ef8e15a819fa76f47a8b1f287903fb848) | `` flake.lock: Update ``                                            |
| [`67d0e7db`](https://github.com/nix-community/home-manager/commit/67d0e7db8827abc3634c02de62f3e651a0c92d8c) | `` Translate using Weblate (Persian) ``                             |
| [`6d3b6dc9`](https://github.com/nix-community/home-manager/commit/6d3b6dc9222c12b951169becdf4b0592ee9576ef) | `` conky: add module ``                                             |
| [`28ef93bb`](https://github.com/nix-community/home-manager/commit/28ef93bb8e5208ae4230f59efe7b96e115e5ddd2) | `` maintainers: add kaleocheng ``                                   |
| [`3c0df2a7`](https://github.com/nix-community/home-manager/commit/3c0df2a7e43b432b739d8e9d289dcb362a44b308) | `` freetube: add module ``                                          |
| [`f8e6694e`](https://github.com/nix-community/home-manager/commit/f8e6694edabe4aaa7a85aac47b43ea5d978b116d) | `` files: make collision error message more helpful ``              |
| [`56326598`](https://github.com/nix-community/home-manager/commit/563265988637c27ba3abe39acb9be3ba2cb35a29) | `` swaync: add module ``                                            |
| [`0125041f`](https://github.com/nix-community/home-manager/commit/0125041fc9ca3127fe95cf53f15c49c482ebaf70) | `` maintainers: add abayomi185 as maintainer ``                     |
| [`4fe1f064`](https://github.com/nix-community/home-manager/commit/4fe1f064bd1a37754266eb4c190eac784ca4aaa9) | `` hyprland: use lib.generators.toHyprconf ``                       |
| [`9fdd301a`](https://github.com/nix-community/home-manager/commit/9fdd301a5e4d8cf4d4cf3f990e799000a54a3737) | `` lib/generators: toHyprconf init ``                               |
| [`1a91cb7c`](https://github.com/nix-community/home-manager/commit/1a91cb7cdbcf6b18c27bbead57241baf279d4513) | `` neomutt: allow binds to override vimKeys ``                      |
| [`7ec0ae18`](https://github.com/nix-community/home-manager/commit/7ec0ae18cda5e3aae80996d35f6d0ebd418f1ac8) | `` Translate using Weblate (Japanese) ``                            |
| [`ba97ffcf`](https://github.com/nix-community/home-manager/commit/ba97ffcfb2bd3ef026bb0a14d8808e9926f57fd7) | `` Translate using Weblate (French) ``                              |
| [`08d3cbfe`](https://github.com/nix-community/home-manager/commit/08d3cbfe4d400dad74e54815127fd67c76608a55) | `` firefox: update extensions option description ``                 |
| [`b8d81ef1`](https://github.com/nix-community/home-manager/commit/b8d81ef15ed8ec4c72ffc610279d39aa0c4ccbf0) | `` mpv: add extraInput option ``                                    |
| [`2af7c78b`](https://github.com/nix-community/home-manager/commit/2af7c78b7bb9cf18406a193eba13ef9f99388f49) | `` thefuck: add nushell integration ``                              |
| [`9fe79591`](https://github.com/nix-community/home-manager/commit/9fe79591c1005ce6f93084ae7f7dab0a2891440d) | `` direnv: add nix-direnv to lib instead of sourcing ``             |
| [`c002bc08`](https://github.com/nix-community/home-manager/commit/c002bc08c8ea6c87198f3024e8bfd6fdb1c90c9e) | `` cliphist: support images in clipboard history ``                 |
| [`02002a08`](https://github.com/nix-community/home-manager/commit/02002a08b489b43e3ac1400609a9bf1b7c08e384) | `` flake.lock: Update ``                                            |
| [`d1980931`](https://github.com/nix-community/home-manager/commit/d1980931de8252b6ac1104b7191fd68bbbe3a291) | `` psd: add module ``                                               |
| [`c1609d58`](https://github.com/nix-community/home-manager/commit/c1609d584a6b5e9e6a02010f51bd368cb4782f8e) | `` xdg-portal: improve description of `enable` option ``            |
| [`26e72d85`](https://github.com/nix-community/home-manager/commit/26e72d85e6fbda36bf2266f1447215501ec376fd) | `` home-manager: set module class to "homeManager" ``               |
| [`0c5704ec`](https://github.com/nix-community/home-manager/commit/0c5704eceefcb7bb238a958f532a86e3b59d76db) | `` home-manager: make newsReadIdsFile more reliable ``              |
| [`6864ca2d`](https://github.com/nix-community/home-manager/commit/6864ca2d2657d57a041110dcaf8be0c4b71346c0) | `` Add translation using Weblate (Icelandic) ``                     |
| [`3ebcff8d`](https://github.com/nix-community/home-manager/commit/3ebcff8d1219c9e0fb3c880ef7959feca7ea2c4a) | `` Translate using Weblate (Icelandic) ``                           |
| [`4c157f84`](https://github.com/nix-community/home-manager/commit/4c157f84e8fbd6a0fd1688b458c6ce04d047a165) | `` flake.lock: Update ``                                            |
| [`2f072c12`](https://github.com/nix-community/home-manager/commit/2f072c127c041eec36621b8e38a531fe0fe07961) | `` zsh: use correct autosuggestion color variable (#5320) ``        |
| [`bfa7c064`](https://github.com/nix-community/home-manager/commit/bfa7c06436771e3a0c666ccc6ee01e815d4c33aa) | `` swayosd: add custom style option ``                              |
| [`33a20182`](https://github.com/nix-community/home-manager/commit/33a20182e3164f451b6a4ac2ecadcab5c2c36703) | `` home-manager: improve session variables comment ``               |
| [`67de98ae`](https://github.com/nix-community/home-manager/commit/67de98ae6eed5ad6f91b1142356d71a87ba97f21) | `` tealdeer: documentation typo ``                                  |
| [`e866aae5`](https://github.com/nix-community/home-manager/commit/e866aae5bbbcfe6798ca05d3004a4e62f1828954) | `` amberol: add module ``                                           |
| [`1451d286`](https://github.com/nix-community/home-manager/commit/1451d2866d9ef3739c20f964c9c8bd6db39cc373) | `` foot: unset PATH in server's systemd unit file ``                |
| [`e2e7ea9b`](https://github.com/nix-community/home-manager/commit/e2e7ea9b8f3de1e6a09f4fc512eae75f6e413a10) | `` kconfig: fix missing quoting ``                                  |
| [`2ad154bd`](https://github.com/nix-community/home-manager/commit/2ad154bd1be2441ac8c624704587734dddb9f41a) | `` Translate using Weblate (Swedish) ``                             |
| [`46833c31`](https://github.com/nix-community/home-manager/commit/46833c3115e8858370880d892748f0927d8193c3) | `` bat: allow overriding package (#5301) ``                         |
| [`670d9ecc`](https://github.com/nix-community/home-manager/commit/670d9ecc3e46a6e3265c203c2d136031a3d3548e) | `` poetry: add module ``                                            |
| [`2846d523`](https://github.com/nix-community/home-manager/commit/2846d5230a3c3923618eabb367deaf8885df580f) | `` joplin-desktop: allow undefined options ``                       |
| [`ad83c154`](https://github.com/nix-community/home-manager/commit/ad83c154bdfedad9807e86dd0633729ea3b116c5) | `` qt: fix `qt.platformTheme = "gtk3"` ``                           |
| [`147b5a5e`](https://github.com/nix-community/home-manager/commit/147b5a5e1c04e1f27e30b6df720966422fb4bc09) | `` qt: fix platform theme package install ``                        |
| [`4cec20db`](https://github.com/nix-community/home-manager/commit/4cec20dbf5c0a716115745ae32531e34816ecbbe) | `` flake.lock: Update ``                                            |
| [`057117a4`](https://github.com/nix-community/home-manager/commit/057117a401a34259c9615ce62218aea7afdee4d3) | `` kdeconnect: fix "tray.target" requires ``                        |
| [`a2040822`](https://github.com/nix-community/home-manager/commit/a20408227466032a16e73893b09a67092258cf67) | `` firefox: fix test ``                                             |
| [`3a435342`](https://github.com/nix-community/home-manager/commit/3a435342e2e5e2bff1d3331c2bd9e70f25693ea2) | `` sway: check config file validity ``                              |
| [`95888b15`](https://github.com/nix-community/home-manager/commit/95888b153c24c36971c4b4b66beecf32593064fb) | `` sway: writeText -> writeTextFile ``                              |
| [`7c61e400`](https://github.com/nix-community/home-manager/commit/7c61e400a99f33cdff3118c1e4032bcb049e1a30) | `` Translate using Weblate (Turkish) ``                             |
| [`991f6faf`](https://github.com/nix-community/home-manager/commit/991f6fafce729e6d7d64107a66e445114194b778) | `` Translate using Weblate (Portuguese) ``                          |
| [`5682ccdc`](https://github.com/nix-community/home-manager/commit/5682ccdcaf72aef74be97e4b683545a9de27c386) | `` Translate using Weblate (Spanish) ``                             |
| [`938357cb`](https://github.com/nix-community/home-manager/commit/938357cb234e85da37109df2cdd9cc59ab9c1cc0) | `` hyprland: remove enableNvidiaPatches option ``                   |
| [`6a171bfd`](https://github.com/nix-community/home-manager/commit/6a171bfd84ee9b3df83f6eb76dab042219978439) | `` kconfig: add module ``                                           |
| [`1f305c36`](https://github.com/nix-community/home-manager/commit/1f305c363ecd7c6505f03fc7baba15505f3aa630) | `` remmina: add module ``                                           |
| [`31c77dcc`](https://github.com/nix-community/home-manager/commit/31c77dcc2e4b6b9f73df0e7eaa89536f175954e8) | `` sway: systemd customization ``                                   |
| [`068dd4ae`](https://github.com/nix-community/home-manager/commit/068dd4ae292b5bf64bda18a48bcd80f39dd76257) | `` alacritty: cleanup after 0.13 merge in nixpkgs ``                |
| [`7ca7025c`](https://github.com/nix-community/home-manager/commit/7ca7025cf2fa88bebc2190955c44263c3989b706) | `` alacritty: fix escape sequence in example and test ``            |
| [`dc906b19`](https://github.com/nix-community/home-manager/commit/dc906b197bc20c518e497fb040bb8240543fa634) | `` kdeconnect: require "tray.target" for kdeconnect ``              |
| [`0184c818`](https://github.com/nix-community/home-manager/commit/0184c8180f5cbb8e3a54a239b874fe849d3073cb) | `` neomutt: add some options ``                                     |
| [`b1a5b3d6`](https://github.com/nix-community/home-manager/commit/b1a5b3d6a524c80c7dd20888bff227d52adf5f03) | `` vdirsyncer: set `postHook` to null when not set (#5294) ``       |
| [`b62cad68`](https://github.com/nix-community/home-manager/commit/b62cad68b754224caec1e3b0dbadf86821b0b255) | `` spotify-player: add module ``                                    |
| [`b5b2b1ac`](https://github.com/nix-community/home-manager/commit/b5b2b1ac63458357e205bcb2df2d0840a2acca13) | `` helix: add ignores option ``                                     |
| [`8ff7bb3f`](https://github.com/nix-community/home-manager/commit/8ff7bb3f4d82a05a52d5242ec454bba14f5d6cc6) | `` tofi: add module ``                                              |
| [`f3506ba8`](https://github.com/nix-community/home-manager/commit/f3506ba86cbc5f8620ea6b4e108146702a4627e9) | `` bash: add bash package to home.packages ``                       |
| [`ffc3600f`](https://github.com/nix-community/home-manager/commit/ffc3600f4009ca39b6cb63b24127ca4f93792854) | `` fd: add module ``                                                |
| [`54e35e0e`](https://github.com/nix-community/home-manager/commit/54e35e0e1c1b6b4888c34423335a448ab3ec78d5) | `` qt: use warnings API ``                                          |
| [`be2b1761`](https://github.com/nix-community/home-manager/commit/be2b17615c536c31d0ea4989a959298b115353b3) | `` qt: fix adwaita decorations link ``                              |
| [`b31019d6`](https://github.com/nix-community/home-manager/commit/b31019d64f9ddd1a869fa8fdb371c32c7ed9b578) | `` qt: add adwaita platform theme ``                                |
| [`7cebe921`](https://github.com/nix-community/home-manager/commit/7cebe921eaffd5f9880f0dab7a23789d15f6169b) | `` Update translation files ``                                      |
| [`178e2689`](https://github.com/nix-community/home-manager/commit/178e26895b3aef028a00a32fb7e7ed0fc660645c) | `` home-manager: error out on missing option argument ``            |
| [`f46814ec`](https://github.com/nix-community/home-manager/commit/f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394) | `` treewide: prefer the official wiki ``                            |
| [`93b917d4`](https://github.com/nix-community/home-manager/commit/93b917d49f0b2ab75ff91e17573e112b95fdd95c) | `` flake.lock: Update ``                                            |
| [`fa8c16e2`](https://github.com/nix-community/home-manager/commit/fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7) | `` systemd: add `enable` option ``                                  |
| [`1c43dcfa`](https://github.com/nix-community/home-manager/commit/1c43dcfac48a2d622797f7ab741670fdbcf8f609) | `` ci: bump peaceiris/actions-gh-pages from 3 to 4 ``               |
| [`59d50bc5`](https://github.com/nix-community/home-manager/commit/59d50bc582bdf439df096a9ae1781e6c9c8a7523) | `` espanso: enable module on darwin ``                              |
| [`9f32c66a`](https://github.com/nix-community/home-manager/commit/9f32c66a51d05e6d4ec0dea555bbff9135749ec7) | `` k9s: configuration files in Darwin without XDG ``                |
| [`76a1650c`](https://github.com/nix-community/home-manager/commit/76a1650c45df8ed130e66eeeb8275a149562c4c5) | `` k9s: fix typos in configuration file names ``                    |
| [`630a0992`](https://github.com/nix-community/home-manager/commit/630a0992b3627c64e34f179fab68e3d48c6991c0) | `` nushell: fix nushell config path on darwin ``                    |
| [`4cc3c916`](https://github.com/nix-community/home-manager/commit/4cc3c91601b6083c3715516d5d891fa46c679e59) | `` flake.lock: Update ``                                            |
| [`f33d5086`](https://github.com/nix-community/home-manager/commit/f33d5086d3f9128aba126135ea2a901c121ebf06) | `` rio: remove redundant `lib.mdDoc` call ``                        |
| [`8fdf3295`](https://github.com/nix-community/home-manager/commit/8fdf329526f06886b53b94ddf433848a0d142984) | `` neovim: enable use of external package manager (#5225) ``        |
| [`40ab43ae`](https://github.com/nix-community/home-manager/commit/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0) | `` foot: set PATH in server's systemd unit file ``                  |
| [`31357486`](https://github.com/nix-community/home-manager/commit/31357486b0ef6f4e161e002b6893eeb4fafc3ca9) | `` fish: use the subcommand style for the status command (#4584) `` |
| [`18f89ef7`](https://github.com/nix-community/home-manager/commit/18f89ef74f0d48635488ccd6a5e30dc9d48a3a87) | `` firefox: add containersForce flag ``                             |
| [`b00d0e4f`](https://github.com/nix-community/home-manager/commit/b00d0e4fe9cba0047f54e77418ddda5f17e6ef2c) | `` bun: add module ``                                               |
| [`40a99619`](https://github.com/nix-community/home-manager/commit/40a99619da804a78a0b166e5c6911108c059c3a8) | `` fzf: add compatibility with fzf≥0.48.0 ``                        |
| [`a561ad6a`](https://github.com/nix-community/home-manager/commit/a561ad6ab38578c812cc9af3b04f2cc60ebf48c9) | `` flake.lock: Update ``                                            |
| [`b787726a`](https://github.com/nix-community/home-manager/commit/b787726a8413e11b074cde42704b4af32d95545c) | `` home-manager: extract inline shell script to file ``             |
| [`782eed8b`](https://github.com/nix-community/home-manager/commit/782eed8bb64b27acaeb7c17be4a095c85e65717f) | `` programs.khal: add "addresses" option + tidy up (#5221) ``       |
| [`1ffd393c`](https://github.com/nix-community/home-manager/commit/1ffd393cba9eb12df94641238f4436cabb285c9b) | `` Translate using Weblate (Catalan) ``                             |
| [`0c73c1b8`](https://github.com/nix-community/home-manager/commit/0c73c1b8da28a24c4fe842ced3f2548d5828b550) | `` zoxide: remove obsolete workaround ``                            |
| [`9de3aab0`](https://github.com/nix-community/home-manager/commit/9de3aab0917914baad72e32023834f9b39e77610) | `` kdeconnect: add package option ``                                |
| [`7e91f2a0`](https://github.com/nix-community/home-manager/commit/7e91f2a0ba4b62b88591279d54f741a13e36245b) | `` xmonad: fix cp failure if libFiles with subdirectories ``        |
| [`80546b22`](https://github.com/nix-community/home-manager/commit/80546b220e95a575c66c213af1b09fe255299438) | `` Translate using Weblate (Norwegian Bokmål) ``                    |
| [`58e5ae81`](https://github.com/nix-community/home-manager/commit/58e5ae81ceb274a249ae69659f3150419673f14c) | `` Translate using Weblate (Romanian) ``                            |
| [`aca33e99`](https://github.com/nix-community/home-manager/commit/aca33e99551250cfb23f384789d9fecea0254ac4) | `` Translate using Weblate (Russian) ``                             |
| [`81cd7199`](https://github.com/nix-community/home-manager/commit/81cd71995ade24333017e7930802040363ce1946) | `` hyprland: fix systemd variables example ``                       |
| [`e429a609`](https://github.com/nix-community/home-manager/commit/e429a60900c1c8f6c07bbd4926b79f05a98544c9) | `` bacon: add default value for settings ``                         |
| [`6396954c`](https://github.com/nix-community/home-manager/commit/6396954c0d26ffd7601c478c11443f454926bf27) | `` bacon: add package option ``                                     |
| [`4be04644`](https://github.com/nix-community/home-manager/commit/4be0464472675212654dedf3e021bd5f1d58b92f) | `` home-manager: fix missing string context ``                      |
| [`820be197`](https://github.com/nix-community/home-manager/commit/820be197ccf3adaad9a8856ef255c13b6cc561a6) | `` programs.khal: ability to set RGB color (#5192) ``               |
| [`30f2ec39`](https://github.com/nix-community/home-manager/commit/30f2ec39519f4f5a8a96af808c439e730c15aeab) | `` flake.lock: Update ``                                            |
| [`c09deb86`](https://github.com/nix-community/home-manager/commit/c09deb869b2e7a4612e489d4bbb11517f78b618e) | `` Translate using Weblate (Vietnamese) ``                          |
| [`c0ef0dab`](https://github.com/nix-community/home-manager/commit/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2) | `` home-environment: fix formatting ``                              |
| [`3142bdcc`](https://github.com/nix-community/home-manager/commit/3142bdcc470e1e291e1fbe942fd69e06bd00c5df) | `` readline: optionally place config file in XDG dir ``             |
| [`179f6aca`](https://github.com/nix-community/home-manager/commit/179f6acaf7c068c7870542cdae72afec9427a5b0) | `` antidote: Use builtins.storeDir (#5182) ``                       |
| [`eb869521`](https://github.com/nix-community/home-manager/commit/eb869521cb6c895b6d351be0b9e010c578de0e4b) | `` darkman: allow no configuration ``                               |
| [`1c2c5e4c`](https://github.com/nix-community/home-manager/commit/1c2c5e4cabba4c43504ef0f8cc3f3dfa284e2dbb) | `` home-manager: fix nix-build option `-q` ``                       |
| [`19b87b9a`](https://github.com/nix-community/home-manager/commit/19b87b9ae6ecfd81104a2a36ef8364f1de1b54b1) | `` vdirsyncer: add urlCommand and userNameCommand options ``        |
| [`1c2acec9`](https://github.com/nix-community/home-manager/commit/1c2acec99933f9835cc7ad47e35303de92d923a4) | `` xdg-portal: align with NixOS module ``                           |
| [`3583fea7`](https://github.com/nix-community/home-manager/commit/3583fea7866834f70960a374cb0f4a6d1ffd0fc0) | `` flake.lock: Update ``                                            |