### PR TITLE
chore(flake/home-manager): `d7830d05` -> `cd886711`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718788307,
-        "narHash": "sha256-SqiOz0sljM0GjyQEVinPXQxaGcbOXw5OgpCWGPgh/vo=",
+        "lastModified": 1719037157,
+        "narHash": "sha256-aOKd8+mhBsLQChCu1mn/W5ww79ta5cXVE59aJFrifM8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d7830d05421d0ced83a0f007900898bdcaf2a2ca",
+        "rev": "cd886711998fe5d9ff7979fdd4b4cbd17b1f1511",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`cd886711`](https://github.com/nix-community/home-manager/commit/cd886711998fe5d9ff7979fdd4b4cbd17b1f1511) | `` blanket: add module ``                   |
| [`c559542f`](https://github.com/nix-community/home-manager/commit/c559542f0aa87971a7f4c1b3478fe33cc904b902) | `` gtk: explicitly set default font size `` |