### PR TITLE
chore(flake/home-manager): `a7117efb` -> `3d65009e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717525419,
-        "narHash": "sha256-5z2422pzWnPXHgq2ms8lcCfttM0dz+hg+x1pCcNkAws=",
+        "lastModified": 1717931644,
+        "narHash": "sha256-Sz8Wh9cAiD5FhL8UWvZxBfnvxETSCVZlqWSYWaCPyu0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a7117efb3725e6197dd95424136f79147aa35e5b",
+        "rev": "3d65009effd77cb0d6e7520b68b039836a7606cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`3d65009e`](https://github.com/nix-community/home-manager/commit/3d65009effd77cb0d6e7520b68b039836a7606cf) | `` waybar: remove modules-* from defaults ``            |
| [`8a20efbb`](https://github.com/nix-community/home-manager/commit/8a20efbb00b096d7d30211cd306cc360c8eba38c) | `` hyprland: install xwayland if enabled ``             |
| [`885c0371`](https://github.com/nix-community/home-manager/commit/885c037109fdbc05f37da8fa1b81c5a2f91f718b) | `` flake.lock: Update ``                                |
| [`8bdb74ea`](https://github.com/nix-community/home-manager/commit/8bdb74eaffa21cfce02d7d5d55cbde5524d50b84) | `` docs: add redirect from the previous options.html `` |
| [`8f1b183c`](https://github.com/nix-community/home-manager/commit/8f1b183c91c65c81131bbf7d76f0d845580c60bd) | `` fcitx5: fix tests ``                                 |