### PR TITLE
chore(flake/nixvim-flake): `86c2ab59` -> `f2c2852c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1716673923,
-        "narHash": "sha256-2u/NXh4FBbj8myQJTd3Are+a+qvhkXeqnpT/jq6VX2s=",
+        "lastModified": 1716759197,
+        "narHash": "sha256-I4r9krPVUl1b70VbC8j8xDQ2mDBoGCx8tH9CExiJMd8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1cc2e02fcaabd224348fa0dbfeb311063787a060",
+        "rev": "ba293d36403c39c22dbb9a928f9af4d0df54b79f",
         "type": "github"
       },
       "original": {
@@ -655,11 +655,11 @@
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
-        "lastModified": 1716686380,
-        "narHash": "sha256-ifKY7A5vuX6JySU455ojH3/mXTtnQSgUZlQo45ccnNk=",
+        "lastModified": 1716772540,
+        "narHash": "sha256-PHTzScWiuu/G9ZuCsCqcGzLtLhWrg3TxlG0B/Q0F6iw=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "86c2ab59d5cb25a81a3ef5ac1f622052657566b1",
+        "rev": "f2c2852cf62a583d3a235105389bea924db3ac5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                         |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`f2c2852c`](https://github.com/alesauce/nixvim-flake/commit/f2c2852cf62a583d3a235105389bea924db3ac5b) | `` chore(flake/nixvim): 23276f62 -> ba293d36 ``                 |
| [`b3ae5f6c`](https://github.com/alesauce/nixvim-flake/commit/b3ae5f6c5c9629bbc55808f37fe111c69e29f02b) | `` changing jdtls to using lib.gexExe to fix executable path `` |
| [`1ba5d862`](https://github.com/alesauce/nixvim-flake/commit/1ba5d86285c2afd045175bc7b6d7c205527a52ef) | `` chore(flake/nixvim): 1cc2e02f -> 23276f62 ``                 |