### PR TITLE
chore(flake/nixpkgs): `d8fe5e6c` -> `08b9151e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`49e6c686`](https://github.com/NixOS/nixpkgs/commit/49e6c686f870addfd89b7fc3af68141a57659aee) | `` mdadm: Fix hardcoded directory ``                                          |
| [`269f5806`](https://github.com/NixOS/nixpkgs/commit/269f5806e0523962932659a454ff097a27f526f5) | `` mdadm: update homepage ``                                                  |
| [`68a93a15`](https://github.com/NixOS/nixpkgs/commit/68a93a152b518176790c8c29d47e30ae15d61168) | `` python311Packages.mplhep: 0.3.41 -> 0.3.44 ``                              |
| [`d9bb2c01`](https://github.com/NixOS/nixpkgs/commit/d9bb2c0160b723f18c4c70110792d337a16be4a4) | `` nvme-cli: remove unused input ``                                           |
| [`fe446431`](https://github.com/NixOS/nixpkgs/commit/fe44643130629388f5e0e851a81e8878083ef807) | `` python311Packages.testcontainers: 4.3.0 -> 4.3.1 ``                        |
| [`e976fa8f`](https://github.com/NixOS/nixpkgs/commit/e976fa8f49c35cf28496301a1ef2aa23ad576b56) | `` coqPackages.vcfloat: enable for Coq 8.18 & 8.19 ``                         |
| [`c02cbef6`](https://github.com/NixOS/nixpkgs/commit/c02cbef6a9657a1b6731ddff4aa98ddc33fb2e54) | `` coqPackages.gappalib: 1.5.4 → 1.5.5 ``                                     |
| [`cffe0a32`](https://github.com/NixOS/nixpkgs/commit/cffe0a32af5bb0e2f32831386b751a606147bfdc) | `` coqPackages.interval: 4.9.0 → 4.10.0 ``                                    |
| [`aeefac7a`](https://github.com/NixOS/nixpkgs/commit/aeefac7af976353fd9e3b433486b4dea5ed03801) | `` python311Packages.cssutils: 2.10.1 -> 2.10.2 ``                            |
| [`4d7913a9`](https://github.com/NixOS/nixpkgs/commit/4d7913a92250fc3119e8eb56e33d1a56994f7e4a) | `` maa-cli: license agpl3Plus -> agpl3Only ``                                 |
| [`427bf67b`](https://github.com/NixOS/nixpkgs/commit/427bf67bed80ee00e76fe777055cf4e67396ae79) | `` nixos/ocis: init at 5.0.0 ``                                               |
| [`9f3798cd`](https://github.com/NixOS/nixpkgs/commit/9f3798cd7bb211d39fb5d57f6b1e16b6cef8a989) | `` ocis-bin: init at 5.0.0 ``                                                 |
| [`8484ed14`](https://github.com/NixOS/nixpkgs/commit/8484ed14b748cc79b8b2c5e9a67c4af5dcabc13b) | `` jetbrains-toolbox: move to `pkgs/by-name` ``                               |
| [`3ebbcab5`](https://github.com/NixOS/nixpkgs/commit/3ebbcab5d08cd4c692d98759438ca280eccc1e4d) | `` pict-rs: 0.5.10 -> 0.5.11 ``                                               |
| [`27b5a9c6`](https://github.com/NixOS/nixpkgs/commit/27b5a9c67e4a13adc599af32d80ba4fe8d69735e) | `` asciigraph: 0.6.0 -> 0.7.1 ``                                              |
| [`3b55dfcf`](https://github.com/NixOS/nixpkgs/commit/3b55dfcf002110d56d035a2f310627510aaa0169) | `` matrix-synapse-unwrapped: 1.103.0 -> 1.104.0 ``                            |
| [`af69be66`](https://github.com/NixOS/nixpkgs/commit/af69be669f0257e734c3fb97828910f69fcb45a1) | `` treewide: Rename nixfmt to nixfmt-classic (#300468) ``                     |
| [`87fba89f`](https://github.com/NixOS/nixpkgs/commit/87fba89f7b2e857929feebc790bd7f5a8858fa9b) | `` kshutdown: init at 5.91-beta ``                                            |
| [`d07bd8a3`](https://github.com/NixOS/nixpkgs/commit/d07bd8a31c38aab0821868e0394c066e9c993d9d) | `` roon-server: 2.0-1388 -> 2.0-1392 ``                                       |
| [`83440df1`](https://github.com/NixOS/nixpkgs/commit/83440df1f6c29e0fcf7dfba1e9a95138d892e703) | `` auditBlasHook: remove ``                                                   |
| [`3d7311ee`](https://github.com/NixOS/nixpkgs/commit/3d7311ee9eb593f0ee4cc1e50bd8d41aaedf39c9) | `` python311Packages.google-cloud-asset: 3.25.1 -> 3.26.0 ``                  |
| [`858f4db3`](https://github.com/NixOS/nixpkgs/commit/858f4db3048c5be3527e183470e93c1a72c5727c) | `` buildDotnetModule: fix handling `executables` with an empty list ``        |
| [`3b883d3c`](https://github.com/NixOS/nixpkgs/commit/3b883d3cdf8942c56e5f232973b50fc1c9e941aa) | `` lib/strings: Add makeIncludePath (#296237) ``                              |
| [`ba4f6569`](https://github.com/NixOS/nixpkgs/commit/ba4f6569d258f2d9473c4b51834219c4a3b61431) | `` python3Packages.bidict: rm bundled pytest.ini ``                           |
| [`4c72e95f`](https://github.com/NixOS/nixpkgs/commit/4c72e95faeb81cd5ee72ae8ead65b68f32472021) | `` rekor-server: 1.3.5 -> 1.3.6 ``                                            |
| [`d8b8cc5a`](https://github.com/NixOS/nixpkgs/commit/d8b8cc5a0785d4e994f25a573a93178f56bea7ce) | `` super-slicer: fix build (#298652) ``                                       |
| [`b4f96d2b`](https://github.com/NixOS/nixpkgs/commit/b4f96d2b981a92a2d2699842adcfa9e758cad12e) | `` gh-f: init at 1.1.5 ``                                                     |
| [`5efcd7e4`](https://github.com/NixOS/nixpkgs/commit/5efcd7e460976ef129dd452bc41c0dc38c97f4ec) | `` prometheus-smokeping-prober: 0.7.3 -> 0.8.0 ``                             |
| [`799834a7`](https://github.com/NixOS/nixpkgs/commit/799834a7bba844a37d8af425688aa944b3727ab6) | `` python311Packages.google-cloud-bigquery: refactor ``                       |
| [`0a7ea2e4`](https://github.com/NixOS/nixpkgs/commit/0a7ea2e4620bfc89fa66fe927b199dc0ddaec131) | `` dnf4: 4.19.0 -> 4.19.2 ``                                                  |
| [`9a2a9ff6`](https://github.com/NixOS/nixpkgs/commit/9a2a9ff69fa83953687d9f4df2b6dd4cd2192cd8) | `` ansible-navigator: init at 24.2.0 ``                                       |
| [`0ef3730e`](https://github.com/NixOS/nixpkgs/commit/0ef3730ed948fe0daf4c17b9e11c672834ec1bc5) | `` ansible-builder: init at 3.0.1 ``                                          |
| [`d52b7353`](https://github.com/NixOS/nixpkgs/commit/d52b7353cca1f24465d7d1235fe95acd631e369d) | `` onigurumacffi: init at v1.3.0 ``                                           |
| [`b9215cb1`](https://github.com/NixOS/nixpkgs/commit/b9215cb120fead43a406907e3d732dccf39a94af) | `` jan: 0.4.9 -> 0.4.10 ``                                                    |
| [`41900b8b`](https://github.com/NixOS/nixpkgs/commit/41900b8bf2d3c19c62c223bc691351cbbdf64c00) | `` python311Packages.colorcet: change to use pyproject ``                     |
| [`10c62602`](https://github.com/NixOS/nixpkgs/commit/10c626024d05ee0d7a726f677dfea56ce627bb16) | `` msgpack-cxx: 6.1.0 -> 6.1.1 ``                                             |
| [`094fc5c6`](https://github.com/NixOS/nixpkgs/commit/094fc5c60ca7b9b07d17acdee093278044e06cbb) | `` coppwr: init at 1.5.1 ``                                                   |
| [`e26617d2`](https://github.com/NixOS/nixpkgs/commit/e26617d268cc79066a86cdccc96225941162d294) | `` bindep: init at 2.11.0 ``                                                  |
| [`f9cbf463`](https://github.com/NixOS/nixpkgs/commit/f9cbf463abec500003765015f0aaf16cef2801ef) | `` mapcidr: 1.1.16 -> 1.1.34 ``                                               |
| [`e9488dbe`](https://github.com/NixOS/nixpkgs/commit/e9488dbea7413f76285b85906e0adff7febac00b) | `` sage: work around QuaternionAlgebra random test failure ``                 |
| [`c669611b`](https://github.com/NixOS/nixpkgs/commit/c669611bf24daa4074e28f965ff80939f4e0a7ca) | `` actiona: init at 3.10.2 ``                                                 |
| [`7257398f`](https://github.com/NixOS/nixpkgs/commit/7257398f828aea4556e83f411e7ef7fe482464d4) | `` _64gram: init at 1.1.15 ``                                                 |
| [`e69cc136`](https://github.com/NixOS/nixpkgs/commit/e69cc136ec65f34332f84cc7b8ebdfa4905508c1) | `` meg: init at 0.3.0 ``                                                      |
| [`e0783371`](https://github.com/NixOS/nixpkgs/commit/e0783371fefb6526debedf0736d9fbeb86fb3cb2) | `` maintainers: add RAVENz46 ``                                               |
| [`94e7d0dd`](https://github.com/NixOS/nixpkgs/commit/94e7d0dd01d6e31d02957602f0c60fea87e51e63) | `` etcd: fix update script ``                                                 |
| [`e985d212`](https://github.com/NixOS/nixpkgs/commit/e985d2124c5b359ded5459817406dae1868a8efb) | `` kdePackages.kirigami-addons: 1.0.1 -> 1.1.0 ``                             |
| [`5fa0d872`](https://github.com/NixOS/nixpkgs/commit/5fa0d872d0642ea01e45c2c1426148b1c73199c0) | `` pyprland: 2.0.9 -> 2.1.1 ``                                                |
| [`d10eea21`](https://github.com/NixOS/nixpkgs/commit/d10eea2199ad812fe8f9da439cafdb8cd0f0d51e) | `` linux_latest-libre: 19509 -> 19523 ``                                      |
| [`f515bfb5`](https://github.com/NixOS/nixpkgs/commit/f515bfb594343dc953caa8682bef1c89f05a6de4) | `` linux-rt_6_6: 6.6.22-rt27 -> 6.6.23-rt28 ``                                |
| [`9fc0f243`](https://github.com/NixOS/nixpkgs/commit/9fc0f24367910bbc0f6cfb93b5defcb4d12519d1) | `` linux-rt_6_1: 6.1.82-rt27 -> 6.1.83-rt28 ``                                |
| [`b2504018`](https://github.com/NixOS/nixpkgs/commit/b2504018cb8b6e2f81ace768e7e70a33a02577e8) | `` linux_testing: 6.9-rc1 -> 6.9-rc2 ``                                       |
| [`0e2fe683`](https://github.com/NixOS/nixpkgs/commit/0e2fe683ffea5c45fd7e0a48f94f0d2a6dc0e478) | `` fantomas: 6.3.0 -> 6.3.1 ``                                                |
| [`5e109370`](https://github.com/NixOS/nixpkgs/commit/5e109370d47c07c3ca68e3cbc880a70e9e18014e) | `` python311Packages.transformers: 4.39.2 -> 4.39.3 ``                        |
| [`71fcc06a`](https://github.com/NixOS/nixpkgs/commit/71fcc06aadc817fda676f9d273bb3cf52dd176b6) | `` python311Packages.papermill: relax aiohttp dependency to fix build ``      |
| [`36ab2248`](https://github.com/NixOS/nixpkgs/commit/36ab2248ae4ce624557c929b6ea15d228ed2a794) | `` python311Packages.google-cloud-bigquery: 3.19.0 -> 3.20.1 ``               |
| [`4b4a995c`](https://github.com/NixOS/nixpkgs/commit/4b4a995c6e7c0dc27768298119d5fe80e6da4427) | `` supabase-cli: 1.151.1 -> 1.153.3 ``                                        |
| [`9f0338a9`](https://github.com/NixOS/nixpkgs/commit/9f0338a909c90f9363822bf3a3e24d8bff17beb8) | `` cariddi: refactor ``                                                       |
| [`7ab59131`](https://github.com/NixOS/nixpkgs/commit/7ab59131642a42b92f4d6554173ef9a35cbb39f0) | `` luaPackages: init some neovim packages ``                                  |
| [`33d05c1c`](https://github.com/NixOS/nixpkgs/commit/33d05c1c55fe3b9a2dc3b033033ef444c991a8a7) | `` nim_lk: 20231031 -> 20240210 ``                                            |
| [`3fe26719`](https://github.com/NixOS/nixpkgs/commit/3fe267190eba137a4bc55b2db7cba8dee2a2edfa) | `` python311Packages.awkward: 2.6.2 -> 2.6.3 ``                               |
| [`ddb82e2d`](https://github.com/NixOS/nixpkgs/commit/ddb82e2d4c7a58967f1589890053df95424eb18d) | `` python311Packages.awkward-cpp: 30 -> 32 ``                                 |
| [`1ec66c48`](https://github.com/NixOS/nixpkgs/commit/1ec66c484f2b45f870972c2a080f503b66708d5e) | `` python311Packages.tplink-omada-client: 1.3.13 -> 1.4.0 ``                  |
| [`752e4a36`](https://github.com/NixOS/nixpkgs/commit/752e4a36d8bfbb348e8aae15c1108b187317d5a9) | `` vimPlugins.nvim-treesitter: update grammars ``                             |
| [`3356010f`](https://github.com/NixOS/nixpkgs/commit/3356010f1ecbdca1e37aa3583f6bc6fcdcf17ec3) | `` vimPlugins: resolve github repository redirects ``                         |
| [`636254d2`](https://github.com/NixOS/nixpkgs/commit/636254d20bd59d9f8d1394ee5efd1ed08b624344) | `` vimPlugins: update on 2024-04-02 ``                                        |
| [`43f95622`](https://github.com/NixOS/nixpkgs/commit/43f956227e7bbcb11aa54ce1294f6b5bdf6c8fad) | `` nixos/cjdns: prefer 'install' over 'chmod' ``                              |
| [`3d3a23da`](https://github.com/NixOS/nixpkgs/commit/3d3a23da73a26c17d118e3b88a46dc183132d9c4) | `` python311Packages.litellm: 1.34.16 -> 1.34.20 ``                           |
| [`f43061fd`](https://github.com/NixOS/nixpkgs/commit/f43061fd5f72125eeac0e860600402cc4812c377) | `` nix-update: 1.3.0 -> 1.3.1 ``                                              |
| [`bddc7e4e`](https://github.com/NixOS/nixpkgs/commit/bddc7e4eb409dc6702b271415d30387b662247c6) | `` python312Packages.m3u8: fix changelog entry ``                             |
| [`72d8e937`](https://github.com/NixOS/nixpkgs/commit/72d8e937ddbc8612dfb955395fcb75663ea729d8) | `` python312Packages.m3u8: refactor ``                                        |
| [`a17ddd58`](https://github.com/NixOS/nixpkgs/commit/a17ddd589fce47e333cab1424403989e20bd97d5) | `` python312Packages.django-model-utils: refactor ``                          |
| [`fba58595`](https://github.com/NixOS/nixpkgs/commit/fba585953a0b8211c5ae81fd6ed777ab81d2a335) | `` cargo-information: init at 0.4.2 ``                                        |
| [`cdb93010`](https://github.com/NixOS/nixpkgs/commit/cdb93010f821db4e4f671ce3302b7f4a6589352a) | `` python312Packages.tencentcloud-sdk-python: 3.0.1119 -> 3.0.1121 ``         |
| [`cc6cff71`](https://github.com/NixOS/nixpkgs/commit/cc6cff713acf695228521fab2015eafea4c20ed9) | `` Update pkgs/tools/security/vals/default.nix ``                             |
| [`086be0c0`](https://github.com/NixOS/nixpkgs/commit/086be0c0aebf76c4a9b705e2bff8aac2b8ae2d01) | `` lexical: init at 0.5.2 ``                                                  |
| [`d69933e0`](https://github.com/NixOS/nixpkgs/commit/d69933e0e0f315a3dd7e2f147554e71737996e31) | `` python311Packages.dbt-redshift: refactor ``                                |
| [`6619849f`](https://github.com/NixOS/nixpkgs/commit/6619849f93658ac01b314b1b7837b4d38b50ae8d) | `` python311Packages.xkcdpass: refactor ``                                    |
| [`c723850c`](https://github.com/NixOS/nixpkgs/commit/c723850cc1585cd4988b81cb091c6e5c7d48e1c8) | `` consul-template: 0.37.3 -> 0.37.4 ``                                       |
| [`3074b3f4`](https://github.com/NixOS/nixpkgs/commit/3074b3f4f229ea193fe5c31e00344eaa4997d292) | `` jnv: 0.1.3 -> 0.2.1 ``                                                     |
| [`6b5698da`](https://github.com/NixOS/nixpkgs/commit/6b5698dacec04f38ecac71323b59b7cfd39efd39) | `` wayland-pipewire-idle-inhibit: 0.5.0 -> 0.5.1 ``                           |
| [`d56d232b`](https://github.com/NixOS/nixpkgs/commit/d56d232ba5ae160369b9e8c894cd45f24f3fbe63) | `` ast-grep: 0.20.0 -> 0.20.2 ``                                              |
| [`b0d6f851`](https://github.com/NixOS/nixpkgs/commit/b0d6f851822600107ae7306533954cbbc983d88a) | `` gigalixir: 1.10.0 -> 1.11.1 ``                                             |
| [`71830f5e`](https://github.com/NixOS/nixpkgs/commit/71830f5eed7058e8f968d9805bea0f950803e9ad) | `` gnugrep: disable tests on riscv64 ``                                       |
| [`133d57ae`](https://github.com/NixOS/nixpkgs/commit/133d57ae8e6e64e5ed5c32ea9fab7a49a5ca708f) | `` python311Packages.switchbot-api: refactor ``                               |
| [`7aa12374`](https://github.com/NixOS/nixpkgs/commit/7aa12374a5c6da252e6fed2429dc0bf39978e797) | `` whois: 5.5.21 -> 5.5.22 ``                                                 |
| [`a3f4b45e`](https://github.com/NixOS/nixpkgs/commit/a3f4b45eceb7e703e02ff7dde2b1ef3ff2e829dd) | `` python312Packages.twilio: refactor ``                                      |
| [`47d6cc5e`](https://github.com/NixOS/nixpkgs/commit/47d6cc5e40661f096ad4969bf04792c6e0223cb9) | `` python312Packages.types-docutils: refactor ``                              |
| [`6b0936a9`](https://github.com/NixOS/nixpkgs/commit/6b0936a976208b01187daa0c6aa61a97e38dc0dc) | `` python311Packages.google-cloud-org-policy: refactor ``                     |
| [`227de4c3`](https://github.com/NixOS/nixpkgs/commit/227de4c35beeab0ca104c195fa728e5186eb1d5b) | `` vscode-extensions.bmewburn.vscode-intelephense-client: 1.10.2 -> 1.10.4 `` |
| [`6b9202db`](https://github.com/NixOS/nixpkgs/commit/6b9202db65a48889797051d56c577416549ed326) | `` crawley: 1.7.3 -> 1.7.4 ``                                                 |
| [`5764ccfa`](https://github.com/NixOS/nixpkgs/commit/5764ccfafb43792fd09fd7ae4b225fba7a763b84) | `` wiremock: 3.4.2 -> 3.5.2 ``                                                |
| [`70b6e9ad`](https://github.com/NixOS/nixpkgs/commit/70b6e9ada9f311734d52eb2894efee08e7e713bb) | `` k3s: 1.29.2+k3s1 -> 1.29.3+k3s1 ``                                         |
| [`13e3f898`](https://github.com/NixOS/nixpkgs/commit/13e3f898080c709134a0ac8a0f2991fe5cad517a) | `` pocketbase: 0.22.6 -> 0.22.7 ``                                            |
| [`cfbde8ec`](https://github.com/NixOS/nixpkgs/commit/cfbde8ec8d8f81b53011b14b643584cfb89e980a) | `` nixos/tests/gitlab: reduce memory usage ``                                 |
| [`dcd0f499`](https://github.com/NixOS/nixpkgs/commit/dcd0f499c6e5d5d480a0190bf33e5e361867e69d) | `` nixos/gitlab: Add option sidekiq.concurrency. ``                           |
| [`3c336f30`](https://github.com/NixOS/nixpkgs/commit/3c336f30895ef47d931fc799960a3d804108d75e) | `` coqPackages.Vpl: fix meta ``                                               |
| [`43f594a6`](https://github.com/NixOS/nixpkgs/commit/43f594a64f626be3c0ece1ac547266604b30fe16) | `` python311Packages.dbt-redshift: 1.7.4 -> 1.7.5 ``                          |
| [`c90648d1`](https://github.com/NixOS/nixpkgs/commit/c90648d1976034bf58ac6d3373f629b26cd5fea0) | `` fn-cli: 0.6.30 -> 0.6.31 ``                                                |
| [`cdecd96a`](https://github.com/NixOS/nixpkgs/commit/cdecd96afb205eb7b0f5ebe73ec3f39179791485) | `` heroic: 2.13 -> 2.14 ``                                                    |
| [`fe2d0b11`](https://github.com/NixOS/nixpkgs/commit/fe2d0b11f9858998ea49aacdcf6dd15d75d2b165) | `` python311Packages.switchbot-api: 2.0.0 -> 2.1.0 ``                         |
| [`6c3cd9ec`](https://github.com/NixOS/nixpkgs/commit/6c3cd9ecff7a87b771d7571a536bfa90ee2a2cb9) | `` nwg-panel: 0.9.26 -> 0.9.27 ``                                             |
| [`7158289d`](https://github.com/NixOS/nixpkgs/commit/7158289d9e2c1101c97fd1c675400dd93e6f15cc) | `` typos: 1.20.0 -> 1.20.1 ``                                                 |
| [`5ea02227`](https://github.com/NixOS/nixpkgs/commit/5ea02227c91c3c4273ee1a199d5829d5cdee6d0e) | `` telegraf: 1.30.0 -> 1.30.1 ``                                              |
| [`3d9a630e`](https://github.com/NixOS/nixpkgs/commit/3d9a630ee3d423e3ef20a575066b11175a133cf9) | `` simdutf: 5.0.0 -> 5.2.0 ``                                                 |
| [`47d9ce46`](https://github.com/NixOS/nixpkgs/commit/47d9ce462b048f33db553f77ebfd2750c18a9d49) | `` bat: skip file_with_invalid_utf8_filename test ``                          |
| [`75a63510`](https://github.com/NixOS/nixpkgs/commit/75a6351055b27839f34ff018bcdbd1c19ea7452a) | `` python312Packages.m3u8: 4.0.0 -> 4.1.0 ``                                  |
| [`cf76b2d1`](https://github.com/NixOS/nixpkgs/commit/cf76b2d1794a5bdc7bd7585b5486e2cc6f03993a) | `` python312Packages.types-docutils: 0.20.0.20240317 -> 0.20.0.20240331 ``    |
| [`db902cab`](https://github.com/NixOS/nixpkgs/commit/db902cab975c21c3a9ae1158bb8427b33254275e) | `` atlas: 0.20.0 -> 0.21.0 ``                                                 |
| [`9cfde6b5`](https://github.com/NixOS/nixpkgs/commit/9cfde6b57dc514c195567e3514ff76147e21e68d) | `` media-downloader: 4.4.0 -> 4.5.0 ``                                        |