### PR TITLE
chore(flake/stylix): `97dcf3c2` -> `0fc4e9f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718971834,
-        "narHash": "sha256-k+BjPJgjmG+u8VwyzjA6YxkoBn9tP1m19h0CQGc3iGM=",
+        "lastModified": 1719152448,
+        "narHash": "sha256-Acbi1Crd+UEbpPW8IR0ZGRKV+JCnMXDS2cglFQJvRPM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "97dcf3c216fe5fb19c406e39f265d3bc9b851377",
+        "rev": "0fc4e9f1449a9dce4be7a1ecedd97949da591181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                   |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`0fc4e9f1`](https://github.com/danth/stylix/commit/0fc4e9f1449a9dce4be7a1ecedd97949da591181) | `` hyprland: add 'groupbar' colors (#446) ``                              |
| [`1ddb78df`](https://github.com/danth/stylix/commit/1ddb78df07579a1cd9d7cd3a98de08137cd80863) | `` stylix: import missing 'stylix/opacity.nix' module on darwin (#441) `` |