### PR TITLE
chore(flake/home-manager): `6e277d95` -> `4855bfb6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -469,11 +469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715077503,
-        "narHash": "sha256-AfHQshzLQfUqk/efMtdebHaQHqVntCMjhymQzVFLes0=",
+        "lastModified": 1715337997,
+        "narHash": "sha256-ve562FlHVa7xhLfkFc1ihg1kuuq55IMfkxAgBQcFUY0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e277d9566de9976f47228dd8c580b97488734d4",
+        "rev": "4855bfb6ce20225a1b0e2aae2379da909ab38350",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4855bfb6`](https://github.com/nix-community/home-manager/commit/4855bfb6ce20225a1b0e2aae2379da909ab38350) | `` kanshi: update configuration to better match upstream `` |
| [`f61917cb`](https://github.com/nix-community/home-manager/commit/f61917cbaa6dba317e757aefd0bbb56403aff2f8) | `` fastfetch: add module ``                                 |