### PR TITLE
chore(flake/nix-index-database): `ab78ec24` -> `88ad3d75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1717995391,
-        "narHash": "sha256-lcJ7McLYCOZGmoUqWubg739iFIqVtPD+qDNQx6GPWCY=",
+        "lastModified": 1718011381,
+        "narHash": "sha256-sFXI+ZANp/OC+MwfJoZgPSf4xMdtzQMe1pS3FGti4C8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ab78ec24f803bab7a18370220ae3db92d6d33c94",
+        "rev": "88ad3d7501e22b2401dd72734b032b7baa794434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`aa9e3a7a`](https://github.com/nix-community/nix-index-database/commit/aa9e3a7a29fbae410741831d138df942fa70316a) | `` Pass final into the mkPackages function instead of prev `` |