### PR TITLE
chore(flake/nixpkgs): `4cba8b53` -> `1042fd8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -605,11 +605,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712608508,
-        "narHash": "sha256-vMZ5603yU0wxgyQeHJryOI+O61yrX2AHwY6LOFyV1gM=",
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`dc4f2184`](https://github.com/NixOS/nixpkgs/commit/dc4f2184327d7b04edda404fa8562ba5e3e17755) | `` check-cherry-picks.sh maintainer script: add clarifying message regarding differences found ``     |
| [`b612366a`](https://github.com/NixOS/nixpkgs/commit/b612366abc32edc61e86d0fcc0f4a08cabcf5212) | `` check-cherry-picks.sh maintainer script: fix handling of cherry-pick-less branches ``              |
| [`392c8da8`](https://github.com/NixOS/nixpkgs/commit/392c8da8774676f4adaba2d98fcc2823810fa779) | `` qovery-cli: format with nixfmt ``                                                                  |
| [`08a9aec5`](https://github.com/NixOS/nixpkgs/commit/08a9aec581f31cf1e73b2ff440890785351f1c26) | `` python311Packages.llama-index-vector-stores-qdrant: 0.1.6 -> 0.2.0 ``                              |
| [`dbc967d1`](https://github.com/NixOS/nixpkgs/commit/dbc967d14d354154bc556a4348971c59df5dc56c) | `` Revert "NixOS Integration Tests: Enable again for darwin" ``                                       |
| [`ab0b45a3`](https://github.com/NixOS/nixpkgs/commit/ab0b45a3a027644e404dcd01887b3921ad0533de) | `` nixos/sddm: allow disabling the rest of X11 ``                                                     |
| [`74c15474`](https://github.com/NixOS/nixpkgs/commit/74c1547424498edd75cbe3092a624960a2456695) | `` nixos/doc: suggest mounting the ESP on /boot with umask=077 ``                                     |
| [`e17e60b2`](https://github.com/NixOS/nixpkgs/commit/e17e60b2738bcddf4e0661da3d63872ceec2a9cb) | `` nixos-generate-config: preserve vfat filesystem mount permissions ``                               |
| [`0355aaa7`](https://github.com/NixOS/nixpkgs/commit/0355aaa7d29f6e4c990a52c119766a09d3e4371c) | `` quartus-prime-lite: add option to disable Questa simulator ``                                      |
| [`4d46279a`](https://github.com/NixOS/nixpkgs/commit/4d46279ad98b238bcb7c0c08b53a9e1aba1cf6d6) | `` quartus-prime-lite: make usable under emulation ``                                                 |
| [`a4f75867`](https://github.com/NixOS/nixpkgs/commit/a4f75867ee9c13fdb1f4501108eb37790081ced1) | `` quartus-prime-lite: add more qsys requirements ``                                                  |
| [`e4bf075c`](https://github.com/NixOS/nixpkgs/commit/e4bf075cffda38c7ba857234325f3b4c4411ed53) | `` NixOS Integration Tests: Enable again for darwin ``                                                |
| [`a7418181`](https://github.com/NixOS/nixpkgs/commit/a74181815c9b0f5b21fb71f8a6a99db7c1266f83) | `` linux/common-config: remove old NFSD options from 5.15 too ``                                      |
| [`eaf5fc18`](https://github.com/NixOS/nixpkgs/commit/eaf5fc1813adefeea57a3312e7009c6784ddd50e) | `` gmid: migrate to by-name ``                                                                        |
| [`dadbcf93`](https://github.com/NixOS/nixpkgs/commit/dadbcf93673bb8d6004936992eea55e6fbecbb22) | `` nixos/rl-24.05: Add deprecation entry for cudaPackages.autoAdd{DriverRunpath,OpenGLRunpathHook} `` |
| [`52eb8850`](https://github.com/NixOS/nixpkgs/commit/52eb8850b82e0c3eceafc96fe72c56054fbd0451) | `` cudaPackages.autoAdd{Driver,OpengGL}Runpath: deprecate ``                                          |
| [`658206a8`](https://github.com/NixOS/nixpkgs/commit/658206a8f78b2e7e6b949b61bfe39e43cfc015b1) | `` CODEOWNERS: Fix check-by-name path ``                                                              |
| [`2e10f813`](https://github.com/NixOS/nixpkgs/commit/2e10f813fe216bb6e6e62c28dee8bad53a13b661) | `` nixos/prometheus-nats-exporter: new module ``                                                      |
| [`c044ba36`](https://github.com/NixOS/nixpkgs/commit/c044ba368c1504d5be49809659ff31c6e3ce5668) | `` linux-rt_6_6: 6.6.23-rt28 -> 6.6.25-rt29 ``                                                        |
| [`af887c78`](https://github.com/NixOS/nixpkgs/commit/af887c78d2d1a2073d2600a1102f57bf7cbc3324) | `` nixpkgs-check-by-name: 0.1.0 -> 0.1.1 ``                                                           |
| [`550bbd40`](https://github.com/NixOS/nixpkgs/commit/550bbd40902244523f860819a5babc71a17fcc06) | `` linux_5_15: 5.15.153 -> 5.15.154 ``                                                                |
| [`fa12da8a`](https://github.com/NixOS/nixpkgs/commit/fa12da8a56790e4bf93407a55a38baa466e14204) | `` linux_6_1: 6.1.84 -> 6.1.85 ``                                                                     |
| [`7858a70b`](https://github.com/NixOS/nixpkgs/commit/7858a70becf584782bfe094c1c00b565f37afc99) | `` linux_6_6: 6.6.25 -> 6.6.26 ``                                                                     |
| [`8f6d8ef0`](https://github.com/NixOS/nixpkgs/commit/8f6d8ef0c9e418de136785c0fca7fa805bb5a2b8) | `` linux_6_8: 6.8.4 -> 6.8.5 ``                                                                       |
| [`e863d558`](https://github.com/NixOS/nixpkgs/commit/e863d558d0049de5d925ceccb001616e2044b153) | `` linux_testing: 6.9-rc2 -> 6.9-rc3 ``                                                               |
| [`cd70dc73`](https://github.com/NixOS/nixpkgs/commit/cd70dc73d87c7565770630f6152586e3ab59e32a) | `` linux/kernel/update-mainline: don't readd EOL kernels ``                                           |
| [`6347cd23`](https://github.com/NixOS/nixpkgs/commit/6347cd23dcc2b020dd4ea5bfe5871be35e95ae63) | `` dex-oidc: 2.39.0 -> 2.39.1 (#302821) ``                                                            |
| [`37ba6034`](https://github.com/NixOS/nixpkgs/commit/37ba60342b1dbff9b648e9ac2f4fb83f052d16d5) | `` linux-firmware: 20240312 -> 20240410 ``                                                            |
| [`e7d58a40`](https://github.com/NixOS/nixpkgs/commit/e7d58a4040bae44ca6572fd10e975f221d295d12) | `` raycast: 1.70.3 -> 1.71.1 ``                                                                       |
| [`50939388`](https://github.com/NixOS/nixpkgs/commit/50939388bd533ecfe2db3e9a25a5cf4ff04ef342) | `` qovery-cli: 0.86.2 -> 0.87.0 ``                                                                    |
| [`70a4a21e`](https://github.com/NixOS/nixpkgs/commit/70a4a21ed88915f7c4280aa3e3075dc4991497a9) | `` minder: 1.16.3 -> 1.16.4 ``                                                                        |
| [`fa2d0c69`](https://github.com/NixOS/nixpkgs/commit/fa2d0c69d1a9f6d26f72780446842bcfa3969ed3) | `` googleearth-pro: more specific vulnerability description ``                                        |
| [`de3d3a0c`](https://github.com/NixOS/nixpkgs/commit/de3d3a0cf1c31fe5e3361bd7181dbbc0c06a6d03) | `` python311Packages.aiolifx-themes: 0.4.16 -> 0.4.17 ``                                              |
| [`93afa6f7`](https://github.com/NixOS/nixpkgs/commit/93afa6f76436b89cd5b73aa378ac7adc0bf87dfe) | `` spire: 1.9.3 -> 1.9.4 ``                                                                           |
| [`d8481306`](https://github.com/NixOS/nixpkgs/commit/d8481306a11fa99bcd25a79bb739ef7e59648c4b) | `` vscodium: 1.87.2.24072 -> 1.88.0.24096 ``                                                          |
| [`3536f166`](https://github.com/NixOS/nixpkgs/commit/3536f166827d89333a5c7ac8c82f1bde71b3136c) | `` sing-geoip: add rule-set ``                                                                        |
| [`d5f1fe59`](https://github.com/NixOS/nixpkgs/commit/d5f1fe59586c8386f32c6e173162864c3332313b) | `` bashly: 1.1.1 -> 1.1.10 ``                                                                         |
| [`d50ce37b`](https://github.com/NixOS/nixpkgs/commit/d50ce37b58602e69c36051a76b4cc775f1e1a0af) | `` pgmodeler: add darwin build (#301513) ``                                                           |
| [`ac9f9e7e`](https://github.com/NixOS/nixpkgs/commit/ac9f9e7eec1c667cc117a79a23d508f41655912a) | `` pixel-code: init at 2.1 ``                                                                         |
| [`3a82aa98`](https://github.com/NixOS/nixpkgs/commit/3a82aa9865d09ce22d597fd9526d375d4699fb5f) | `` hermitcli: 0.39.0 -> 0.39.1 ``                                                                     |
| [`60392a45`](https://github.com/NixOS/nixpkgs/commit/60392a452f5d753e1d6ddb602f4a51cd70415f9e) | `` ghq: 1.6.0 -> 1.6.1 ``                                                                             |
| [`4803dda9`](https://github.com/NixOS/nixpkgs/commit/4803dda921840e8808b1be3768fc76a77e133776) | `` goa: 3.15.2 -> 3.16.0 ``                                                                           |
| [`7935635f`](https://github.com/NixOS/nixpkgs/commit/7935635fc67b978b7709990f9d00cb311605150d) | `` python311Packages.jupyterlab-server: 2.25.4 -> 2.26.0 ``                                           |
| [`099f557c`](https://github.com/NixOS/nixpkgs/commit/099f557c424f37ee27b54defed016418477c07eb) | `` python311Packages.jupyterlab: 4.1.5 -> 4.1.6 ``                                                    |
| [`a33508e6`](https://github.com/NixOS/nixpkgs/commit/a33508e69f6060d8b0e28584e95910dfb19cbd38) | `` python311Packages.pytest-jupyter: 0.9.1 -> 0.10.1 ``                                               |
| [`3223d992`](https://github.com/NixOS/nixpkgs/commit/3223d99210d16575d3822cda9c13bd48d3606c2b) | `` python311Packages.nbformat: 5.10.3 -> 5.10.4 ``                                                    |
| [`c392dd79`](https://github.com/NixOS/nixpkgs/commit/c392dd79976fdcc7cd4617514463c12d29b5a708) | `` kid3: build with qt6 and KDE support ``                                                            |
| [`db6607c3`](https://github.com/NixOS/nixpkgs/commit/db6607c336dcc75f50b26d61407ecf91bfb27c85) | `` flarectl: 0.92.0 -> 0.93.0 ``                                                                      |
| [`11d360a4`](https://github.com/NixOS/nixpkgs/commit/11d360a45b8df9fa23ba1725c8392cbc9bd33156) | `` fastly: 10.8.9 -> 10.8.10 ``                                                                       |
| [`cba54bf9`](https://github.com/NixOS/nixpkgs/commit/cba54bf96aa4e1faa5c5be85533e9f9af605e895) | `` expr: 1.16.3 -> 1.16.4 ``                                                                          |
| [`4e76f408`](https://github.com/NixOS/nixpkgs/commit/4e76f4085b7d3c9859f19d4da6454892cebad125) | `` entt: 3.13.1 -> 3.13.2 ``                                                                          |
| [`264f8655`](https://github.com/NixOS/nixpkgs/commit/264f8655623fc190e1b8d15f17d53db69810c0fa) | `` deck: 1.36.1 -> 1.36.2 ``                                                                          |
| [`aab8dc5a`](https://github.com/NixOS/nixpkgs/commit/aab8dc5aced175fc6e8454c43d385378a4b127fb) | `` ctranslate2: 4.1.1 -> 4.2.0 ``                                                                     |
| [`415f8b2d`](https://github.com/NixOS/nixpkgs/commit/415f8b2d9aaa7f2f8c8c3520c8a03cecb5cb4143) | `` ausweisapp: 2.1.0 -> 2.1.1 ``                                                                      |
| [`f31ddd38`](https://github.com/NixOS/nixpkgs/commit/f31ddd385bbca57fcba0f5de066764bf2db0436a) | `` trayscale: 0.11.1 -> 0.11.2 ``                                                                     |
| [`f1c99961`](https://github.com/NixOS/nixpkgs/commit/f1c99961e37d2dfc40fe6f4da5010399597b04df) | `` nixos/fzf: fix typo ``                                                                             |
| [`5f599df3`](https://github.com/NixOS/nixpkgs/commit/5f599df38e4fa6fec857fbcf5ac54fc715f1884a) | `` osc: 1.3.1 -> 1.6.1 ``                                                                             |
| [`ee3702bf`](https://github.com/NixOS/nixpkgs/commit/ee3702bff257b954b3375b93dbf2f2ad6bf89193) | `` appthreat-depscan: rename to dep-scan ``                                                           |
| [`ded5cfda`](https://github.com/NixOS/nixpkgs/commit/ded5cfda5932e2b198cb86c6e677e475cec13548) | `` dep-scan: format with nixfmt ``                                                                    |
| [`f70161f8`](https://github.com/NixOS/nixpkgs/commit/f70161f889b2c3e31a7768d352c7428c5907f916) | `` dep-scan: 5.2.14 -> 5.3.2 ``                                                                       |
| [`dbf5e973`](https://github.com/NixOS/nixpkgs/commit/dbf5e973575c35c6c13fe0959c80be9d10bc1567) | `` python312Packages.appthreat-vulnerability-db: 5.6.6 -> 5.6.7 ``                                    |
| [`2f85c76e`](https://github.com/NixOS/nixpkgs/commit/2f85c76e07fcfeec9e2753ea87d63ee74d6e2e4c) | `` python312Packages.appthreat-vulnerability-db: format with nixfmt ``                                |
| [`5dfb296a`](https://github.com/NixOS/nixpkgs/commit/5dfb296a9dca8aea24c572e96f851a4c93c35ac6) | `` homepage-dashboard: 0.8.10 -> 0.8.11 ``                                                            |
| [`4610d269`](https://github.com/NixOS/nixpkgs/commit/4610d2694e5334eb1a75bf3363c0e0e8b91c76cb) | `` python312Packages.apsw: 3.45.1.0 -> 3.45.2.0 ``                                                    |
| [`52f123b1`](https://github.com/NixOS/nixpkgs/commit/52f123b158a0f4c5d25123f366b1e8a3c606f4f4) | `` python312Packages.credstash: format with nixfmt ``                                                 |
| [`a9cca8bf`](https://github.com/NixOS/nixpkgs/commit/a9cca8bfcb483a8c271ad32f20dc5d6fb069379b) | `` python312Packages.credstash: refactor ``                                                           |
| [`76fe963e`](https://github.com/NixOS/nixpkgs/commit/76fe963e0333b3edb848e400847d799d952b5186) | `` s3ql: 4.0.0 -> 5.1.3 ``                                                                            |
| [`1573d996`](https://github.com/NixOS/nixpkgs/commit/1573d996c9fb19d2e954c7b41670e7bc9fb7524a) | `` s3ql: format with nixfmt ``                                                                        |
| [`e30e8b37`](https://github.com/NixOS/nixpkgs/commit/e30e8b374e2c9a14360a0eef31eb4807cb9f082e) | `` s3ql: refactor ``                                                                                  |
| [`aa440662`](https://github.com/NixOS/nixpkgs/commit/aa440662310a2b95a3f1fd471fd44aa86b503c35) | `` libretro.genesis-plus-gx: unstable-2024-03-15 -> unstable-2024-04-05 ``                            |
| [`61147380`](https://github.com/NixOS/nixpkgs/commit/611473809dc03464bb06426880715ae9531aec3a) | `` bearer: format with nixfmt ``                                                                      |
| [`7f22f7f6`](https://github.com/NixOS/nixpkgs/commit/7f22f7f671a8f7e501c6d535f100a10d1bbb801a) | `` libretro.fceumm: unstable-2024-03-02 -> unstable-2024-04-06 ``                                     |
| [`ce27583a`](https://github.com/NixOS/nixpkgs/commit/ce27583abac595449a04ac7b5817a7f95d0eccd0) | `` libretro.flycast: unstable-2024-04-03 -> unstable-2024-04-05 ``                                    |
| [`819184e8`](https://github.com/NixOS/nixpkgs/commit/819184e86e9d4e2134b5b772c94c23d4cbc96e80) | `` libretro.mame: unstable-2024-04-01 -> unstable-2024-04-05 ``                                       |
| [`7126ab5b`](https://github.com/NixOS/nixpkgs/commit/7126ab5b259e2a94ce5eee82e1cbac70b86638b7) | `` vtm: 0.9.76 -> 0.9.77 ``                                                                           |
| [`1dafbd6e`](https://github.com/NixOS/nixpkgs/commit/1dafbd6eb89fd1259e6d99afa89dd5000dec07b9) | `` walker: init at 0.0.68 (#296165) ``                                                                |
| [`b3954004`](https://github.com/NixOS/nixpkgs/commit/b3954004b7acb99be203a9d77d8f163b6b63f1c9) | `` python312Packages.marimo: 0.3.9 -> 0.3.12 ``                                                       |
| [`9f35426d`](https://github.com/NixOS/nixpkgs/commit/9f35426d61bb085a9e80ecdc4b9caca66ab9ab2c) | `` libretro.fbneo: unstable-2024-04-02 -> unstable-2024-04-08 ``                                      |
| [`87ce0c4f`](https://github.com/NixOS/nixpkgs/commit/87ce0c4fc76cca22ffd2cd8852ab2959588a132f) | `` python312Packages.ajsonrpc: format with nixfmt ``                                                  |
| [`45e67eb3`](https://github.com/NixOS/nixpkgs/commit/45e67eb30e88dabd2b36253a28e6b5c0b4f5ec79) | `` python312Packages.ajsonrpc: refactor ``                                                            |
| [`b38c346a`](https://github.com/NixOS/nixpkgs/commit/b38c346ad24694f956e17465f78bca1421767523) | `` python312Packages.goodwe: foramt with nixfmt ``                                                    |
| [`e349bce6`](https://github.com/NixOS/nixpkgs/commit/e349bce6375476bfb6e6a3e365cfedc7ea3be2ac) | `` libretro.ppsspp: unstable-2024-04-04 -> unstable-2024-04-09 ``                                     |
| [`a91f6fbe`](https://github.com/NixOS/nixpkgs/commit/a91f6fbe05c6b8f98ca657f5670bd0cc6feef797) | `` python312Packages.goodwe: refactor ``                                                              |
| [`61815940`](https://github.com/NixOS/nixpkgs/commit/618159404c84af23afdab3c58d9d3aa5e555235d) | `` python312Packages.goodwe: 0.3.1 -> 0.3.2 ``                                                        |
| [`685f6ca7`](https://github.com/NixOS/nixpkgs/commit/685f6ca79de5d94e0f1d99bcc7e1b2e73b8d1ec9) | `` libretro.mame2003-plus: unstable-2024-04-03 -> unstable-2024-04-09 ``                              |
| [`0dda011f`](https://github.com/NixOS/nixpkgs/commit/0dda011f18c7cfdc8b56a04778e252a8b7e0e20f) | `` Remove left-over ``                                                                                |
| [`47b06b68`](https://github.com/NixOS/nixpkgs/commit/47b06b6872c909df97619c0d33f47b47d67877ac) | `` python312Packages.azure-mgmt-kusto: format with nixfmt ``                                          |
| [`8eadba8a`](https://github.com/NixOS/nixpkgs/commit/8eadba8a35a90566bb4a99ca1ef18b50713af2cb) | `` python312Packages.azure-mgmt-kusto: refactor ``                                                    |
| [`848c6916`](https://github.com/NixOS/nixpkgs/commit/848c6916062f10fcd298d93d530ae7cdf427584a) | `` juce: 7.0.10 -> 7.0.11 ``                                                                          |
| [`955f206c`](https://github.com/NixOS/nixpkgs/commit/955f206cc495a4ce85f5fcdbc3dcc70a7f9a4b97) | `` python312Packages.azure-synapse-spark: format with nixfmt ``                                       |
| [`7c1d1716`](https://github.com/NixOS/nixpkgs/commit/7c1d1716c99dfcd4a6b9e64d47c214d033ef3828) | `` python312Packages.azure-synapse-spark: refactor ``                                                 |
| [`a59f11bb`](https://github.com/NixOS/nixpkgs/commit/a59f11bb52184a3048f055015c8122c83c3ce3d5) | `` python312Packages.azure-synapse-managedprivateendpoints: format with nixfmt ``                     |
| [`861720bd`](https://github.com/NixOS/nixpkgs/commit/861720bdb1d6afcaf376d406c19cf64e27b07057) | `` python312Packages.azure-synapse-managedprivateendpoints: refactor ``                               |
| [`758deff9`](https://github.com/NixOS/nixpkgs/commit/758deff945ff797b4346764b4d82c82132affc9c) | `` python312Packages.azure-synapse-accesscontrol: format with nixfmt ``                               |
| [`ba4882b1`](https://github.com/NixOS/nixpkgs/commit/ba4882b1e33f777f1ccdaec554b2a87e9faa2d49) | `` python312Packages.azure-synapse-accesscontrol: refactor ``                                         |
| [`4f7927d5`](https://github.com/NixOS/nixpkgs/commit/4f7927d53d1b04399c733f51dd4c4f35438bf308) | `` libretro.pcsx-rearmed: unstable-2024-03-29 -> unstable-2024-04-06 ``                               |
| [`321f3408`](https://github.com/NixOS/nixpkgs/commit/321f340885224f676597a416679c107ce619dbb8) | `` brave: add aarch64-linux support ``                                                                |
| [`9f77c758`](https://github.com/NixOS/nixpkgs/commit/9f77c758dbe6c04964c5253c6b844cdeaac9ac81) | `` python312Packages.azure-multiapi-storage: format with nixfmt ``                                    |
| [`94c80c74`](https://github.com/NixOS/nixpkgs/commit/94c80c749a225cea4bb777b38fafb42f81647223) | `` python312Packages.azure-multiapi-storage: refactor ``                                              |
| [`0a0a7a12`](https://github.com/NixOS/nixpkgs/commit/0a0a7a12b9d13dd6201f74d6559094debeeb8afe) | `` python312Packages.azure-mgmt-synapse: format with nixfmt ``                                        |
| [`e90880f5`](https://github.com/NixOS/nixpkgs/commit/e90880f50838152a6d5b9a409ce89d95f76a1e0a) | `` python312Packages.azure-mgmt-synapse: refactor ``                                                  |
| [`100ec365`](https://github.com/NixOS/nixpkgs/commit/100ec36577b0d7465d711f42eb0fafeae3642511) | `` python312Packages.azure-mgmt-sqlvirtualmachine: format with nixfmt ``                              |
| [`cd955c18`](https://github.com/NixOS/nixpkgs/commit/cd955c18b745468e504e98a82236ce92026fcd70) | `` python312Packages.azure-mgmt-sqlvirtualmachine: refactor ``                                        |
| [`0f69c9b6`](https://github.com/NixOS/nixpkgs/commit/0f69c9b60c9721802af77b2e677f9aa2c421a6c6) | `` libretro.nestopia: unstable-2024-03-29 -> unstable-2024-04-07 ``                                   |
| [`cd4f9d4b`](https://github.com/NixOS/nixpkgs/commit/cd4f9d4bfe13406b950a95f32ee4f4adcb95f3a5) | `` python312Packages.azure-mgmt-managedservices: format with nixfmt ``                                |
| [`b1d9a3d6`](https://github.com/NixOS/nixpkgs/commit/b1d9a3d64e8f8e73940b9970c9d8b2b24dce1b72) | `` python312Packages.azure-mgmt-managedservices: refactor ``                                          |
| [`1bda2cf4`](https://github.com/NixOS/nixpkgs/commit/1bda2cf4a95b269dba15a99309044cee28bbc445) | `` python312Packages.azure-mgmt-hdinsight: format with nixfmt ``                                      |
| [`4b91cf3e`](https://github.com/NixOS/nixpkgs/commit/4b91cf3e4273c6e10023bbf2d40f66ea1c5c6532) | `` python312Packages.azure-mgmt-hdinsight: refactor ``                                                |
| [`962952fd`](https://github.com/NixOS/nixpkgs/commit/962952fd7e449add689f46a2b9821d044329b847) | `` python312Packages.azure-mgmt-extendedlocation: format with nixfmt ``                               |
| [`4d6237f5`](https://github.com/NixOS/nixpkgs/commit/4d6237f592028c44fb5edc905a9d98c24bd7e17d) | `` python312Packages.azure-mgmt-extendedlocation: refactor ``                                         |
| [`7718e586`](https://github.com/NixOS/nixpkgs/commit/7718e586104df2dedadae663885922b04bd0ee6b) | `` python312Packages.azure-mgmt-deploymentmanager: format with nixfmt ``                              |
| [`9b8f9134`](https://github.com/NixOS/nixpkgs/commit/9b8f9134d5668c90b4cce8b7b67f9fb71cc50c17) | `` python312Packages.azure-mgmt-deploymentmanager: refactor ``                                        |
| [`598ba7fb`](https://github.com/NixOS/nixpkgs/commit/598ba7fb545d5c3ff3d72edc70e001330d13533f) | `` python312Packages.azure-mgmt-databoxedge: format with nixfmt ``                                    |
| [`97540bcf`](https://github.com/NixOS/nixpkgs/commit/97540bcfed14ae1efa8ed3aae6a795cffc0483a5) | `` python312Packages.azure-mgmt-databoxedge: refactor ``                                              |
| [`c9bbedab`](https://github.com/NixOS/nixpkgs/commit/c9bbedab24917b97622e90a6bdd94e52e831148b) | `` python312Packages.azure-mgmt-botservice: format with nixfmt ``                                     |