### PR TITLE
chore(flake/darwin): `0bea8222` -> `c0d5b8c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716511055,
-        "narHash": "sha256-5Fe/DGgvMhPEMl9VdVxv3zvwRcwNDmW5eRJ0gk72w7U=",
+        "lastModified": 1716993688,
+        "narHash": "sha256-vo5k2wQekfeoq/2aleQkBN41dQiQHNTniZeVONWiWLs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0bea8222f6e83247dd13b055d83e64bce02ee532",
+        "rev": "c0d5b8c54d6828516c97f6be9f2d00c63a363df4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`9639c550`](https://github.com/LnL7/nix-darwin/commit/9639c5509b148381c5d832204a1d3704b7d7ec60) | `` Update modules/system/defaults/NSGlobalDomain.nix `` |
| [`2e0f9a9e`](https://github.com/LnL7/nix-darwin/commit/2e0f9a9e500addf92844f09a4970617629c53cf1) | `` Update NSGlobalDomain.nix ``                         |
| [`0e5fc002`](https://github.com/LnL7/nix-darwin/commit/0e5fc0028b278f23db0de9ea75d8a1a9b1f9dcf8) | `` Update NSGlobalDomain.nix ``                         |
| [`120e085d`](https://github.com/LnL7/nix-darwin/commit/120e085d1ac1b15a5cffc1f980f49665f211e080) | `` Update NSGlobalDomain.nix ``                         |
| [`6cbe6bc2`](https://github.com/LnL7/nix-darwin/commit/6cbe6bc2da267273c55ee08eaaeebfbc7dfcdf30) | `` Update trackpad.nix ``                               |