### PR TITLE
chore(flake/nixpkgs): `25865a40` -> `b211b392`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -572,11 +572,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714906307,
-        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
+        "lastModified": 1715087517,
+        "narHash": "sha256-CLU5Tsg24Ke4+7sH8azHWXKd0CFd4mhLWfhYgUiDBpQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
+        "rev": "b211b392b8486ee79df6cdfb1157ad2133427a29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`e027db61`](https://github.com/NixOS/nixpkgs/commit/e027db61dc24e1efbf15a1624bc59fcbe890b773) | `` python311Packages.pettingzoo: init at 1.24.3 ``                                        |
| [`8224753d`](https://github.com/NixOS/nixpkgs/commit/8224753ddf178ecb7e86b742506010b9f3d03c46) | `` python311Packages.pytest-markdown-docs: init at 0.5.1 ``                               |
| [`832bb3df`](https://github.com/NixOS/nixpkgs/commit/832bb3df1c1805040f5c637413efd9a4e9fc7277) | `` phpdocumentor: add missing build input ``                                              |
| [`f543909d`](https://github.com/NixOS/nixpkgs/commit/f543909d2da0bc374276d6ce0000a34fd5dcddec) | `` python311Packages.yolink-api: 0.4.3 -> 0.4.4 ``                                        |
| [`b5b84589`](https://github.com/NixOS/nixpkgs/commit/b5b845891c872a16c5c22cece7223b9061f5e590) | `` python311Packages.rlcard: init at 1.0.7 ``                                             |
| [`c6729c8d`](https://github.com/NixOS/nixpkgs/commit/c6729c8df5a0f0e229002f06f7ff4c1e0a1adece) | `` python311Packages.craft-application: 2.6.1 -> 2.6.3 ``                                 |
| [`d2b58349`](https://github.com/NixOS/nixpkgs/commit/d2b58349e3b17889f3ff1102be92a9c7408d2f4f) | `` snapcraft: 8.2.1 -> 8.2.5 ``                                                           |
| [`3d155494`](https://github.com/NixOS/nixpkgs/commit/3d155494e45d63780685591272da68cd358451ea) | `` build-support/php: reorganize files ``                                                 |
| [`08e29ab1`](https://github.com/NixOS/nixpkgs/commit/08e29ab1632a5b920420a568fd9fdf238831eb75) | `` build-support/php: remove confusing `with self;` ``                                    |
| [`d68b4789`](https://github.com/NixOS/nixpkgs/commit/d68b47892b6bab89d77db56210d3b2cfe6a6eada) | `` uxn: unstable-2024-04-15 -> 1.0-unstable-2024-05-06 ``                                 |
| [`e99bede0`](https://github.com/NixOS/nixpkgs/commit/e99bede01dffcdbd1ae0a554bbe0f2e3f53671e8) | `` linux-doc: adopt, fix build, apply minor changes ``                                    |
| [`5cc13d7e`](https://github.com/NixOS/nixpkgs/commit/5cc13d7e058cae6b047a308e936dc0aaff8808b5) | `` python311Packages.torchsnapshot: init at 0.1.0 ``                                      |
| [`bc4962ed`](https://github.com/NixOS/nixpkgs/commit/bc4962edf2c8642c51b52f3738be8cef61a04f50) | `` nixos-anywhere: add missing `get-facts` script to output ``                            |
| [`9e4b41f6`](https://github.com/NixOS/nixpkgs/commit/9e4b41f629a5699da08c62e2f33da069fe7d7650) | `` sqlfluff: 3.0.5 -> 3.0.6 ``                                                            |
| [`ce300f2d`](https://github.com/NixOS/nixpkgs/commit/ce300f2d7b8260747a735cb2a594102820768dad) | `` trufflehog: 3.75.0 -> 3.75.1 ``                                                        |
| [`b7222e49`](https://github.com/NixOS/nixpkgs/commit/b7222e491d2c1bfb9e7bbbb4a76c3832d3b2a91a) | `` igvm-tooling: init at 1.5.0 ``                                                         |
| [`57b85fd2`](https://github.com/NixOS/nixpkgs/commit/57b85fd2c2b2e3ce46b3a281bcddb30c7846f747) | `` grype: 0.77.2 -> 0.77.3 ``                                                             |
| [`f014e2ce`](https://github.com/NixOS/nixpkgs/commit/f014e2cee1cb79962bd025c7ed4e3b54a1fc0120) | `` checkov: 3.2.82 -> 3.2.83 ``                                                           |
| [`4a0e580f`](https://github.com/NixOS/nixpkgs/commit/4a0e580f7e89591b7de084bd5d970cf3c11f6994) | `` stackit-cli: 0.3.0 -> 0.4.0 ``                                                         |
| [`e82ddf6e`](https://github.com/NixOS/nixpkgs/commit/e82ddf6eda1713e1873e18f6255960ae3c1b119b) | `` python312Packages.winacl: format with nixfmt ``                                        |
| [`ab9a066a`](https://github.com/NixOS/nixpkgs/commit/ab9a066ae1217b4807a6e30ce9747ac007957159) | `` cargo-show-asm: 0.2.34 -> 0.2.35 ``                                                    |
| [`71aa963d`](https://github.com/NixOS/nixpkgs/commit/71aa963dd960c00bd5353fa36516da802ff160ef) | `` python312Packages.winacl: refactor ``                                                  |
| [`23e49b58`](https://github.com/NixOS/nixpkgs/commit/23e49b584efddfaa977730b7c7520fda9e8676d7) | `` python312Packages.winacl: 0.1.8 -> 0.1.9 ``                                            |
| [`a4e357ce`](https://github.com/NixOS/nixpkgs/commit/a4e357cec93dcba435c8812863dfe73c1ef3fc35) | `` gnuchess: unbreak clang build with -std=c++14 ``                                       |
| [`fd369669`](https://github.com/NixOS/nixpkgs/commit/fd3696696091ae39bd84c7fec43c68112931bdda) | `` python311Packages.blackjax: 1.1.1 -> 1.2.0 ``                                          |
| [`f33136f5`](https://github.com/NixOS/nixpkgs/commit/f33136f51d915e6c1d8b9c2a596d8ce2d2f2bcf1) | `` python312Packages.duckdb: disable flaky test ``                                        |
| [`5054f44f`](https://github.com/NixOS/nixpkgs/commit/5054f44fad1ec80e5d5fd3c74dc0e5cd0304e5af) | `` tie: -std=c89 for code written in 1993 ``                                              |
| [`a3bc1c60`](https://github.com/NixOS/nixpkgs/commit/a3bc1c60f8a08c386de8ef0e62be24d879d43cbb) | `` awscli: relax deps botocore ``                                                         |
| [`8ef4d71d`](https://github.com/NixOS/nixpkgs/commit/8ef4d71d813ff71fc3dd54e47de3dec637c55084) | `` symfony-cli: 5.8.16 -> 5.8.17 ``                                                       |
| [`86cdfb44`](https://github.com/NixOS/nixpkgs/commit/86cdfb44d32931f0c37722e18f7a53c697f0960f) | `` python311Packages.weasel: unbreak relax deps typer ``                                  |
| [`0c251eee`](https://github.com/NixOS/nixpkgs/commit/0c251eee7ac1fede6cf58e35f0c9d076648a3ea8) | `` python311Packages.pathlib-abc: Revert "python3Packages.pathlib-abc: 0.1.1 -> 0.2.0" `` |
| [`b14ef356`](https://github.com/NixOS/nixpkgs/commit/b14ef3562c5bc8d4e8852a7b55e195458ed92ecb) | `` wl-clip-persist: 0.4.1 -> 0.4.3 ``                                                     |
| [`ee6feee5`](https://github.com/NixOS/nixpkgs/commit/ee6feee518381c6c45fe15988ef0588f9fd046a1) | `` python311Packages.gensim: unbreak with upstream patch ``                               |
| [`f959fd3f`](https://github.com/NixOS/nixpkgs/commit/f959fd3fff605950d39fc0e71d6f3bcc303f11b3) | `` nixos/fish: disable logrotate service in module test ``                                |
| [`3056f095`](https://github.com/NixOS/nixpkgs/commit/3056f0955437b71dac062998a3488b76cfcea8d5) | `` nixos/fish: add `package` option ``                                                    |
| [`4e175979`](https://github.com/NixOS/nixpkgs/commit/4e175979e795a82e2e957b5758782f9a93be5b51) | `` vscode-extensions.ms-python.vscode-pylance: 2024.4.1 -> 2024.5.1 ``                    |
| [`c3463962`](https://github.com/NixOS/nixpkgs/commit/c346396257496014da9fb5a931113609b2c2b356) | `` python311Packages.scrapy: unbreak tests with upstream patch ``                         |
| [`afbee830`](https://github.com/NixOS/nixpkgs/commit/afbee830e061149f6f4644b2d6eaea050f42a903) | `` python3Packages.pycparser: add python >= 3.8 check ``                                  |
| [`ea98d5db`](https://github.com/NixOS/nixpkgs/commit/ea98d5db44dfecdb755c85655bd2fa18ad1c3473) | `` castxml: 0.6.5 -> 0.6.6 ``                                                             |
| [`355fc99f`](https://github.com/NixOS/nixpkgs/commit/355fc99f3f18ec92230146e847ab326a7f2db523) | `` process-compose: 1.2.0 -> 1.5.0 ``                                                     |
| [`a7b4b2bd`](https://github.com/NixOS/nixpkgs/commit/a7b4b2bdda4ddeb0087ea091af8de5d0bcae129d) | `` castxml: refactor ``                                                                   |
| [`5502f065`](https://github.com/NixOS/nixpkgs/commit/5502f0657966d785d03166924cc965db12590bcb) | `` castxml: migrate to by-name ``                                                         |
| [`7eb75621`](https://github.com/NixOS/nixpkgs/commit/7eb75621ee9704c63670743fb4bbc946e6ab40b0) | `` qmenumodel: disable broken tests ``                                                    |
| [`cab5f0bc`](https://github.com/NixOS/nixpkgs/commit/cab5f0bc2652243ffbc1807380621d1691b79b41) | `` cargo-expand: 1.0.85 -> 1.0.86 ``                                                      |
| [`91ba60a4`](https://github.com/NixOS/nixpkgs/commit/91ba60a4bd2b62153412692e2fd3e1769bb49eda) | `` cargo-llvm-lines: 0.4.37 -> 0.4.38 ``                                                  |
| [`9d7a7292`](https://github.com/NixOS/nixpkgs/commit/9d7a729277d7a71f584d37181df0236ece2522ab) | `` treewide: ReadWriteDirectories -> ReadWritePaths. ``                                   |
| [`52a5da6a`](https://github.com/NixOS/nixpkgs/commit/52a5da6a01b33a13ff7d1d28f42deaa8bb610216) | `` rapidcheck: unstable-2023-12-14 -> 0-unstable-2023-12-14 ``                            |
| [`046edaea`](https://github.com/NixOS/nixpkgs/commit/046edaea92757ec5b846b3a5022038b96e983c48) | `` libcxxrt: unstable-2024-04-15 -> 4.0.10-unstable-2024-04-15 ``                         |
| [`eb394b29`](https://github.com/NixOS/nixpkgs/commit/eb394b2974d6435ca13353b6457c42ae7af9f6a7) | `` minilibx: unstable-2021-10-30 -> 0-unstable-2021-10-30 ``                              |
| [`97d0c1d1`](https://github.com/NixOS/nixpkgs/commit/97d0c1d1587860115a831dbce63c27a63e5e7911) | `` libz: unstable-2018-03-31 -> 1.2.8.2015.12.26-unstable-2018-03-31 ``                   |
| [`bfb6ea04`](https://github.com/NixOS/nixpkgs/commit/bfb6ea04cfd87d33afd0c1b4ca41d5120f0592a3) | `` libvgm: unstable-2024-04-24 -> 0-unstable-2024-04-24 ``                                |
| [`72aa0eea`](https://github.com/NixOS/nixpkgs/commit/72aa0eeac48addaa566daed47fc160ca7a8ad58c) | `` libsegfault: unstable-2022-11-13 -> 0-unstable-2022-11-13 ``                           |
| [`0c67a69f`](https://github.com/NixOS/nixpkgs/commit/0c67a69f7a06a9fb91e9d6c8e2bcadb3f9c59655) | `` hax11: unstable-2023-09-25 -> 0-unstable-2023-09-25 ``                                 |
| [`e85faede`](https://github.com/NixOS/nixpkgs/commit/e85faede0a211303100d7d35f113b6a38b9fc088) | `` gtk-frdp: unstable-2024-03-01 -> 3.37.1-unstable-2024-03-01 ``                         |
| [`935882c6`](https://github.com/NixOS/nixpkgs/commit/935882c621d7a4a0b695defe489e31da5f25b82e) | `` gl3w: unstable-2023-10-10 -> 0-unstable-2023-10-10 ``                                  |
| [`53ff5df1`](https://github.com/NixOS/nixpkgs/commit/53ff5df1b9ea27c9d778f8e3856be6fad217572e) | `` crossguid: unstable-2019-05-29 -> 0.2.2-unstable-2019-05-29 ``                         |
| [`e72e5aca`](https://github.com/NixOS/nixpkgs/commit/e72e5acac8a851e0a73f5ce31e7bb483543af079) | `` cegui: unstable-2023-03-18 -> 0-unstable-2023-03-18 ``                                 |
| [`be1b856e`](https://github.com/NixOS/nixpkgs/commit/be1b856e5c4822ac871f086ebd50abd3e29a8bf5) | `` fastfetch: 2.11.3 -> 2.11.5 ``                                                         |
| [`29f395b8`](https://github.com/NixOS/nixpkgs/commit/29f395b8ddc139d44688df6616df5e06bbb1e78d) | `` checkov: disable failing test ``                                                       |
| [`d6a01b6f`](https://github.com/NixOS/nixpkgs/commit/d6a01b6fa5502da23928b91e4adc21b9c4b00618) | `` python312Packages.python-ecobee-api: forma twith nixfmt ``                             |
| [`af190e4d`](https://github.com/NixOS/nixpkgs/commit/af190e4d57818f335d17d525d0fa9b8fba78baed) | `` python312Packages.python-ecobee-api: 0.2.17 -> 0.2.18 ``                               |
| [`0357a40b`](https://github.com/NixOS/nixpkgs/commit/0357a40b865bc29936f0b098ccd0c04c5006db10) | `` python312Packages.python-ecobee-api: refactor ``                                       |
| [`efd232d7`](https://github.com/NixOS/nixpkgs/commit/efd232d7b6a17bc0f200c06a3a8451428e105fa2) | `` python312Packages.django_5: 5.0.4 -> 5.0.5 ``                                          |
| [`1eb80bce`](https://github.com/NixOS/nixpkgs/commit/1eb80bce6da68304c08ad444098ce2c974298612) | `` python312Packages.pyjson5: format with nixfmt ``                                       |
| [`22cdfcbe`](https://github.com/NixOS/nixpkgs/commit/22cdfcbe5459ffb5f8496ce9126d210cf27d7aa0) | `` python312Packages.pyjson5: init at 1.6.6 ``                                            |
| [`e8beca26`](https://github.com/NixOS/nixpkgs/commit/e8beca26170633f3b1efd9ed77eb5d6f71878ee3) | `` nftables: fix substituted file location ``                                             |
| [`76fe77b6`](https://github.com/NixOS/nixpkgs/commit/76fe77b6c09b83c050f509bf1afb84907a98ccda) | `` python312Packages.langsmith: 0.1.53 -> 0.1.54 ``                                       |
| [`bdb3d105`](https://github.com/NixOS/nixpkgs/commit/bdb3d1057542e36b08265816e9dfb9ae58473d97) | `` python312Packages.langchain-community: 0.0.36 -> 0.0.37 ``                             |
| [`8c34b9a1`](https://github.com/NixOS/nixpkgs/commit/8c34b9a1286f87e4edf8370850a41e79ba2f4df9) | `` python312Packages.langchain-core: 0.1.48 -> 0.1.51 ``                                  |
| [`26084a2c`](https://github.com/NixOS/nixpkgs/commit/26084a2c6c1b00bf1db1c81def2f75cc78e0e5f3) | `` checkov: 3.2.79 -> 3.2.82 ``                                                           |
| [`70e176b9`](https://github.com/NixOS/nixpkgs/commit/70e176b9ce3b9603ffe0a3d1324e1a32ad66dcf6) | `` python311Packages.reproject: relax numpy deps, fix filterwarnings marker error ``      |
| [`118c083d`](https://github.com/NixOS/nixpkgs/commit/118c083dfc76444f8f28b2f1e332dd11148e0b2e) | `` python312Packages.boto3-stubs: 1.34.98 -> 1.34.99 ``                                   |
| [`d1977bab`](https://github.com/NixOS/nixpkgs/commit/d1977bab90af748fe3e97c00f976b9bf5903e616) | `` home-assistant: 2024.5.1 -> 2024.5.2 ``                                                |
| [`bf2ccd8a`](https://github.com/NixOS/nixpkgs/commit/bf2ccd8a063e29121df37b88ed64b9775368df13) | `` python312Packages.bluetooth-adapters: 0.19.1 -> 0.19.2 ``                              |
| [`4f3bbb2c`](https://github.com/NixOS/nixpkgs/commit/4f3bbb2c2d2a3822a23cf7824522f2ed51de3b98) | `` python312Packages.airthings-ble: 0.8.0 -> 0.9.0 ``                                     |
| [`545b050c`](https://github.com/NixOS/nixpkgs/commit/545b050c0e489b036e521445c0485632d2ef2395) | `` python312Packages.holidays: 0.47 -> 0.48 ``                                            |
| [`a1511991`](https://github.com/NixOS/nixpkgs/commit/a1511991954d084e35c20c750fb8b4caefbd9517) | `` clojure: 1.11.3.1456 -> 1.11.3.1463 ``                                                 |
| [`14d21edb`](https://github.com/NixOS/nixpkgs/commit/14d21edba6efa39613b959360abe5c0d7aa0fd91) | `` python312Packages.validator-collection: disable failing tests ``                       |
| [`a9c6372e`](https://github.com/NixOS/nixpkgs/commit/a9c6372eba7a2bbf72d93299d17c00148f873e43) | `` c3c: unstable-2021-07-30 -> 0.5.5 ``                                                   |
| [`c9335c65`](https://github.com/NixOS/nixpkgs/commit/c9335c6596a3d8426e40957171c1a96ed218a68c) | `` dumb-init: fix missing platforms (#308923) ``                                          |
| [`d5169712`](https://github.com/NixOS/nixpkgs/commit/d51697124627278b1b4d1bc27abbbbd2d5733482) | `` workflows: Add `pkgs/os-specific/bsd` to formatter whitelist ``                        |
| [`a18682e9`](https://github.com/NixOS/nixpkgs/commit/a18682e994f7ca29c10fe48444de8e2fcc5d2936) | `` python312Packages.bitbox02: foramt with nixfmt ``                                      |
| [`81565e13`](https://github.com/NixOS/nixpkgs/commit/81565e13d365c16327694f297f589b5b92c5cdb1) | `` python312Packages.bitbox02: refactor ``                                                |
| [`d85d3af4`](https://github.com/NixOS/nixpkgs/commit/d85d3af4f9295cc258744dd14c79b2552035deea) | `` python312Packages.bitbox02: 6.2.0 -> 6.3.0 ``                                          |
| [`0150af1a`](https://github.com/NixOS/nixpkgs/commit/0150af1a6cc4c46827186a0bbbd3fdf1ad47437d) | `` flashprog: 1.0.1 -> 1.1 ``                                                             |
| [`40e304c8`](https://github.com/NixOS/nixpkgs/commit/40e304c8b0ff217cc2547df2b931b5a98046d2c6) | `` kdbplus: remove ``                                                                     |
| [`00a248e2`](https://github.com/NixOS/nixpkgs/commit/00a248e2ab129061c62732bbfb5c106c2fdcd2de) | `` melonDS: 0.9.5-unstable-2024-04-18 -> 0.9.5-unstable-2024-05-05 (#309445) ``           |
| [`7c87bee7`](https://github.com/NixOS/nixpkgs/commit/7c87bee77b8ab8a22dafa973e7be3b6329a97e9e) | `` nixos/oauth2-proxy: fix missing `lib.` ``                                              |
| [`75a864ed`](https://github.com/NixOS/nixpkgs/commit/75a864edf1e78ecb75860ad6366b8984e36e5736) | `` nixos/kanata: replace deflayer with deflayermap in config example ``                   |
| [`4eafe145`](https://github.com/NixOS/nixpkgs/commit/4eafe1458d481569d1b7736c53eece2b65143b1a) | `` nixos/kanata: improve links to the upstream documentation ``                           |
| [`f7b50c39`](https://github.com/NixOS/nixpkgs/commit/f7b50c397770431da55462f941a081dcd7d5f9f3) | `` nixos/kanata: improve example of the package option ``                                 |
| [`de161855`](https://github.com/NixOS/nixpkgs/commit/de1618552c9956bf2c5915d94c584a017e3c4a3d) | `` sage: Add as passthru.tests to critical dependencies ``                                |
| [`3489da47`](https://github.com/NixOS/nixpkgs/commit/3489da471e95b066f3efee8b3368a2d0e57ffb4a) | `` {libqalculate, qalculate-gtk, qalculate-qt}: 5.0.0 -> 5.1.0 ``                         |
| [`a23b904c`](https://github.com/NixOS/nixpkgs/commit/a23b904c8b7238a5d1600f45bfe526a58956b6a9) | `` python311Packages.scikit-bio: unbreak, refactor, run tests, adopt ``                   |
| [`5a9fabb4`](https://github.com/NixOS/nixpkgs/commit/5a9fabb4ecef0925bef4332a31b30a42dcfae703) | `` python311Packages.scikit-bio: format with nixfmt ``                                    |
| [`700b90e6`](https://github.com/NixOS/nixpkgs/commit/700b90e609646ed419b76452a8e17e1496c195ae) | `` python311Packages.biom-format: init at 2.1.15 ``                                       |
| [`249a84be`](https://github.com/NixOS/nixpkgs/commit/249a84be14f4d3b58bd9de97506c362bfe109445) | `` phpunit: 11.1.1 -> 11.1.3 ``                                                           |
| [`95269ee8`](https://github.com/NixOS/nixpkgs/commit/95269ee8dbc9daacad586e8ad87567369a7e1042) | `` tipidee: mark broken on Darwin ``                                                      |
| [`d60bf67e`](https://github.com/NixOS/nixpkgs/commit/d60bf67ef58984825841130c43a5107de7a1a9a5) | `` tipidee: 0.0.3.0 -> 0.0.4.0 ``                                                         |
| [`dcbbbbf1`](https://github.com/NixOS/nixpkgs/commit/dcbbbbf13aed538b58e4449446501bddbbaa0af5) | `` s6: 2.12.0.3 -> 2.12.0.4 ``                                                            |
| [`b2907933`](https://github.com/NixOS/nixpkgs/commit/b2907933db58b8c5477899ce53cfb5ee6e641d5e) | `` execline: 2.9.4.0 -> 2.9.5.1 ``                                                        |
| [`1eab6955`](https://github.com/NixOS/nixpkgs/commit/1eab69550972d800ba640c8dc27d5ed92c7d8331) | `` qownnotes: 24.4.4 -> 24.5.1 ``                                                         |
| [`49bf0587`](https://github.com/NixOS/nixpkgs/commit/49bf0587cca566876431f5f44fa87955247aa3d3) | `` git-blame-ignore-revs: Add BSD reformatting ``                                         |
| [`3fe3b055`](https://github.com/NixOS/nixpkgs/commit/3fe3b055adfc020e6a923c466b6bcd978a13069a) | `` bsd treewide: Run RFC formatter ``                                                     |
| [`56590dd7`](https://github.com/NixOS/nixpkgs/commit/56590dd7b38778f7c4c5506c99dafc4228c4c812) | `` netbsd: Remove unneded let-bind ``                                                     |