### PR TITLE
chore(flake/home-manager): `5d151429` -> `10c7c219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -453,11 +453,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716736760,
-        "narHash": "sha256-h3RmnNknKYtVA+EvUSra6QAwfZjC2q1G8YA7W0gat8Y=",
+        "lastModified": 1716847642,
+        "narHash": "sha256-rjEswRV0o23eBBils8lJXyIGha+l/VjV73IPg+ztxgk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5d151429e1e79107acf6d06dcc5ace4e642ec239",
+        "rev": "10c7c219b7dae5795fb67f465a0d86cbe29f25fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`10c7c219`](https://github.com/nix-community/home-manager/commit/10c7c219b7dae5795fb67f465a0d86cbe29f25fa) | `` listenbrainz-mpd: fix config example ``              |
| [`90010df1`](https://github.com/nix-community/home-manager/commit/90010df15878762ff359e4fe391355a9dcad0bcf) | `` topgrade: update example config ``                   |
| [`939375b3`](https://github.com/nix-community/home-manager/commit/939375b39661c7b5d2533c9cd7be6117ed98896a) | `` khal: add package option ``                          |
| [`7e769959`](https://github.com/nix-community/home-manager/commit/7e769959e8ec80333bb262d685333003bf013c1b) | `` hyprland: onChange: remove subshell comment ``       |
| [`7ac529c2`](https://github.com/nix-community/home-manager/commit/7ac529c22129ee9fb024744ede18f73e6b148ede) | `` hyprland: onChange: check XDG_RUNTIME_DIR as well `` |
| [`0cf552f3`](https://github.com/nix-community/home-manager/commit/0cf552f39f1f8567a8e76e14c90e2843634182b5) | `` bash: add missing 'ignoreboth' to historyControl ``  |
| [`e8482a79`](https://github.com/nix-community/home-manager/commit/e8482a798fd85d6316dcf42387ad30b3a079585e) | `` yazi: use builtin cd ``                              |
| [`65e0f5aa`](https://github.com/nix-community/home-manager/commit/65e0f5aa25619ee992e1eb3ad69f227a46b0a1b1) | `` eza: don't create shell aliases with empty args ``   |
| [`8f8eb15c`](https://github.com/nix-community/home-manager/commit/8f8eb15c6d66afa7eef0dd6357bbb41c3aeb1099) | `` fd: don't create shell aliases with empty args ``    |