### PR TITLE
chore(flake/git-hooks): `fa606ccc` -> `0e8fcc54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715870890,
-        "narHash": "sha256-nacSOeXtUEM77Gn0G4bTdEOeFIrkCBXiyyFZtdGwuH0=",
+        "lastModified": 1716213921,
+        "narHash": "sha256-xrsYFST8ij4QWaV6HEokCUNIZLjjLP1bYC60K8XiBVA=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "fa606cccd7b0ccebe2880051208e4a0f61bfc8c1",
+        "rev": "0e8fcc54b842ad8428c9e705cb5994eaf05c26a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`10a15426`](https://github.com/cachix/git-hooks.nix/commit/10a15426814594c35507c1c122bc9a7a1f92a119) | `` Include hpack in the hpack dir output `` |