### PR TITLE
chore(flake/darwin): `ff988d78` -> `801f8ab2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718345812,
-        "narHash": "sha256-FJhA+YFsOFrAYe6EaiTEfomNf7jeURaPiG5/+a3DRSc=",
+        "lastModified": 1718427431,
+        "narHash": "sha256-qu7ayh4MoaFfznRDUBk0Fincr3JS6Inp+iunT+onidY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ff988d78f2f55641efacdf9a585d2937f7e32a9b",
+        "rev": "801f8ab2bcd03a90a751370bf91e83068414c5b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`7d4f8672`](https://github.com/LnL7/nix-darwin/commit/7d4f8672101536674ca5d75d91161474739a83e2) | `` fonts: remove `fonts.fontDir.enable` ``              |
| [`adf578e3`](https://github.com/LnL7/nix-darwin/commit/adf578e398445f981a36ad919928f23a1dd5ee12) | `` fonts: reimplement and rename to `fonts.packages` `` |
| [`27517d2d`](https://github.com/LnL7/nix-darwin/commit/27517d2d182629cf32020b9c77cffdc462a34c01) | `` fonts: refactor `system.build.fonts` ``              |
| [`09e72ff9`](https://github.com/LnL7/nix-darwin/commit/09e72ff9b9a2d888aac70bc8019e5a0696f4c24c) | `` fonts: remove `with lib` ``                          |
| [`eb2f62d0`](https://github.com/LnL7/nix-darwin/commit/eb2f62d0de9997b2f73b409a2843ac5968e1a6f3) | `` fonts: use non-standard path in test ``              |