### PR TITLE
chore(flake/home-manager): `850cb322` -> `e4611630`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716457508,
-        "narHash": "sha256-ZxzffLuWRyuMrkVVq7wastNUqeO0HJL9xqfY1QsYaqo=",
+        "lastModified": 1716679503,
+        "narHash": "sha256-aX8AEWHLwuiYX8OCpTnHGrQeei1Gb+AGbk1hq+RIClg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "850cb322046ef1a268449cf1ceda5fd24d930b05",
+        "rev": "e4611630c3cc8ed618b48d92f6291f65be9f7913",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`e4611630`](https://github.com/nix-community/home-manager/commit/e4611630c3cc8ed618b48d92f6291f65be9f7913) | `` ci: fix manual build in sourcehut build `` |
| [`d179da4e`](https://github.com/nix-community/home-manager/commit/d179da4e81bcd4227e8abf4b62b92c4ae214ae39) | `` home-manager: prepare 24.11-pre ``         |
| [`548ba194`](https://github.com/nix-community/home-manager/commit/548ba194d0676849424657cc41c59ab57d94b344) | `` home-manager: prepare release 24.05 ``     |