### PR TITLE
chore(flake/nix-fast-build): `f024a66e` -> `071d4468`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1713864757,
-        "narHash": "sha256-eBh+4DLKktrMWh0QfSFwugd4Gf2KO/X0VUTlRspR+9I=",
+        "lastModified": 1714663357,
+        "narHash": "sha256-2D2UVkXHivtNUohlJy3GjMaiE7efozJCRgnYOkBbZlY=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "f024a66e6a1f83de95aba109287a97dd6ca76127",
+        "rev": "071d44681486271060f938a354ef9ba82ee4f9ea",
         "type": "github"
       },
       "original": {
@@ -910,11 +910,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698438538,
-        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
+        "lastModified": 1714058656,
+        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
+        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`071d4468`](https://github.com/Mic92/nix-fast-build/commit/071d44681486271060f938a354ef9ba82ee4f9ea) | `` README: add cachix section `` |
| [`0d657189`](https://github.com/Mic92/nix-fast-build/commit/0d6571895ad3defdb9bf9229345f7cc952b73324) | `` rip i686-linux ``             |
| [`e8300b48`](https://github.com/Mic92/nix-fast-build/commit/e8300b4862bd2819fa8c3216929e55a8d1f0961f) | `` disable testing darwin ``     |
| [`da88afb0`](https://github.com/Mic92/nix-fast-build/commit/da88afb03d00c3329ae023112abb5443fb58da9a) | `` bump nixpkgs ``               |
| [`fe9b0aa7`](https://github.com/Mic92/nix-fast-build/commit/fe9b0aa7bc4176e6f0208bc144dfacd4c7020aee) | `` add cachix support ``         |
| [`bfe8a698`](https://github.com/Mic92/nix-fast-build/commit/bfe8a69874829c6c91b6bc5eebccd1ecf708e7c4) | `` flake.lock: Update ``         |