### PR TITLE
chore(flake/stylix): `f0ddd45f` -> `ca3247ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -738,11 +738,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717859878,
-        "narHash": "sha256-4tVJ4y2fRykrlBozQ1t1nSDcseSzpuODabBCQZi72lQ=",
+        "lastModified": 1717866166,
+        "narHash": "sha256-iOeRZXIhFpQJdxzNJ3nUAANyDfLqCslRhjGhLD2RstM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f0ddd45fbe8d72964e4b92701fe2243da7e48937",
+        "rev": "ca3247ed8cfbf369f3fe1b7a421579812a95c101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                        |
| --------------------------------------------------------------------------------------------- | ------------------------------ |
| [`ca3247ed`](https://github.com/danth/stylix/commit/ca3247ed8cfbf369f3fe1b7a421579812a95c101) | `` tofi: use opacity (#410) `` |