### PR TITLE
chore(flake/nixpkgs): `57610d2f` -> `cb0317c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -570,11 +570,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717196966,
-        "narHash": "sha256-yZKhxVIKd2lsbOqYd5iDoUIwsRZFqE87smE2Vzf6Ck0=",
+        "lastModified": 1717384422,
+        "narHash": "sha256-sQ1FBYvO4SoZwoRvUIDY94hQyg+uqakG0UMClRbqyG4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "57610d2f8f0937f39dbd72251e9614b1561942d8",
+        "rev": "cb0317c4552b5639d7e2d85d2adbf4b9de0ff0d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`1c8e6101`](https://github.com/NixOS/nixpkgs/commit/1c8e6101197b0e3895ebdb4fbd967ea18f3875c3) | `` glances: reformat and update dependencies ``                      |
| [`0c66b010`](https://github.com/NixOS/nixpkgs/commit/0c66b01048e26cfd0de41c60af06ad2024c6fd41) | `` ejson2env: add tests ``                                           |
| [`da799551`](https://github.com/NixOS/nixpkgs/commit/da799551a49f67f3586f6205cb88a0de3d9c26c8) | `` nixos/proxmox-lxc: fix console access (#307163) ``                |
| [`7c0937d6`](https://github.com/NixOS/nixpkgs/commit/7c0937d6689916e9d8b4c43de665e7e628bb35f9) | `` nixos/nextcloud-notify_push: use `Type=notify` ``                 |
| [`a8e75ef7`](https://github.com/NixOS/nixpkgs/commit/a8e75ef7d4c4825e789491dec55e161cc9a73d2d) | `` python3Packages.libnbd: init at 1.18.2 (#313358) ``               |
| [`ea63e59e`](https://github.com/NixOS/nixpkgs/commit/ea63e59edc22b42f965fec9d42e77a27e7a52782) | `` nixos/adguardhome: fix typo ``                                    |
| [`b8f7f443`](https://github.com/NixOS/nixpkgs/commit/b8f7f4431e01bcae8a945d54ce5b0b0b1cd8280e) | `` lnd: 0.17.5-beta -> 0.18.0-beta ``                                |
| [`c9e2a2de`](https://github.com/NixOS/nixpkgs/commit/c9e2a2de8c96bc4a6eda369968ce27c1ddab7c93) | `` pgadmin4: 8.6 -> 8.7 ``                                           |
| [`a77c8a1f`](https://github.com/NixOS/nixpkgs/commit/a77c8a1f0456fe78d997acf540656c2e1fdc854b) | `` supergfxctl-plasmoid: init at 2.0.0 (#315196) ``                  |
| [`40c9def8`](https://github.com/NixOS/nixpkgs/commit/40c9def80eeca98c8ca86a7daf1ec0626c59bf60) | `` remove 'babariviere' as a maintainer ``                           |
| [`ca6e0689`](https://github.com/NixOS/nixpkgs/commit/ca6e0689b3319ca383a3ee1cac62a046af3509c7) | `` hunspellDict.tr_TR: init at 1.1.1 (#311416) ``                    |
| [`b3f70c29`](https://github.com/NixOS/nixpkgs/commit/b3f70c29d524e7e33fba4e24ee903fa3ceab0fe8) | `` nixos/containerd: remove LimitNOFILE from service (#313507) ``    |
| [`a8506f49`](https://github.com/NixOS/nixpkgs/commit/a8506f499fe0d781a72829cf2a0c1d2f047afc76) | `` wine64Packages.{unstable,staging}: 9.9 -> 9.10 ``                 |
| [`78ae8350`](https://github.com/NixOS/nixpkgs/commit/78ae8350dc223c7e51b82ed829f0a9ce30b94206) | `` nushell: 0.93.0 -> 0.94.1 ``                                      |
| [`898be2ef`](https://github.com/NixOS/nixpkgs/commit/898be2ef0f52c3feea5041770929a871c2c73777) | `` ccache: make src reproducible ``                                  |
| [`1d5618e0`](https://github.com/NixOS/nixpkgs/commit/1d5618e0ec2289e8c669a404c242ccf3418ea94c) | `` wakatime: rename to wakatime-cli ``                               |
| [`481f0b14`](https://github.com/NixOS/nixpkgs/commit/481f0b1409e555a0e79bcd2e74696de1aa6c2f93) | `` dbgate: init at 5.2.8 ``                                          |
| [`7b53b685`](https://github.com/NixOS/nixpkgs/commit/7b53b685912a6942a61a84ddf30d9f27fa79c44e) | `` renderdoc: 1.32 -> 1.33 ``                                        |
| [`4412282f`](https://github.com/NixOS/nixpkgs/commit/4412282fc03c15d74d015017bf417886904b747a) | `` ipxe: 1.21.1-unstable-2024-04-17 -> 1.21.1-unstable-2024-05-31 `` |
| [`230567ca`](https://github.com/NixOS/nixpkgs/commit/230567caec0c3384ba75ffdb23c66928144239a0) | `` vcmi: 1.5.1 -> 1.5.2 ``                                           |
| [`2de94cff`](https://github.com/NixOS/nixpkgs/commit/2de94cff7f737f1896925ee736c3b1beb5af37db) | `` maa-assistant-arknights: fix output path ``                       |
| [`e897944f`](https://github.com/NixOS/nixpkgs/commit/e897944fded7dd30d733b4fe47e80048aa8dd218) | `` tdf: init at 0-unstable-2024-05-29 ``                             |
| [`96e2a0db`](https://github.com/NixOS/nixpkgs/commit/96e2a0dbd345f23b3a45982947277b46bd444fa6) | `` podman-tui: 1.0.1 -> 1.1.0 ``                                     |