### PR TITLE
chore(flake/darwin): `f0dd0838` -> `230a1970`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -170,11 +170,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711591334,
-        "narHash": "sha256-9d5ilxxq4CXw44eFw8VFrRneAKex7D8xjn95mwZjgf4=",
+        "lastModified": 1713946171,
+        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f0dd0838c3558b59dc3b726d8ab89f5b5e35c297",
+        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`ec06ea88`](https://github.com/LnL7/nix-darwin/commit/ec06ea883757c6075c61d1426f40719742d51f59) | `` nix-daemon: increase SoftResourceLimits.NumberOfFiles `` |
| [`def1e23b`](https://github.com/LnL7/nix-darwin/commit/def1e23be848848400d1d097d4f044e3c401f9dd) | `` treewide: remove lib.mdDoc ``                            |
| [`1098e60e`](https://github.com/LnL7/nix-darwin/commit/1098e60e92afc5e30611a3933ad783d99e198734) | `` ci, readme: update stable nixpkgs to 23.11 ``            |
| [`81f7aab5`](https://github.com/LnL7/nix-darwin/commit/81f7aab5edf705d851415762d1bfe4fa836bbce7) | `` Update ShowDate in menuExtraClock ``                     |
| [`398510f6`](https://github.com/LnL7/nix-darwin/commit/398510f601cb1a1978a393814514f9ca9fbcfe72) | `` Add `nix.optimise` module ``                             |