### PR TITLE
chore(flake/stylix): `0fc4e9f1` -> `7cdbd128`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719152448,
-        "narHash": "sha256-Acbi1Crd+UEbpPW8IR0ZGRKV+JCnMXDS2cglFQJvRPM=",
+        "lastModified": 1719235398,
+        "narHash": "sha256-yccyHeuMUdbG/89Yi1ZSqx0XlpIKb0WQI+mAnTf/GJw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "0fc4e9f1449a9dce4be7a1ecedd97949da591181",
+        "rev": "7cdbd128172d7c4ec63f5073d49da5d0e7d6396c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                  |
| --------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`7cdbd128`](https://github.com/danth/stylix/commit/7cdbd128172d7c4ec63f5073d49da5d0e7d6396c) | `` nushell: fix separator typo (#449) `` |