### PR TITLE
chore(flake/nix-index-database): `6b94c48c` -> `e0638db3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716088072,
-        "narHash": "sha256-ZXzV39r4ShjS6lvhOX+oN0Vazg5A/zibJDzE2r1jlRM=",
+        "lastModified": 1716170277,
+        "narHash": "sha256-fCAiox/TuzWGVaAz16PxrR4Jtf9lN5dwWL2W74DS0yI=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6b94c48c3bb22d5181333c3fb71beff44116e251",
+        "rev": "e0638db3db43b582512a7de8c0f8363a162842b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                         |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`e0638db3`](https://github.com/nix-community/nix-index-database/commit/e0638db3db43b582512a7de8c0f8363a162842b9) | `` build(deps): bump cachix/install-nix-action from 26 to 27 `` |