### PR TITLE
chore(flake/nixvim-flake): `7b7ad747` -> `72c81d4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -684,11 +684,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717118148,
-        "narHash": "sha256-LoSFj2gSTmdHviUMx+uXm0Dix4WyPuPVnCiSWJ9Io6A=",
+        "lastModified": 1717121803,
+        "narHash": "sha256-VmNi7U9nanTngSjhKuGWBFZyo0xSPy4TLm2WU+PNBBg=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "7b7ad747112a3747b1c0d8d27d72098b54d1c5cf",
+        "rev": "72c81d4f5013ced112f875520064cb66d8556371",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                    |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`72c81d4f`](https://github.com/alesauce/nixvim-flake/commit/72c81d4f5013ced112f875520064cb66d8556371) | `` Updating README ``                                      |
| [`8aa9d9a7`](https://github.com/alesauce/nixvim-flake/commit/8aa9d9a7bec6d6c88b148635ee28e48b456ac544) | `` removing lombok flag from jdtls init. jdt config WIP `` |