### PR TITLE
chore(flake/nixvim-flake): `ccb47fcb` -> `3a8edca4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -708,11 +708,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1711110775,
-        "narHash": "sha256-Iptg5dPS5RnIfilHESW9MI1+DxdjBN6JUVln1Qr2HV0=",
+        "lastModified": 1711283599,
+        "narHash": "sha256-UwhZuRfD4eVNsrYB1E0bGQNAK22YeDBSwhjWBB5f82w=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "ccb47fcb006a89b0038de5e1e5b8d5b85f9f17e1",
+        "rev": "3a8edca454969775b9ba33efede1270ad91030eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`3a8edca4`](https://github.com/alesauce/nixvim-flake/commit/3a8edca454969775b9ba33efede1270ad91030eb) | `` chore(flake/nixpkgs): 20f77aa0 -> 44d0940e `` |