### PR TITLE
chore(flake/stylix): `76e7daf5` -> `81df8443`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716037261,
-        "narHash": "sha256-eF0A36GdegKkEiwFArjCysGU/XEYvzj7x5jfkFMtmqM=",
+        "lastModified": 1716206302,
+        "narHash": "sha256-5Qc3aQGVyPEOuN82zVamStaV81HebHvLjk3fGfpyCPY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "76e7daf5a16d442ac98e844582f7dc1354610886",
+        "rev": "81df8443556335016d6f0bc22630a95776a56d8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                    |
| --------------------------------------------------------------------------------------------- | -------------------------- |
| [`81df8443`](https://github.com/danth/stylix/commit/81df8443556335016d6f0bc22630a95776a56d8b) | `` vesktop: init (#365) `` |