### PR TITLE
chore(flake/nixvim-flake): `5963e085` -> `8997f3a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1716192498,
-        "narHash": "sha256-InEctfSjPgeu4DjJKUtQY/guQKmpGIi0+CwnbbVfoxY=",
+        "lastModified": 1716326274,
+        "narHash": "sha256-1LyTvpjb8Cmlg3TRnP56rvqK1WSNa518pD6F0tjgM+U=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "169d7f4dc0df90820f50e00d8764a6cec5445fa9",
+        "rev": "5d2e01495944dcf7cf7ee53a7074c4010165d756",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1716340353,
-        "narHash": "sha256-6H/OVGSmUXen4QVoa0QH27MYNLJxpYlJdL3kwMDOuqs=",
+        "lastModified": 1716355485,
+        "narHash": "sha256-rwer3oNE9ncjwaz0MhTT1fHEhFPNqzBtxHVOHJoekgU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5963e0858fc80184b3c9526454b24cefafcf383d",
+        "rev": "8997f3a6168f1dea68edd86e2641a747e94c3b24",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                 |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
| [`8997f3a6`](https://github.com/alesauce/nixvim-flake/commit/8997f3a6168f1dea68edd86e2641a747e94c3b24) | `` removing get-attrs until I am smart enough to actually build a useful ci workflow `` |
| [`9cb04ccc`](https://github.com/alesauce/nixvim-flake/commit/9cb04ccc7f3113f1ac11c472e2459248cd1c2118) | `` testing out new way to get jq from flake ``                                          |
| [`e47dd925`](https://github.com/alesauce/nixvim-flake/commit/e47dd9253ad50f2f2bd586939389438974695d17) | `` chore(flake/nixvim): 169d7f4d -> 5d2e0149 ``                                         |
| [`31ccc1f5`](https://github.com/alesauce/nixvim-flake/commit/31ccc1f59bedca248b716822af8c3f72f93d77ef) | `` testing out new way to get jq from flake ``                                          |
| [`0ab0945e`](https://github.com/alesauce/nixvim-flake/commit/0ab0945e6de8fc225de8129cca81f8844671feeb) | `` testing out new way to get jq from flake ``                                          |
| [`0eedb414`](https://github.com/alesauce/nixvim-flake/commit/0eedb414d0f29284e503bfc2abd57f842c0abe09) | `` Updating ci workflow and config names ``                                             |