### PR TITLE
chore(flake/home-manager): `9b53a10f` -> `2cacdd6a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -482,11 +482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717316182,
-        "narHash": "sha256-Xi0EpZcu39N0eW7apLjFfUOR9y80toyjYizez7J1wMI=",
+        "lastModified": 1717483170,
+        "narHash": "sha256-Xr/oYk3vmyv2a/nY8o/Wd0MdLsI5vaC38Kris7CWunM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b53a10f4c91892f5af87cf55d08fba59ca086af",
+        "rev": "2cacdd6a27477f1fa46b7026dd806de30f164d3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`2cacdd6a`](https://github.com/nix-community/home-manager/commit/2cacdd6a27477f1fa46b7026dd806de30f164d3b) | `` ci/labeler: fix upgrade to v5 format ``    |
| [`1a577c13`](https://github.com/nix-community/home-manager/commit/1a577c135cad84eb0cd5a922efe2de9cc467772a) | `` ci/labeler: upgrade to v5 format ``        |
| [`07b2c41d`](https://github.com/nix-community/home-manager/commit/07b2c41d2df2878a5c71229a66fb1f8ccef71c47) | `` ci: bump all actions versions (#5496) ``   |
| [`83bfe1ba`](https://github.com/nix-community/home-manager/commit/83bfe1bac8e0d930f36cee6874bd17e77c8754d1) | `` nix-gc: add `persistent` option (#5490) `` |