### PR TITLE
chore(flake/home-manager): `29c69d9a` -> `0eb314b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717052710,
-        "narHash": "sha256-LRhOxzXmOza5SymhOgnEzA8EAQp+94kkeUYWKKpLJ/U=",
+        "lastModified": 1717097707,
+        "narHash": "sha256-HC5vJ3oYsjwsCaSbkIPv80e4ebJpNvFKQTBOGlHvjLs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae",
+        "rev": "0eb314b4f0ba337e88123e0b1e57ef58346aafd9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`0eb314b4`](https://github.com/nix-community/home-manager/commit/0eb314b4f0ba337e88123e0b1e57ef58346aafd9) | `` home-manager: use short -f instead of --fqdn `` |