### PR TITLE
chore(flake/nix-index-database): `6af2c5e5` -> `4293f532`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718507237,
-        "narHash": "sha256-xBEWCxWeRpWQggFFp8ugJCDa63cOJsVvx71R9F0Eowg=",
+        "lastModified": 1719111455,
+        "narHash": "sha256-rnIxHx+fLpydjMQsbpZ21kblUr/lMqSaAtMA4+qMMEE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "6af2c5e58c20311276f59d247341cafeebfcb6f4",
+        "rev": "4293f532d0107dfb7e6f8b34a0421dc8111320e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                  |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`4293f532`](https://github.com/nix-community/nix-index-database/commit/4293f532d0107dfb7e6f8b34a0421dc8111320e6) | `` flake.lock: Update `` |