### PR TITLE
chore(flake/nixvim-flake): `9fe6d1d8` -> `a58c4c6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -659,11 +659,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1716925245,
-        "narHash": "sha256-MO32KGgZUiWWsDYu93H47iOGWNlXO9BVOMrZzauZKCc=",
+        "lastModified": 1716961281,
+        "narHash": "sha256-rUSuwmGdd5yLJc1RHDR3mXGTJJ/fKRtqr26MU78Lnvc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "56d39f54fe11776ba83903ec077bffc7a7d0e638",
+        "rev": "cf037458ddc16f1b0d037630546760ecad0231c3",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1716945492,
-        "narHash": "sha256-JHppDI0WEbTQgDbB3y3J4XLx7WxzMprBnG+fplvr6oo=",
+        "lastModified": 1716971085,
+        "narHash": "sha256-qvqJdJM0KIwmM2j8IX5lvmAzMJk0C1ODVcI+PyVa1MI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "9fe6d1d8928c61ee72bdba3576153cc5d820affb",
+        "rev": "a58c4c6d755a70a9a913bbc5b95dba6a2e0eb371",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`a58c4c6d`](https://github.com/alesauce/nixvim-flake/commit/a58c4c6d755a70a9a913bbc5b95dba6a2e0eb371) | `` chore(flake/nixvim): 56d39f54 -> cf037458 `` |