### PR TITLE
chore(flake/nixvim-flake): `52fe4406` -> `250c4629`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -659,11 +659,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1717274692,
-        "narHash": "sha256-CnMCPxY9GfBAONN3BoWmPc36QV5Sv9uZFKH9VkE5KJI=",
+        "lastModified": 1717367392,
+        "narHash": "sha256-7Kpbdp6muCCggQqYPVl0wqxuEE7Gf5b/IZwMWP7MouM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e58380adcddc450eb08c37760a3f282077386d19",
+        "rev": "514413f6316a9a37648ba87e7519b148d66bd042",
         "type": "github"
       },
       "original": {
@@ -684,11 +684,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717316503,
-        "narHash": "sha256-rV/I/ERVw/+HGy3lx9aAU8AD79HcNeiTKuXk09xQ7kw=",
+        "lastModified": 1717377406,
+        "narHash": "sha256-0Kx/69uqdYEhkKrVXS1XpbJ8l+l6sAPWX5oq8fP9uIY=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "52fe440663993a92985e8c17f6a448c86898b2ef",
+        "rev": "250c462993addb072feae7aea7db90c94409c177",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`250c4629`](https://github.com/alesauce/nixvim-flake/commit/250c462993addb072feae7aea7db90c94409c177) | `` chore(flake/nixvim): f7e009d2 -> 514413f6 `` |
| [`4699e8ba`](https://github.com/alesauce/nixvim-flake/commit/4699e8ba2e02c8b69dc14d2b6da70a404546497c) | `` chore(flake/nixvim): e58380ad -> f7e009d2 `` |