### PR TITLE
chore(flake/nixvim-flake): `cc097076` -> `f0e4962e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -561,11 +561,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1715803356,
-        "narHash": "sha256-wvsg/UMM/jekzgbggH56KLZJzRmwrB9ErevaXXyWyqc=",
+        "lastModified": 1719305207,
+        "narHash": "sha256-gxJ1xgkXe/iHpyYBtx96D7AKccQYqutC6R7cKv2uBNY=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "cfff239d93716e92f6467f8953d8f8c12da1892a",
+        "rev": "02c50df6881266f5425f06f475d504e90e491767",
         "type": "github"
       },
       "original": {
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719278317,
-        "narHash": "sha256-pxPFdlSmUHtORRTM5CsDJojp/fYnDREjq5JV48DPxoQ=",
+        "lastModified": 1719332710,
+        "narHash": "sha256-W2Uyuvv7RbwknW2wZtdzEbKiBENCRvb7kiXJ/pULdGI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "cc097076b736224290aad8af6f7d830cd0c7bd35",
+        "rev": "f0e4962e3fd1439de9638d86213fc363b5692940",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`f0e4962e`](https://github.com/alesauce/nixvim-flake/commit/f0e4962e3fd1439de9638d86213fc363b5692940) | `` chore(flake/nix-fast-build): cfff239d -> 02c50df6 `` |