### PR TITLE
chore(flake/home-manager): `1b589257` -> `29c69d9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717020155,
-        "narHash": "sha256-Xpyv9i02ineeGakmmzd45hkBgy2a7Zf/3d6amM6MUb4=",
+        "lastModified": 1717052710,
+        "narHash": "sha256-LRhOxzXmOza5SymhOgnEzA8EAQp+94kkeUYWKKpLJ/U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1b589257f72c9c54e92d1d631e988e5346156736",
+        "rev": "29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`29c69d9a`](https://github.com/nix-community/home-manager/commit/29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae) | `` kdeconnect: fix service with 24.05 package version `` |
| [`60b85414`](https://github.com/nix-community/home-manager/commit/60b85414b49d5d69816c2453865adb6cc39df33a) | `` Translate using Weblate (Korean) ``                   |