### PR TITLE
chore(flake/nix-index-database): `e25efda8` -> `34519f3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710644923,
-        "narHash": "sha256-0fjbN5GYYDKPyPay0l8gYoH+tFfNqPPwP5sxxBreeA4=",
+        "lastModified": 1711249705,
+        "narHash": "sha256-h/NQECj6mIzF4XR6AQoSpkCnwqAM+ol4+qOdYi2ykmQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e25efda85e39fcdc845e371971ac4384989c4295",
+        "rev": "34519f3bb678a5abbddf7b200ac5347263ee781b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`34519f3b`](https://github.com/nix-community/nix-index-database/commit/34519f3bb678a5abbddf7b200ac5347263ee781b) | `` update packages.nix to release 2024-03-24-030726 `` |
| [`d7b713a5`](https://github.com/nix-community/nix-index-database/commit/d7b713a5fed6f7c8d21de9c510ccd782cb36cd74) | `` flake.lock: Update ``                               |