### PR TITLE
chore(flake/stylix): `f13c9461` -> `7dcab071`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -738,11 +738,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718634635,
-        "narHash": "sha256-REUyeY+gD/QuTwAhuJycheej0FWFGPTosI+jiG5TsQk=",
+        "lastModified": 1718789425,
+        "narHash": "sha256-YJvgBThIUPeywoTjnFk+F73c0l2oaAENIrz2uldqb5A=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f13c946181730f98e1a5cd09714100490207b250",
+        "rev": "7dcab0711bfc103a1fb05ba643ee7a3bd309fbe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`7dcab071`](https://github.com/danth/stylix/commit/7dcab0711bfc103a1fb05ba643ee7a3bd309fbe4) | `` fonts: remove 'fonts.fontDir.enable' and use 'fonts.packages' (#439) `` |