### PR TITLE
chore(flake/nixvim-flake): `f1bbb8f1` -> `0e1c5692`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1718560097,
-        "narHash": "sha256-JI17CzgQbbzeB2H0n3G9N/HtTAMFSq2IFbRPnlJNTt8=",
+        "lastModified": 1718611490,
+        "narHash": "sha256-4rd3tTGdUsIoqABoJG9OjNikNoc5ZAHZ6fEqE2gpjE4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6ac0d2869d8d5a71547a504900f9199871d62506",
+        "rev": "7087b6014dae5ce3169f822dbccfb69fca0325a8",
         "type": "github"
       },
       "original": {
@@ -668,11 +668,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1718587109,
-        "narHash": "sha256-S/taLyJTzGpmVWP/vrOZW3UzroJeIjth5jAfzy2jk50=",
+        "lastModified": 1718612643,
+        "narHash": "sha256-dL66Wi6r4xreegyFH2VXJbH9TjywJ6KAp9PtIOsCMvM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "f1bbb8f13b3bec5958a4dd8b2d0613e3f0eecdce",
+        "rev": "0e1c569231874eba9540637c4d561facb7d4f05d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`0e1c5692`](https://github.com/alesauce/nixvim-flake/commit/0e1c569231874eba9540637c4d561facb7d4f05d) | `` chore(flake/nixvim): 6ac0d286 -> 7087b601 `` |