### PR TITLE
chore(flake/nixvim-flake): `38f1dbd1` -> `f71f26d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,21 +291,6 @@
         "type": "github"
       }
     },
-    "flake-root": {
-      "locked": {
-        "lastModified": 1713493429,
-        "narHash": "sha256-ztz8JQkI08tjKnsTpfLqzWoKFQF4JGu2LRz8bkdnYUk=",
-        "owner": "srid",
-        "repo": "flake-root",
-        "rev": "bc748b93b86ee76e2032eecda33440ceb2532fcd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "srid",
-        "repo": "flake-root",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -648,7 +633,6 @@
         "devshell": "devshell",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
-        "flake-root": "flake-root",
         "git-hooks": "git-hooks_2",
         "home-manager": "home-manager_2",
         "nix-darwin": "nix-darwin",
@@ -659,11 +643,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1717522463,
-        "narHash": "sha256-GYmgttJ7Dzs84Fb8wYsnF6KaQCafp99gKQaQWTvV/wo=",
+        "lastModified": 1717607611,
+        "narHash": "sha256-lpyXoLb/DhbPNl59wc64NWX4ZySfqDFiXtYaRgPb5ho=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cfff48c2673bb7ac2841201ed700d332b6d643ab",
+        "rev": "f530700ccd2955ceb620cd12fc1f5b04d2c752f4",
         "type": "github"
       },
       "original": {
@@ -684,11 +668,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717558289,
-        "narHash": "sha256-yYqr1rgIpDJgyRDc2AHR/F6NO8re7X5gt9fSOfdHpsE=",
+        "lastModified": 1717636540,
+        "narHash": "sha256-fxMGy0HtELpr/W12PS8GQOhRcGAy8KlqJjFzZV5IbYs=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "38f1dbd1eeaa9cfd3065f5a2d2c8e3b9c25da50b",
+        "rev": "f71f26d0ae3fa7c0f833d6c3f89d4d0d17e07c61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`f71f26d0`](https://github.com/alesauce/nixvim-flake/commit/f71f26d0ae3fa7c0f833d6c3f89d4d0d17e07c61) | `` chore(flake/nixvim): cfff48c2 -> f530700c `` |