### PR TITLE
chore(flake/nixpkgs): `20578140` -> `33d1e753`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -611,11 +611,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715534503,
-        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "lastModified": 1715787315,
+        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`e0dcf2a8`](https://github.com/NixOS/nixpkgs/commit/e0dcf2a849f4e8ef7bf55d27656efcbc121a7091) | `` stalwart: Fix nixosTest in passthru ``                                      |
| [`a7848608`](https://github.com/NixOS/nixpkgs/commit/a784860836f66a782bdd263d43b5b75241954e41) | `` tiny-dfr: init at 0.2.0 ``                                                  |
| [`ffe33486`](https://github.com/NixOS/nixpkgs/commit/ffe334861c0524d086c44427f13af6a9346288ee) | `` misconfig-mapper: 1.1.0 -> 1.1.1 ``                                         |
| [`23835bcf`](https://github.com/NixOS/nixpkgs/commit/23835bcff700183d65b0e301f5ebb19e35e63151) | `` zulu22: fix javafx hashes (#311800) ``                                      |
| [`1cc90fe9`](https://github.com/NixOS/nixpkgs/commit/1cc90fe92c408670ca9594d60463a1d4da7ff201) | `` ocamlPackages.uring: 0.8 → 0.9 ``                                           |
| [`147760c1`](https://github.com/NixOS/nixpkgs/commit/147760c141c4eaf02ab42b783d35de1032c3cdbe) | `` cdemu: avoid double-wrapper and nested callPackage ``                       |
| [`0a3bfb43`](https://github.com/NixOS/nixpkgs/commit/0a3bfb437537b53e848fe9c4e985b2821215f0a7) | `` cdemu: use standard cmake build hook ``                                     |
| [`90bbb562`](https://github.com/NixOS/nixpkgs/commit/90bbb562d316b357325d827f3f0d8fc45be8d9ea) | `` cdemu: use hash instead of sha256 ``                                        |
| [`db4f375b`](https://github.com/NixOS/nixpkgs/commit/db4f375bd01e91f49907018317bcb8ec895ae83b) | `` cdemu: updates, fixes and build simplification ``                           |
| [`1a53d626`](https://github.com/NixOS/nixpkgs/commit/1a53d626d9b14045cd80ac200d0004f25b298596) | `` bash-kernel: fix and add smoke test ``                                      |
| [`81dbc8cb`](https://github.com/NixOS/nixpkgs/commit/81dbc8cb813053a4cd2a43343434df048f7d4ce6) | `` mullvad-browser: 13.0.14 -> 13.0.15 ``                                      |
| [`60e86e1b`](https://github.com/NixOS/nixpkgs/commit/60e86e1b32959966dbe05d829064b054fd6aefca) | `` tor-browser: 13.0.14 -> 13.0.15 ``                                          |
| [`ea6604c0`](https://github.com/NixOS/nixpkgs/commit/ea6604c03a26ff35f1337797b721952d1990bbfc) | `` nixosTests.garage: migrate replicationMode to string ``                     |
| [`24ace2ab`](https://github.com/NixOS/nixpkgs/commit/24ace2abee4d9ae78cb79d3dc82cf7439d067bb2) | `` nixos/garage: assert that replication_mode is string ``                     |
| [`1284b4f7`](https://github.com/NixOS/nixpkgs/commit/1284b4f7fa36a3e4e7f05a979f56136277ac8983) | `` Reapply "nixos/garage: drop replication_mode setting" ``                    |
| [`948c5506`](https://github.com/NixOS/nixpkgs/commit/948c55066995ed360efbcbe35a55a8c694545d48) | `` nixosTests.garage: run test for garage_1_x ``                               |
| [`9aa2270e`](https://github.com/NixOS/nixpkgs/commit/9aa2270e21e77a7e320adde62ac8db61f82a3266) | `` python312Packages.boto3-stubs: 1.34.104 -> 1.34.105 ``                      |
| [`302dcd8d`](https://github.com/NixOS/nixpkgs/commit/302dcd8dc85eeab22427a639cbb288e96f9a08c6) | `` python312Packages.tencentcloud-sdk-python: 3.0.1145 -> 3.0.1146 ``          |
| [`261928d7`](https://github.com/NixOS/nixpkgs/commit/261928d7b7a7c3999b7e0afe070df86a3f90c1f0) | `` python312Packages.tencentcloud-sdk-python: 3.0.1144 -> 3.0.1145 ``          |
| [`3414a30e`](https://github.com/NixOS/nixpkgs/commit/3414a30e5ed86465b44930e1693b5de7c4fc2865) | `` eigenlayer: 0.7.3 -> 0.8.0 ``                                               |
| [`bb132441`](https://github.com/NixOS/nixpkgs/commit/bb132441ea3046bd0c6a0b7957c83e124cc51a72) | `` haskellPackages: mark builds failing on hydra as broken ``                  |
| [`67cf6279`](https://github.com/NixOS/nixpkgs/commit/67cf6279d046f35a3a5be87af074ef063354d1b2) | `` Revert "nixos/garage: drop replication_mode setting" ``                     |
| [`130bc7e3`](https://github.com/NixOS/nixpkgs/commit/130bc7e3987eb51582a8b2f57b220d2dd197ddea) | `` haskellPackages: regenerate package set based on current config ``          |
| [`0fa7e069`](https://github.com/NixOS/nixpkgs/commit/0fa7e0693d8e52c22fe61402f0eed9d40d87f3df) | `` gau: format with nixfmt ``                                                  |
| [`a057cca6`](https://github.com/NixOS/nixpkgs/commit/a057cca665b07f8be9e085e61829cb65e2d4eaf4) | `` gau: refactor ``                                                            |
| [`ad54e187`](https://github.com/NixOS/nixpkgs/commit/ad54e187f5062b882c4a850273969b9a6e12db67) | `` wakatime: add sigmanificient to maintainers ``                              |
| [`a0f84489`](https://github.com/NixOS/nixpkgs/commit/a0f84489a96bd95d97959999ebcbd4ae42cd6aab) | `` cppi: add sigmanificient to maintainers ``                                  |
| [`e9d7e9c6`](https://github.com/NixOS/nixpkgs/commit/e9d7e9c6028d44078295acfe4ec49de8a6c7d812) | `` gcovr: add sigmanificient in maintainers ``                                 |
| [`97e7864f`](https://github.com/NixOS/nixpkgs/commit/97e7864fd3e9f4bf8d1d353ae0f77ead3d4501fd) | `` loc: add sigmanificient to maitainers ``                                    |
| [`36d34167`](https://github.com/NixOS/nixpkgs/commit/36d341673d070d4fec7096da981759e1cd22f3e9) | `` yyjson: add sigmanificient to maintainers ``                                |
| [`1ad5a8e7`](https://github.com/NixOS/nixpkgs/commit/1ad5a8e75fa00cba57cd5bc0a6c32cb4ca9658e3) | `` parson: add sigmanificient to maintainers ``                                |
| [`cecbef9c`](https://github.com/NixOS/nixpkgs/commit/cecbef9c8c6400ced4f02ffa3013a3537c88aa4f) | `` rasm: add sigmanificient to maintainers ``                                  |
| [`bf126ae8`](https://github.com/NixOS/nixpkgs/commit/bf126ae817e282dfc425b0c1c644cf7ebf437c1a) | `` apl386: add sigmanificient to maintainers ``                                |
| [`4e7ef76a`](https://github.com/NixOS/nixpkgs/commit/4e7ef76a3a3f8586f25a3142a75c689795747415) | `` git-standup: modenize, migrate to by-name ``                                |
| [`58cba5ba`](https://github.com/NixOS/nixpkgs/commit/58cba5ba799cba407d717653f3e2b4c503fa2274) | `` git-standup: add sigmanificient to maintainers ``                           |
| [`adf65e01`](https://github.com/NixOS/nixpkgs/commit/adf65e0148561da1b8fd5b37074f8324968eed0e) | `` kitty-themes: remove uneeded rec ``                                         |
| [`65a8a69e`](https://github.com/NixOS/nixpkgs/commit/65a8a69ece9caf4436601207400dee416437f8aa) | `` kitty-themes: add sigmanificient to maintainers ``                          |
| [`60a9d5f4`](https://github.com/NixOS/nixpkgs/commit/60a9d5f4779a2f96f3c664837b0404eee73973e7) | `` unipicker: modernize, migrate to by-name ``                                 |
| [`c22e92df`](https://github.com/NixOS/nixpkgs/commit/c22e92dfe18b7cbe716741dfe9d24d1d0f59d1ab) | `` unipicker: add sigmanificient to maintainers ``                             |
| [`232464aa`](https://github.com/NixOS/nixpkgs/commit/232464aa31a38900e377a6b1e43ca1130b36e4fe) | `` tipp10: add sigmanificient in maintainers ``                                |
| [`4d7083f2`](https://github.com/NixOS/nixpkgs/commit/4d7083f20f9a2b8c05dbd34aee207cd68a586fd0) | `` hexedit: migrate to by-name, refactor ``                                    |
| [`a75a4c9f`](https://github.com/NixOS/nixpkgs/commit/a75a4c9fedb5a6005cdc71f030a4db0081814f0d) | `` hexedit: add sigmanificient to maintainers ``                               |
| [`0798a053`](https://github.com/NixOS/nixpkgs/commit/0798a05349721d3d9437f04bb8427d0f02dcc593) | `` fte: modernize, migrate to by-name ``                                       |
| [`7202a12e`](https://github.com/NixOS/nixpkgs/commit/7202a12e6ae51bd18c7adfa6882f1950cec57f0e) | `` fte: add sigmanificient in maintainers ``                                   |
| [`c6f5d6a5`](https://github.com/NixOS/nixpkgs/commit/c6f5d6a526e3177fcf6dad93b9409883c241a704) | `` ksh: reformat, use finalAttrs over rec ``                                   |
| [`88382bf5`](https://github.com/NixOS/nixpkgs/commit/88382bf5e82fa49fa1b8d7f8c6cf9d75457ba376) | `` ksh: add sigmanificient in maintainers ``                                   |
| [`d90c0786`](https://github.com/NixOS/nixpkgs/commit/d90c078609c57f19bcb0e030a812178dab0f87dd) | `` gbsplay: modernize, migrate to by-name ``                                   |
| [`2a9ad594`](https://github.com/NixOS/nixpkgs/commit/2a9ad59445f459fe1bfc222e53cabae3f64edfff) | `` gbsplay: add sigmanificient in maintainers ``                               |
| [`b8b69c7c`](https://github.com/NixOS/nixpkgs/commit/b8b69c7cee909df1354ab179786c9487759df43a) | `` python312Packages.argilla: format with nixfmt ``                            |
| [`1f46409e`](https://github.com/NixOS/nixpkgs/commit/1f46409e3f22ca4863bb95d356f4042b33cef545) | `` python312Packages.argilla: refactor ``                                      |
| [`1345ecbe`](https://github.com/NixOS/nixpkgs/commit/1345ecbeb986bde8e5afdb58011b05218cca73b6) | `` instawow: 4.2.0 -> 4.3.0 ``                                                 |
| [`ece1819e`](https://github.com/NixOS/nixpkgs/commit/ece1819ea0f903aa32244f543bbfa336b7079beb) | `` python311Packages.tabula-py: format with nixfmt ``                          |
| [`8209a5dd`](https://github.com/NixOS/nixpkgs/commit/8209a5ddc0612a830dd31c79e9d959d025e20d59) | `` python312Packages.tabula-py: refactor ``                                    |
| [`351274bf`](https://github.com/NixOS/nixpkgs/commit/351274bf946be200d60a7b34d4333cf894d636dc) | `` nushellPlugins.query: 0.92.1 -> 0.93.0 ``                                   |
| [`89b96219`](https://github.com/NixOS/nixpkgs/commit/89b9621978b8c108377c24e07e329d5823124959) | `` nushellPlugins.gstat: 0.92.1 -> 0.93.0 ``                                   |
| [`2d3eb89a`](https://github.com/NixOS/nixpkgs/commit/2d3eb89ad06d9bee4acff4c0d46e90e974a8176b) | `` nushellPlugins.formats: 0.92.1 -> 0.93.0 ``                                 |
| [`573ea0e2`](https://github.com/NixOS/nixpkgs/commit/573ea0e25486346f843178c8a352e6a4e509ebed) | `` python311Packages.coffea: 2024.4.1 -> 2024.5.0 ``                           |
| [`307baf47`](https://github.com/NixOS/nixpkgs/commit/307baf478f252444343da3b5bd3f4bba4c7bd96e) | `` pocketbase: 0.22.11 -> 0.22.12 ``                                           |
| [`69679623`](https://github.com/NixOS/nixpkgs/commit/6967962380453a7a6456c5fb97c6f591ed392dae) | `` cnspec: 11.3.1 -> 11.4.1 ``                                                 |
| [`88c9b153`](https://github.com/NixOS/nixpkgs/commit/88c9b153af526e9ac68fbf131d103347dd1d961e) | `` cargo-expand: 1.0.86 -> 1.0.87 ``                                           |
| [`1efcd566`](https://github.com/NixOS/nixpkgs/commit/1efcd566e74c19e24eb5412b590c8bc9e93265e8) | `` trufflehog: 3.75.1 -> 3.76.0 ``                                             |
| [`1084a605`](https://github.com/NixOS/nixpkgs/commit/1084a605d460b85148c10454a645f9d7b0420726) | `` sbclPackages.qlot-cli: init at 1.5.2 ``                                     |
| [`ab0dfac1`](https://github.com/NixOS/nixpkgs/commit/ab0dfac13a8365330198238d02d0b891b8e5e3ea) | `` texturepacker: 7.3.0 -> 7.4.0 ``                                            |
| [`6e768148`](https://github.com/NixOS/nixpkgs/commit/6e768148e727fb6006854b7408245c377e662849) | `` gurobi: 11.0.1 -> 11.0.2 ``                                                 |
| [`875acb18`](https://github.com/NixOS/nixpkgs/commit/875acb186b34381235f93042e6c7012120bc14ec) | `` photoqt: 4.4 -> 4.5 ``                                                      |
| [`250e5c09`](https://github.com/NixOS/nixpkgs/commit/250e5c09389f0b8b5168d3c1399215b17dbc9f54) | `` opensearch: 2.13.0 -> 2.14.0 ``                                             |
| [`fc4c89c4`](https://github.com/NixOS/nixpkgs/commit/fc4c89c4473ba2f992565948b280434c0fa910b1) | `` cargo-tally: 1.0.44 -> 1.0.45 ``                                            |
| [`0b7468b8`](https://github.com/NixOS/nixpkgs/commit/0b7468b8082dbbadff7f55affcb4487f0e348f75) | `` lutgen: 0.10.0 -> 0.10.1 ``                                                 |
| [`32b9bd52`](https://github.com/NixOS/nixpkgs/commit/32b9bd52d62e6ea768f34e1ec928367bb00ea16d) | `` hyprland-autoname-workspaces: 1.1.13 -> 1.1.14 ``                           |
| [`37789994`](https://github.com/NixOS/nixpkgs/commit/377899940e6665c0fe4dff90bf458d9a61badd96) | `` gau: 2.2.1 -> 2.2.3 ``                                                      |
| [`9401e087`](https://github.com/NixOS/nixpkgs/commit/9401e087e2a485560dd67f60db0457bf5e7dce67) | `` linux: fix issue in config generation on lqx kernel ``                      |
| [`608d6feb`](https://github.com/NixOS/nixpkgs/commit/608d6febb95cb72ea085980528aa2756eaab32cf) | `` cargo-mutants: 24.4.0 -> 24.5.0 ``                                          |
| [`bd683b83`](https://github.com/NixOS/nixpkgs/commit/bd683b83be74eefd5846d104a7d5776340a49844) | `` cava: 0.10.1 -> 0.10.2 ``                                                   |
| [`4afa9444`](https://github.com/NixOS/nixpkgs/commit/4afa9444ae0fe6d44c2f0e866ac28a76ae9e3a30) | `` nixos/testing: fix markdown link in enableOCR description ``                |
| [`b4c2ea96`](https://github.com/NixOS/nixpkgs/commit/b4c2ea968e2b4e6f2fed61e0e3067fd98d0445e1) | `` upsun: add darwin build ``                                                  |
| [`e995bb43`](https://github.com/NixOS/nixpkgs/commit/e995bb433e7c6f2bbc023d4b2ed8a5f2af662422) | `` stalwart-mail: add nixos vm test passthru ``                                |
| [`e5d9b197`](https://github.com/NixOS/nixpkgs/commit/e5d9b197e9f13b29ca797e6a0aab21840eab64d4) | `` darwin.openwith: unbreak on x86_64-darwin ``                                |
| [`91e23d45`](https://github.com/NixOS/nixpkgs/commit/91e23d45c234ef620ad6be321c69b136a6d25ed4) | `` bitmagnet: add version to flags ``                                          |
| [`4d03b1c0`](https://github.com/NixOS/nixpkgs/commit/4d03b1c02675382549d72c3d3a84331b0634f737) | `` clblas: fix building on aarch64-darwin ``                                   |
| [`aa107a60`](https://github.com/NixOS/nixpkgs/commit/aa107a60c498df364942e4ff7759082eec821224) | `` nixos/stalwart-mail: fix vm test for v0.6.0 ``                              |
| [`d1414f54`](https://github.com/NixOS/nixpkgs/commit/d1414f543e40172dfd20e5a42ccd8c9108219693) | `` python311Packages.snakemake: 8.11.3 -> 8.11.4 (#311726) ``                  |
| [`f4c5060e`](https://github.com/NixOS/nixpkgs/commit/f4c5060ecc3367c71265fa5f3410e51a4b4a260e) | `` nixos/stalwart-mail: set default lookup storage ``                          |
| [`98bd35c2`](https://github.com/NixOS/nixpkgs/commit/98bd35c20c6092951605a2d33aea4ff6a8a26f5c) | `` linuxPackages.ena: patch kcompat.h for explicit compatibility with < 6.8 `` |
| [`32d27b3c`](https://github.com/NixOS/nixpkgs/commit/32d27b3cca0b48030957bcc6a5922f84549ddf1f) | `` pyright: 1.1.361 -> 1.1.362 ``                                              |
| [`9eff372d`](https://github.com/NixOS/nixpkgs/commit/9eff372d39fc497f46a86f44675bc5b853082d5c) | `` python311Packages.argilla: 1.27.0 -> 1.28.0 ``                              |
| [`5eb28724`](https://github.com/NixOS/nixpkgs/commit/5eb28724fe3a05a6bb9b9f5cbd44c5d73526c6a9) | `` virtualbox: add passthru.tests ``                                           |
| [`43332773`](https://github.com/NixOS/nixpkgs/commit/433327733ca5ae742d67cba8471e76d378faae68) | `` python3Packages.pyqtgraph: mark as broken if python newer than 3.12 ``      |
| [`9307cdbb`](https://github.com/NixOS/nixpkgs/commit/9307cdbbeb1f55c37cc97dadfffa0a6c748d123b) | `` flexget: 3.11.31 -> 3.11.33 ``                                              |
| [`f6236777`](https://github.com/NixOS/nixpkgs/commit/f62367776ff350ac2429abe2252e48376b89c37f) | `` openclonk: 8.1 -> unstable-2023-10-30 ``                                    |
| [`ba8f2950`](https://github.com/NixOS/nixpkgs/commit/ba8f29504a665116fc48affa885a1b03e58e5146) | `` hurl: 4.2.0 -> 4.3.0 ``                                                     |
| [`a1e8cbb3`](https://github.com/NixOS/nixpkgs/commit/a1e8cbb3fc342ea1efedbb1b8d4d720678993b4b) | `` python311Packages.tabula-py: 2.9.0 -> 2.9.1 ``                              |
| [`2292d443`](https://github.com/NixOS/nixpkgs/commit/2292d443699fa2169bfd28ef0bb8bb8bfdf49602) | `` ast-grep: 0.21.4 -> 0.22.3 ``                                               |
| [`5d5ab9a6`](https://github.com/NixOS/nixpkgs/commit/5d5ab9a63e81d269d63a7bcf511fc85e20c08fbd) | `` python312Packages.google-cloud-bigquery: 3.21.0 -> 3.22.0 ``                |
| [`b51053ad`](https://github.com/NixOS/nixpkgs/commit/b51053ad88c7ae4e0e676a7b1e1a58393bef0017) | `` python3Packages.orange3: fix test ``                                        |
| [`c29c7f5f`](https://github.com/NixOS/nixpkgs/commit/c29c7f5f91d8e655f2f38fb58a07fb186df224a7) | `` python3Packages.widget-base: 4.23.0 -> 4.22.0 ``                            |
| [`cb0423e7`](https://github.com/NixOS/nixpkgs/commit/cb0423e75f03533d8652834fe6878cea4925bb04) | `` python3Packages.orange-canvas-core: 0.2.0 -> 0.1.35 ``                      |
| [`9f3fff83`](https://github.com/NixOS/nixpkgs/commit/9f3fff8353f49ffd4779b9cf3efd49fbd4bc8a06) | `` whatsapp-emoji-font: 2.24.2.76-1 -> 2.24.8.85-1 ``                          |
| [`55574da3`](https://github.com/NixOS/nixpkgs/commit/55574da31d50242459c1e13ca4ee899c3065c8d1) | `` python312Packages.google-cloud-bigquery-storage: 2.24.0 -> 2.25.0 ``        |
| [`8d1874f2`](https://github.com/NixOS/nixpkgs/commit/8d1874f25d7c14fd634610ded556d89a55e34872) | `` python312Packages.google-cloud-dlp: 3.16.0 -> 3.17.0 ``                     |
| [`142f5de0`](https://github.com/NixOS/nixpkgs/commit/142f5de0fb96780d482669324ddcb97bbd09074e) | `` python312Packages.pynmeagps: refactor ``                                    |
| [`820db7f2`](https://github.com/NixOS/nixpkgs/commit/820db7f250f6ee3a38ae3dbc7e49414bdb16e530) | `` python311Packages.ldappool: fix build, use pyproject = true, clean up ``    |
| [`69b9b662`](https://github.com/NixOS/nixpkgs/commit/69b9b662a33c569e4e5020bd8a6dae40efe4714c) | `` python311Packages.openai-triton: fix `meta.platform` ``                     |
| [`b39a6cb3`](https://github.com/NixOS/nixpkgs/commit/b39a6cb3dedeb9ca177c04f4b3b930a71c0271e3) | `` python311Packages.openai-whisper: fix Darwin build ``                       |
| [`22666a6c`](https://github.com/NixOS/nixpkgs/commit/22666a6cbfe50d7e1cef9615544b4477d2e833a7) | `` nushell: 0.92.1 -> 0.93.0 ``                                                |
| [`2ec7c081`](https://github.com/NixOS/nixpkgs/commit/2ec7c081dfbc38403726ed0c1aeedb4cfc8dd3c6) | `` python311Packages.filedate: init at 3.0 ``                                  |
| [`836a8bbe`](https://github.com/NixOS/nixpkgs/commit/836a8bbeb98e150031477d89811ec8b9da97e58d) | `` snipe-it: 6.3.4 -> 6.4.1 ``                                                 |
| [`bb99280c`](https://github.com/NixOS/nixpkgs/commit/bb99280c9c4e56e427522b5689f56527db3a1280) | `` nixosTests.virtualbox: remove minimal profile ``                            |
| [`d0b70795`](https://github.com/NixOS/nixpkgs/commit/d0b707950b7fe5a0c868ab5468890d17379317fd) | `` surrealdb: 1.4.2 -> 1.5.0 ``                                                |
| [`a96fbdc7`](https://github.com/NixOS/nixpkgs/commit/a96fbdc763bf46f2f10503ec0ebceec08c818587) | `` python3Packages.django-allauth: compile `.mo` files ``                      |
| [`6fc3ccd9`](https://github.com/NixOS/nixpkgs/commit/6fc3ccd95ada9aa6a86459f5dae638f55c9ea964) | `` workflows/check-by-name: Skip instead of canceling on conflicts ``          |
| [`4b051a67`](https://github.com/NixOS/nixpkgs/commit/4b051a679727e16efda23b53a995b06b0d67c92d) | `` python312Packages.pyais: init at 2.6.5 ``                                   |
| [`9e68ee2e`](https://github.com/NixOS/nixpkgs/commit/9e68ee2e296a88976ec3ce2e3cd818a872bf6e4f) | `` oh-my-posh: 19.27.0 -> 19.29.0 ``                                           |
| [`5f6fe961`](https://github.com/NixOS/nixpkgs/commit/5f6fe961b9f7fd8831ff77ee41ee73e024844aef) | `` python312Packages.requirements-detector: mark as broken ``                  |
| [`9a225893`](https://github.com/NixOS/nixpkgs/commit/9a2258930a8f71adba6f512b8a041c489c26c919) | `` moneydance: 2023.3_5064 -> 2024.1_5118 ``                                   |
| [`baccd57d`](https://github.com/NixOS/nixpkgs/commit/baccd57dd2c2656291372c6ad57581eae0fb600f) | `` python312Packages.requirements-detector: refactor ``                        |
| [`2be62737`](https://github.com/NixOS/nixpkgs/commit/2be62737abeab75de00c7d363e50a1c57e5b72b8) | `` openvas-scanner: 23.2.0 -> 23.2.1 ``                                        |
| [`bdfbe9f9`](https://github.com/NixOS/nixpkgs/commit/bdfbe9f9d099c27d8a50a6ef816229f8e2d34956) | `` moar: 1.23.12 -> 1.23.14 ``                                                 |
| [`f74e4dbe`](https://github.com/NixOS/nixpkgs/commit/f74e4dbe6db703e0601542508513d01fdf56ae31) | `` minio: 2024-05-01T01-11-10Z -> 2024-05-10T01-41-38Z ``                      |
| [`90b56b0b`](https://github.com/NixOS/nixpkgs/commit/90b56b0b892841cf9afc362a36661358e8b19059) | `` limine: 7.5.0 -> 7.5.1 ``                                                   |
| [`9ec24862`](https://github.com/NixOS/nixpkgs/commit/9ec2486208b0d28898e45d7f5769c91d7efc6768) | `` recoll: wrap rcljoplin.py ``                                                |