### PR TITLE
chore(flake/nix-index-database): `a362555e` -> `f9027322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714878592,
-        "narHash": "sha256-E68C03sYRsYFsK7wiGHUIJm8IsyPRALOrFoTL0glXnI=",
+        "lastModified": 1715483403,
+        "narHash": "sha256-WMDuQj7J5jbpXI/X/E6FZRKgBFGcaSTvYyVxPnKE6KU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a362555e9dbd4ecff3bb98969bbdb8f79fe87f10",
+        "rev": "f9027322f48b427da23746aa359a6510dfcd0228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f9027322`](https://github.com/nix-community/nix-index-database/commit/f9027322f48b427da23746aa359a6510dfcd0228) | `` update packages.nix to release 2024-05-12-030850 `` |
| [`03c449f9`](https://github.com/nix-community/nix-index-database/commit/03c449f9a0d87c3cca9b0c6002bd3782790215cf) | `` flake.lock: Update ``                               |