### PR TITLE
chore(flake/home-manager): `92a26bf6` -> `607f969f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719385710,
-        "narHash": "sha256-0yb5D0wCEtXoTi4ssNZxwvLTrahTwlHYPtx252FZ1MU=",
+        "lastModified": 1719418488,
+        "narHash": "sha256-Hu75KIbGLJA8qe42rO5WkRQ+E+BuzjS42bNEZcy9zT8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "92a26bf6df1f00cbbed16a99d2547531ff4b3a83",
+        "rev": "607f969f5dca2dc100cbc53e24ab49ac24ef8987",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`607f969f`](https://github.com/nix-community/home-manager/commit/607f969f5dca2dc100cbc53e24ab49ac24ef8987) | `` systemd: don't try to restart templates ``                |
| [`7a88ff6a`](https://github.com/nix-community/home-manager/commit/7a88ff6ad1e001043f876ebdb1d7460cdfe874d2) | `` systemd: fix sd-switch error on empty target directory `` |