### PR TITLE
chore(flake/nix-index-database): `e0638db3` -> `6e4a2b3b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716170277,
-        "narHash": "sha256-fCAiox/TuzWGVaAz16PxrR4Jtf9lN5dwWL2W74DS0yI=",
+        "lastModified": 1716692972,
+        "narHash": "sha256-gz3UiLa5mdd+AoOD/p//sdTty0vWk0BLOieTM+F6dGQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e0638db3db43b582512a7de8c0f8363a162842b9",
+        "rev": "6e4a2b3b7c60aae5dac8c21117a134a4a56648da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`6e4a2b3b`](https://github.com/nix-community/nix-index-database/commit/6e4a2b3b7c60aae5dac8c21117a134a4a56648da) | `` update packages.nix to release 2024-05-26-030820 `` |
| [`693705f2`](https://github.com/nix-community/nix-index-database/commit/693705f22a9d378c203ad5304a7e630c6b03048f) | `` flake.lock: Update ``                               |