### PR TITLE
chore(flake/stylix): `f1bb5c50` -> `b5f4ca49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,16 +448,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1698794309,
-        "narHash": "sha256-/TIkZ8y5Wv3QHLFp79Poao9fINurKs5pa4z0CRe+F8s=",
+        "lastModified": 1713702291,
+        "narHash": "sha256-zYP1ehjtcV8fo+c+JFfkAqktZ384Y+y779fzmR9lQAU=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "a7c169c6c29cf02a4c392fa0acbbc5f5072823e7",
+        "rev": "0d0aadf013f78a7f7f1dc984d0d812971864b934",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "45.1",
+        "ref": "46.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -794,11 +794,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715245733,
-        "narHash": "sha256-Jhp0A2Vw0NL2kL8LMfOu6Vfjw11k59LHUWwSt+jmfdU=",
+        "lastModified": 1715516559,
+        "narHash": "sha256-xzUwP85yIYvVSKHY2MutzAt5/ZQwUzlhL5/Gfh7jySc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f1bb5c5080685b0b18c7fdff091e5278353ba39d",
+        "rev": "b5f4ca49df372c3d26ce04b1554fb02a0107cc8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                 |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b5f4ca49`](https://github.com/danth/stylix/commit/b5f4ca49df372c3d26ce04b1554fb02a0107cc8d) | `` stylix: provide root access in testbeds (#362) ``    |
| [`98039f33`](https://github.com/danth/stylix/commit/98039f333191b25720759c35c527a291a85cf28a) | `` gnome: change panel background to `base01` (#360) `` |
| [`f83376bf`](https://github.com/danth/stylix/commit/f83376bfdc375e54196e953665997ede027eae86) | `` doc: update NixOS wiki link (#363) ``                |
| [`19752692`](https://github.com/danth/stylix/commit/197526923a2929b223bab3e36d3aa240f5f84870) | `` gnome: update to GNOME 46 (#357) ``                  |