### PR TITLE
chore(flake/darwin): `58b905ea` -> `29b3096a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718440858,
-        "narHash": "sha256-iMVwdob8F6P6Ib+pnhMZqyvYI10ZxmvA885jjnEaO54=",
+        "lastModified": 1718662658,
+        "narHash": "sha256-AKG7BsqtVWDlefgzyKz7vjaKTLi4+bmTSBhowbQoZtM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "58b905ea87674592aa84c37873e6c07bc3807aba",
+        "rev": "29b3096a6e283d7e6779187244cb2a3942239fdf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`d21ba5a4`](https://github.com/LnL7/nix-darwin/commit/d21ba5a4871f02c50efc2de0ae61b749a6318a10) | `` linux-builder: make compatible with cross-arch builder package `` |