### PR TITLE
chore(flake/stylix): `a7fbda1f` -> `80e8e1e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -738,11 +738,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718457106,
-        "narHash": "sha256-sVpsAuvXaSRHhcCw8XbVKlZe8GqB5jpGj4oyZaHAI/Y=",
+        "lastModified": 1718546905,
+        "narHash": "sha256-FmtNOW6Ng11TTgsXkQLqBcIE0j2SmlydHXu/DnWlS4k=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a7fbda1fd965cc22e62463896a4af0342cb00e6a",
+        "rev": "80e8e1e2f613bdc8749461899f0959312eb4a54e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                          |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`80e8e1e2`](https://github.com/danth/stylix/commit/80e8e1e2f613bdc8749461899f0959312eb4a54e) | `` treewide: add linters and apply pending suggestions (#426) `` |
| [`29044a02`](https://github.com/danth/stylix/commit/29044a02428f12c9d590a8f424ef2024b4f0898c) | `` plymouth: use logo from `nixos-icons` (#424) ``               |
| [`25106f20`](https://github.com/danth/stylix/commit/25106f203f1fc711e26e75fc6eaab4a6e18805a7) | `` emacs: change 256 color source (#436) ``                      |