### PR TITLE
chore(flake/nixvim-flake): `714355aa` -> `cc097076`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -640,11 +640,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1718447546,
-        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
+        "lastModified": 1718811006,
+        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "842253bf992c3a7157b67600c2857193f126563a",
+        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
         "type": "github"
       },
       "original": {
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719017239,
-        "narHash": "sha256-EUHE+rN75ZJsj5XZU90J/bGKgSSlkQEyG5zeLo79KaQ=",
+        "lastModified": 1719278317,
+        "narHash": "sha256-pxPFdlSmUHtORRTM5CsDJojp/fYnDREjq5JV48DPxoQ=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "714355aa960eec30c8e3cff75d5137e11a5e65db",
+        "rev": "cc097076b736224290aad8af6f7d830cd0c7bd35",
         "type": "github"
       },
       "original": {
@@ -719,11 +719,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1718879355,
-        "narHash": "sha256-RTyqP4fBX2MdhNuMP+fnR3lIwbdtXhyj7w7fwtvgspc=",
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "8cd35b9496d21a6c55164d8547d9d5280162b07a",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`cc097076`](https://github.com/alesauce/nixvim-flake/commit/cc097076b736224290aad8af6f7d830cd0c7bd35) | `` chore(flake/pre-commit-hooks): 8cd35b94 -> 0ff4381b `` |