### PR TITLE
chore(flake/stylix): `43d23b16` -> `61c024f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714555012,
-        "narHash": "sha256-WVUrm3TGVj6c8g5aG20OjJRHMvUtAZjpHQgukDhyOT8=",
+        "lastModified": 1715001543,
+        "narHash": "sha256-VXEnKTWrMrvgFst/abTBefijEwJk7kZ/ctkPNf9l3ts=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "43d23b1609b87f6a4100db2a09bd118c52c78766",
+        "rev": "61c024f839ceb9787c1441fae718dc2077bde2ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                  |
| --------------------------------------------------------------------------------------------- | ------------------------ |
| [`61c024f8`](https://github.com/danth/stylix/commit/61c024f839ceb9787c1441fae718dc2077bde2ce) | `` gitui: init (#354) `` |