### PR TITLE
chore(flake/stylix): `4da2d793` -> `43d23b16`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,39 +18,6 @@
         "type": "github"
       }
     },
-    "base16-alacritty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1703982197,
-        "narHash": "sha256-TNxKbwdiUXGi4Z4chT72l3mt3GSvOcz6NZsUH8bQU/k=",
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "c95c200b3af739708455a03b5d185d3d2d263c6e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "type": "github"
-      }
-    },
-    "base16-alacritty-yaml": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674275109,
-        "narHash": "sha256-Adwx9yP70I6mJrjjODOgZJjt4OPPe8gJu7UuBboXO4M=",
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "aarowill",
-        "repo": "base16-alacritty",
-        "rev": "63d8ae5dfefe5db825dd4c699d0cdc2fc2c3eaf7",
-        "type": "github"
-      }
-    },
     "base16-fish": {
       "flake": false,
       "locked": {
@@ -811,8 +778,6 @@
     "stylix": {
       "inputs": {
         "base16": "base16",
-        "base16-alacritty": "base16-alacritty",
-        "base16-alacritty-yaml": "base16-alacritty-yaml",
         "base16-fish": "base16-fish",
         "base16-foot": "base16-foot",
         "base16-helix": "base16-helix",
@@ -829,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711106191,
-        "narHash": "sha256-WX1Tyb94jB3ksSQ5UtlTY/1UBsO7FlFNPjG3BXt9/0Q=",
+        "lastModified": 1714555012,
+        "narHash": "sha256-WVUrm3TGVj6c8g5aG20OjJRHMvUtAZjpHQgukDhyOT8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4da2d793e586f3f45a54fb9755ee9bf39d3cd52e",
+        "rev": "43d23b1609b87f6a4100db2a09bd118c52c78766",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`43d23b16`](https://github.com/danth/stylix/commit/43d23b1609b87f6a4100db2a09bd118c52c78766) | `` bat: use config instead of env variable (#353) ``                 |
| [`0fe277a3`](https://github.com/danth/stylix/commit/0fe277a3641a849478a94c7900c2d5a90609a306) | `` treewide: remove `lib.mdDoc` (#349) ``                            |
| [`267cf91e`](https://github.com/danth/stylix/commit/267cf91e0340076e1057cb14930fa8437f591b5a) | `` doc: add documentation for testbeds (#347) ``                     |
| [`2f29ecd3`](https://github.com/danth/stylix/commit/2f29ecd3e4c0ebf75f46647b4c4fb7261b978aac) | `` alacritty: replace base16-alacritty with a custom theme (#346) `` |
| [`845c6745`](https://github.com/danth/stylix/commit/845c6745108b0ee76361a3d677a2e1df1d3d9487) | `` nixos-icons: remove rendered version of logo (#344) ``            |
| [`5749cf16`](https://github.com/danth/stylix/commit/5749cf162340b230e86fa75571b3cb6ce7f11441) | `` nixos-icons: `white.svg` -> `nix-snowflake-white.svg` (#343) ``   |
| [`b36fb34a`](https://github.com/danth/stylix/commit/b36fb34a9c8fb728c7efe5dbbb222bb23dcaa967) | `` stylix: add testbeds for desktop environments (#320) ``           |
| [`83866ed8`](https://github.com/danth/stylix/commit/83866ed8800ed39519a79ea30b18c8eb21f26080) | `` plymouth: remove substituteInPlace to fix build failure (#338) `` |
| [`406f7930`](https://github.com/danth/stylix/commit/406f793045ce82689194273cb7e7c4ad0fec530c) | `` stylix: escape spaces in wallpaper path (#318) ``                 |
| [`c630a7d3`](https://github.com/danth/stylix/commit/c630a7d3ee4530e6a0e20ddf45ad813fc8b6da1b) | `` plymouth: lock URL version (#335) ``                              |
| [`58761b51`](https://github.com/danth/stylix/commit/58761b51f86be18a4638ba59ba1debd01d71323a) | `` doc: add mention of `lib.stylix.pixel` to tricks (#327) ``        |
| [`f9b9bc7c`](https://github.com/danth/stylix/commit/f9b9bc7c8e69942cd2583a3309f86fc5260f1275) | `` stylix: do not escape spaces in wallpaper path (#329) ``          |
| [`b6dbe9ac`](https://github.com/danth/stylix/commit/b6dbe9ac5d57d27d5620445f20cad2c353089f86) | `` kde: use provided `verboseEcho` function (#316) ``                |
| [`a0bdd9c1`](https://github.com/danth/stylix/commit/a0bdd9c15b23a5db48d29afe3b238333605c357c) | `` stylix: escape spaces in wallpaper path (#317) ``                 |
| [`3c6b34fb`](https://github.com/danth/stylix/commit/3c6b34fbc29c57b741f848df77f3072041fd19c3) | `` kde: apply Bash best practices (#314) ``                          |
| [`fdf8fd26`](https://github.com/danth/stylix/commit/fdf8fd261eba972e23e8926caeb3aa41c5e3ac68) | `` treewide: use Bash internal 'test' command (#311) ``              |
| [`bad1af63`](https://github.com/danth/stylix/commit/bad1af63ff330b397b87fc243d479701417740da) | `` kde: remove internal debugging logs (#304) ``                     |
| [`504c54db`](https://github.com/danth/stylix/commit/504c54dbf1d91857b52133ee9c9bd4c526b3275c) | `` kde: remove redundant function declaration space (#305) ``        |
| [`75fd2477`](https://github.com/danth/stylix/commit/75fd247712ac54d756b7c0bb7150dc6858d29522) | `` mangohud: remove `font_file` (#307) ``                            |
| [`53d3e5d5`](https://github.com/danth/stylix/commit/53d3e5d5b36a5227b906e00d7e884dcfb7852403) | `` nixos-icons: recolor white logo (#297) ``                         |