### PR TITLE
chore(flake/darwin): `801f8ab2` -> `58b905ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718427431,
-        "narHash": "sha256-qu7ayh4MoaFfznRDUBk0Fincr3JS6Inp+iunT+onidY=",
+        "lastModified": 1718440858,
+        "narHash": "sha256-iMVwdob8F6P6Ib+pnhMZqyvYI10ZxmvA885jjnEaO54=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "801f8ab2bcd03a90a751370bf91e83068414c5b0",
+        "rev": "58b905ea87674592aa84c37873e6c07bc3807aba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`861af0fc`](https://github.com/LnL7/nix-darwin/commit/861af0fc94df9454f4e92d6892f75588763164bb) | `` fix(launchd): improve `StartCalendarInterval` `` |