### PR TITLE
chore(flake/stylix): `8f7abd22` -> `f1bb5c50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715108364,
-        "narHash": "sha256-6AlOCZCSEpdHEpRQ8pwaGkbfSHVx11+e1+1CMp8+Huc=",
+        "lastModified": 1715245733,
+        "narHash": "sha256-Jhp0A2Vw0NL2kL8LMfOu6Vfjw11k59LHUWwSt+jmfdU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8f7abd2252d0d773ca202cf2c190b47d439f045d",
+        "rev": "f1bb5c5080685b0b18c7fdff091e5278353ba39d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                 |
| --------------------------------------------------------------------------------------------- | ----------------------- |
| [`f1bb5c50`](https://github.com/danth/stylix/commit/f1bb5c5080685b0b18c7fdff091e5278353ba39d) | `` tofi: init (#355) `` |