### PR TITLE
chore(flake/home-manager): `6a35d196` -> `5d151429`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716711215,
-        "narHash": "sha256-0koEdYN3XOE1ECwWvFdPgI/709jrXYNo8nKDoQe2p3U=",
+        "lastModified": 1716736760,
+        "narHash": "sha256-h3RmnNknKYtVA+EvUSra6QAwfZjC2q1G8YA7W0gat8Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6a35d1969e4626a0f8d285e60b6cfd331e2687a9",
+        "rev": "5d151429e1e79107acf6d06dcc5ace4e642ec239",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`5d151429`](https://github.com/nix-community/home-manager/commit/5d151429e1e79107acf6d06dcc5ace4e642ec239) | `` kanshi: fix configuration example ``              |
| [`b2a4ddf6`](https://github.com/nix-community/home-manager/commit/b2a4ddf657e6ad87569665545ffaf7dd5e9a02af) | `` flake.lock: Update ``                             |
| [`05e6ba83`](https://github.com/nix-community/home-manager/commit/05e6ba83eb3585ce0aff7b41e4bd0e317d05ad4a) | `` Translate using Weblate (Danish) ``               |
| [`517682ed`](https://github.com/nix-community/home-manager/commit/517682ed21a19c193f09f043ecd8dc4002a962c3) | `` Translate using Weblate (Japanese) ``             |
| [`cd29501b`](https://github.com/nix-community/home-manager/commit/cd29501b799c2621276376fb714cd2532fb2f0f7) | `` Translate using Weblate (Japanese) ``             |
| [`943f1e97`](https://github.com/nix-community/home-manager/commit/943f1e97fc171476f0235d7657448f9315465f18) | `` Translate using Weblate (German) ``               |
| [`fb7feac5`](https://github.com/nix-community/home-manager/commit/fb7feac55b2b95692b58e388a608fc326ec66608) | `` Translate using Weblate (Chinese (Simplified)) `` |