### PR TITLE
chore(flake/nixvim-flake): `d1a8cb39` -> `c600edc3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -708,11 +708,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1711801845,
-        "narHash": "sha256-ThtGU1pLIGSvY1Lfu3/9UtWp9A6kkin6Z79ES+mKD6U=",
+        "lastModified": 1712061269,
+        "narHash": "sha256-ajh7ucbnpE8puYLurJHEBzVGAvgKUTuQJSpZJNvoLko=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "d1a8cb3929c41c9b96b2432ea27e1db9b07a30c2",
+        "rev": "c600edc3a956865377c38ad5952bc27555aab997",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`c600edc3`](https://github.com/alesauce/nixvim-flake/commit/c600edc3a956865377c38ad5952bc27555aab997) | `` chore(flake/flake-parts): f7b3c975 -> 9126214d `` |