### PR TITLE
chore(flake/flake-parts): `9126214d` -> `e5d10a24`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -289,11 +289,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -621,20 +621,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
-        "type": "github"
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`99b383f9`](https://github.com/hercules-ci/flake-parts/commit/99b383f98859b688ea9c7d51fd1788deeaf5d422) | `` dev: Also update dev flake lock ``                |
| [`e807eea9`](https://github.com/hercules-ci/flake-parts/commit/e807eea9e845afc954ee189e8d3f57de67d7156f) | `` flake-update: Get the nixpkgs/lib subtree only `` |
| [`49771354`](https://github.com/hercules-ci/flake-parts/commit/497713541ecda51cee05f4376ba3f234b9ca8d1b) | `` dev/flake.lock: Update ``                         |
| [`59fc6f42`](https://github.com/hercules-ci/flake-parts/commit/59fc6f42218854aa35a8d76790649e8c737c8d69) | `` flake.lock: Update ``                             |
| [`288fa518`](https://github.com/hercules-ci/flake-parts/commit/288fa518e2d5ffa074a8deaa38398e96a211479f) | `` flake.nix: Update nixpkgs-lib tree ``             |
| [`ffe9d8eb`](https://github.com/hercules-ci/flake-parts/commit/ffe9d8eb04c0b9e76301a23d06910e2d56c0114c) | `` flake.lock: Update ``                             |