### PR TITLE
chore(flake/stylix): `76d6ca22` -> `a7fbda1f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -117,15 +117,15 @@
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1663659192,
-        "narHash": "sha256-uJvaYYDMXvoo0fhBZUhN8WBXeJ87SRgof6GEK2efFT0=",
-        "owner": "chriskempson",
+        "lastModified": 1716150083,
+        "narHash": "sha256-ZMhnNmw34ogE5rJZrjRv5MtG3WaqKd60ds2VXvT6hEc=",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "3be3cd82cd31acfcab9a41bad853d9c68d30478d",
+        "rev": "6e955d704d046b0dc3e5c2d68a2a6eeffd2b5d3d",
         "type": "github"
       },
       "original": {
-        "owner": "chriskempson",
+        "owner": "tinted-theming",
         "repo": "base16-vim",
         "type": "github"
       }
@@ -738,11 +738,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718400985,
-        "narHash": "sha256-+geG68ZukjXif9nnckOrABfQVfzw1CXaYNIZRudZ1XM=",
+        "lastModified": 1718457106,
+        "narHash": "sha256-sVpsAuvXaSRHhcCw8XbVKlZe8GqB5jpGj4oyZaHAI/Y=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "76d6ca2224adef72f482e46fd61d66d2ef57fb66",
+        "rev": "a7fbda1fd965cc22e62463896a4af0342cb00e6a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                             |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`a7fbda1f`](https://github.com/danth/stylix/commit/a7fbda1fd965cc22e62463896a4af0342cb00e6a) | `` vim: use maintained fork of base16-vim (#428) `` |
| [`7941795d`](https://github.com/danth/stylix/commit/7941795d444c590f053ba64a84a9c5339e672a3e) | `` vim: fix missing lib prefix (#433) ``            |
| [`64c5bd0f`](https://github.com/danth/stylix/commit/64c5bd0fbe410475b2cbfc3e8166c161432e69c0) | `` vscode: fix typo in template.mustache (#434) ``  |