### PR TITLE
chore(flake/nixvim-flake): `c600edc3` -> `57c849eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -708,11 +708,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1712061269,
-        "narHash": "sha256-ajh7ucbnpE8puYLurJHEBzVGAvgKUTuQJSpZJNvoLko=",
+        "lastModified": 1712234035,
+        "narHash": "sha256-UmcX0h2qxoSZ40mjUQM+65ZiaTTTASPyvgxZwdR4MVc=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "c600edc3a956865377c38ad5952bc27555aab997",
+        "rev": "57c849eb298bc91841d4324246cd13bdf5fd64eb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`57c849eb`](https://github.com/alesauce/nixvim-flake/commit/57c849eb298bc91841d4324246cd13bdf5fd64eb) | `` chore(flake/nixpkgs): d8fe5e6c -> 08b9151e `` |