### PR TITLE
chore(flake/flake-parts): `e5d10a24` -> `8dc45382`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -256,11 +256,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                  |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`411e5ab0`](https://github.com/hercules-ci/flake-parts/commit/411e5ab0e88c0127a974e45394c166035f8c50ee) | `` Add class: imports "type checking" `` |
| [`b5ab46fe`](https://github.com/hercules-ci/flake-parts/commit/b5ab46fe037461bbf92e9ffa0f7538b40c11bed3) | `` maint: Remove lib.mdDoc calls ``      |