### PR TITLE
chore(flake/nixvim-flake): `20f51fc3` -> `48976683`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1716501867,
-        "narHash": "sha256-4ytMzHH3E3TTBnNv7w+v0JH+nln0kgAR8ODIC7oPuZk=",
+        "lastModified": 1716566815,
+        "narHash": "sha256-WO3MF4W1SrSD0lanU1n7dfuHizeSLfDHJNEir9exlcM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "56aaef010ad9afae1730337e8ce71060fbcaa542",
+        "rev": "9d858de2e9ab136d1c53d92af62fed8fccf492ab",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1716528168,
-        "narHash": "sha256-2RWdqejISUfIy8HcVak6rQrhXZ8q7n4zMMM9WlCrVV8=",
+        "lastModified": 1716567684,
+        "narHash": "sha256-V6E1Xi3sMM2mAlzybas+mHkD3E2g4CSl6apUXsfZdmY=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "20f51fc33ab29fcddd49560d19b743d7c5c5fc76",
+        "rev": "48976683e3ab5764f78ab7d1066bc71d9b93e52b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`48976683`](https://github.com/alesauce/nixvim-flake/commit/48976683e3ab5764f78ab7d1066bc71d9b93e52b) | `` chore(flake/nixvim): 56aaef01 -> 9d858de2 `` |