### PR TITLE
chore(flake/stylix): `81df8443` -> `23cbb966`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716206302,
-        "narHash": "sha256-5Qc3aQGVyPEOuN82zVamStaV81HebHvLjk3fGfpyCPY=",
+        "lastModified": 1716393259,
+        "narHash": "sha256-tIIbKFR3dARgNsppfgMd1zdVCk2Jzw96pEotODDi2dY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "81df8443556335016d6f0bc22630a95776a56d8b",
+        "rev": "23cbb966386dda61720266ec4406b6633ba07317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`23cbb966`](https://github.com/danth/stylix/commit/23cbb966386dda61720266ec4406b6633ba07317) | `` doc: refresh screenshots (#382) ``         |
| [`f9bf9764`](https://github.com/danth/stylix/commit/f9bf97645b41c5fcf28f044ab2b72f1b60a8ef9c) | `` doc: mention YouTube video guide (#384) `` |