### PR TITLE
chore(flake/nixvim-flake): `8aed6f6c` -> `f1bbb8f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1718376125,
-        "narHash": "sha256-NIJZxmY2CWsqJK/9BQCRSHfcCY9K6thjq/1XtJobxmU=",
+        "lastModified": 1718560097,
+        "narHash": "sha256-JI17CzgQbbzeB2H0n3G9N/HtTAMFSq2IFbRPnlJNTt8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a2a25af02be25987aa43cd681312f4b5ba12317",
+        "rev": "6ac0d2869d8d5a71547a504900f9199871d62506",
         "type": "github"
       },
       "original": {
@@ -668,11 +668,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1718393049,
-        "narHash": "sha256-NqpYis5fHekq1GOSyALHtTAI6U+Y+8j1TD5MJUn3y6s=",
+        "lastModified": 1718587109,
+        "narHash": "sha256-S/taLyJTzGpmVWP/vrOZW3UzroJeIjth5jAfzy2jk50=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8aed6f6cc24d66cad4acf832cba050bc26a2d28c",
+        "rev": "f1bbb8f13b3bec5958a4dd8b2d0613e3f0eecdce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`f1bbb8f1`](https://github.com/alesauce/nixvim-flake/commit/f1bbb8f13b3bec5958a4dd8b2d0613e3f0eecdce) | `` chore(flake/nixvim): 7a2a25af -> 6ac0d286 `` |