### PR TITLE
chore(flake/stylix): `00a11ba2` -> `5234b3d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716744577,
-        "narHash": "sha256-YvYYKLuf+SNj129k6SS/bhVybaLYgUlnznTa7rKv904=",
+        "lastModified": 1716895458,
+        "narHash": "sha256-W9Y/+K4L7JcF5xcXO4MVGQk/0DgzHrp/IjlHyLeYExY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "00a11ba2f0b52f761c0bc77daebb00cb4d44ba09",
+        "rev": "5234b3d467aa803ad8d3fe898ef5673246045984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`5234b3d4`](https://github.com/danth/stylix/commit/5234b3d467aa803ad8d3fe898ef5673246045984) | `` gnome: use internal `mkEnableTarget` function (#397) `` |
| [`659dd55a`](https://github.com/danth/stylix/commit/659dd55a32e79d4e17be0d10dfcbc1862e39ef5a) | `` waybar: put font-family string in quotes (#391) ``      |