### PR TITLE
chore(flake/stylix): `5234b3d4` -> `99bcaa55`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -754,11 +754,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716895458,
-        "narHash": "sha256-W9Y/+K4L7JcF5xcXO4MVGQk/0DgzHrp/IjlHyLeYExY=",
+        "lastModified": 1717201670,
+        "narHash": "sha256-7tXlevpGhg+73g53RAS8gEOglTf9fPdVMlTOn8r7XAk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5234b3d467aa803ad8d3fe898ef5673246045984",
+        "rev": "99bcaa552096ccff21658a9eb6a1e8397b10eb78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                          |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`99bcaa55`](https://github.com/danth/stylix/commit/99bcaa552096ccff21658a9eb6a1e8397b10eb78) | `` stylix: standardize `autoEnable` and `mkEnableTarget` documentation (#398) `` |
| [`ebaed9d4`](https://github.com/danth/stylix/commit/ebaed9d4bf258f4eda7d0690c4092fadcbeefa9d) | `` console: adjust colors (#404) ``                                              |