### PR TITLE
chore(flake/home-manager): `e3ad5108` -> `850cb322`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1716457508,
+        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`850cb322`](https://github.com/nix-community/home-manager/commit/850cb322046ef1a268449cf1ceda5fd24d930b05) | `` ci: make dependabot consider the release-24.05 `` |
| [`25dedb0d`](https://github.com/nix-community/home-manager/commit/25dedb0d52c20448f6a63cc346df1adbd6ef417e) | `` version: allow 24.11 as state version ``          |