### PR TITLE
chore(flake/nix-index-database): `34519f3b` -> `a362555e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711249705,
-        "narHash": "sha256-h/NQECj6mIzF4XR6AQoSpkCnwqAM+ol4+qOdYi2ykmQ=",
+        "lastModified": 1714878592,
+        "narHash": "sha256-E68C03sYRsYFsK7wiGHUIJm8IsyPRALOrFoTL0glXnI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "34519f3bb678a5abbddf7b200ac5347263ee781b",
+        "rev": "a362555e9dbd4ecff3bb98969bbdb8f79fe87f10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`a362555e`](https://github.com/nix-community/nix-index-database/commit/a362555e9dbd4ecff3bb98969bbdb8f79fe87f10) | `` update packages.nix to release 2024-05-05-030852 `` |
| [`7a20d550`](https://github.com/nix-community/nix-index-database/commit/7a20d550bed76a862e355181d1eb5f23a6c86272) | `` flake.lock: Update ``                               |
| [`941c4973`](https://github.com/nix-community/nix-index-database/commit/941c4973c824509e0356be455d89613611f76c8a) | `` update packages.nix to release 2024-04-28-030722 `` |
| [`3a859831`](https://github.com/nix-community/nix-index-database/commit/3a85983125dea5cf40b86e28b50fcd7f84546e53) | `` flake.lock: Update ``                               |
| [`dcb6ac44`](https://github.com/nix-community/nix-index-database/commit/dcb6ac44922858ce3a5b46f77a36d6030181460c) | `` hm: Symlink per default only if needed ``           |
| [`622b16b7`](https://github.com/nix-community/nix-index-database/commit/622b16b7d8b8697e40cb2e1d10e37188df02bfc2) | `` update to new merge configuration ``                |
| [`07ece11b`](https://github.com/nix-community/nix-index-database/commit/07ece11b22217b8459df589f858e92212b74f1a1) | `` update packages.nix to release 2024-04-21-030753 `` |
| [`be659309`](https://github.com/nix-community/nix-index-database/commit/be6593097ad7635defd5e08560cf9952b75f0046) | `` flake.lock: Update ``                               |
| [`93aed672`](https://github.com/nix-community/nix-index-database/commit/93aed67288be60c9ef6133ba2f8de128f4ef265c) | `` update packages.nix to release 2024-04-14-035802 `` |
| [`1b4ef0a7`](https://github.com/nix-community/nix-index-database/commit/1b4ef0a7b7481b7b8ad7a1962e4e090718075947) | `` flake.lock: Update ``                               |
| [`4676d72d`](https://github.com/nix-community/nix-index-database/commit/4676d72d872459e1e3a248d049609f110c570e9a) | `` update packages.nix to release 2024-04-07-030847 `` |
| [`373c00eb`](https://github.com/nix-community/nix-index-database/commit/373c00eb260c976fb13c886c0a6235818125f388) | `` flake.lock: Update ``                               |
| [`2844b5f3`](https://github.com/nix-community/nix-index-database/commit/2844b5f3ad3b478468151bd101370b9d8ef8a3a7) | `` update packages.nix to release 2024-03-31-030752 `` |
| [`784ca729`](https://github.com/nix-community/nix-index-database/commit/784ca7299336509ebcfb3702be28fcb0015e99cd) | `` flake.lock: Update ``                               |
| [`ed94c127`](https://github.com/nix-community/nix-index-database/commit/ed94c127153dccb088aa1a6c47d01cfdbdd07bc7) | `` mergify: also merge dependabot ``                   |