### PR TITLE
chore(flake/nixvim-flake): `f0e4962e` -> `582eec46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -561,11 +561,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1719305207,
-        "narHash": "sha256-gxJ1xgkXe/iHpyYBtx96D7AKccQYqutC6R7cKv2uBNY=",
+        "lastModified": 1719475157,
+        "narHash": "sha256-8zW6eWvE9T03cMpo/hY8RRZIsSCfs1zmsJOkEZzuYwM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "02c50df6881266f5425f06f475d504e90e491767",
+        "rev": "030e586195c97424844965d2ce680140f6565c02",
         "type": "github"
       },
       "original": {
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719332710,
-        "narHash": "sha256-W2Uyuvv7RbwknW2wZtdzEbKiBENCRvb7kiXJ/pULdGI=",
+        "lastModified": 1719476660,
+        "narHash": "sha256-SA0E6c+Gp5uMZX42cr0ihZ9Rdf7qy4gK3qImDl7r44k=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "f0e4962e3fd1439de9638d86213fc363b5692940",
+        "rev": "582eec46c69363df96d753b2341cebf439a00eeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`582eec46`](https://github.com/alesauce/nixvim-flake/commit/582eec46c69363df96d753b2341cebf439a00eeb) | `` chore(flake/nix-fast-build): 02c50df6 -> 030e5861 `` |