### PR TITLE
chore(flake/home-manager): `892f76bd` -> `8d5e27b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718141734,
-        "narHash": "sha256-cA+6l8ZCZ7MXGijVuY/1f55+wF/RT4PlTR9+g4bx86w=",
+        "lastModified": 1718243258,
+        "narHash": "sha256-abBpj2VU8p6qlRzTU8o22q68MmOaZ4v8zZ4UlYl5YRU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "892f76bd0aa09a0f7f73eb41834b8a904b6d0fad",
+        "rev": "8d5e27b4807d25308dfe369d5a923d87e7dbfda3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`8d5e27b4`](https://github.com/nix-community/home-manager/commit/8d5e27b4807d25308dfe369d5a923d87e7dbfda3) | `` nix: add a declarative alternative to Nix channels (#4031) `` |