### PR TITLE
chore(flake/stylix): `7dcab071` -> `97dcf3c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718789425,
-        "narHash": "sha256-YJvgBThIUPeywoTjnFk+F73c0l2oaAENIrz2uldqb5A=",
+        "lastModified": 1718971834,
+        "narHash": "sha256-k+BjPJgjmG+u8VwyzjA6YxkoBn9tP1m19h0CQGc3iGM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7dcab0711bfc103a1fb05ba643ee7a3bd309fbe4",
+        "rev": "97dcf3c216fe5fb19c406e39f265d3bc9b851377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                |
| --------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`97dcf3c2`](https://github.com/danth/stylix/commit/97dcf3c216fe5fb19c406e39f265d3bc9b851377) | `` zellij: fix black & white (#444) `` |