### PR TITLE
chore(flake/stylix): `7cdbd128` -> `1ff9d37d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -765,11 +765,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719235398,
-        "narHash": "sha256-yccyHeuMUdbG/89Yi1ZSqx0XlpIKb0WQI+mAnTf/GJw=",
+        "lastModified": 1719525570,
+        "narHash": "sha256-xSO/H67GAHEW0siD2PHoO/e97MbROL3r3s5SpF6A6Dc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7cdbd128172d7c4ec63f5073d49da5d0e7d6396c",
+        "rev": "1ff9d37d27377bfe8994c24a8d6c6c1734ffa116",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                          |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`1ff9d37d`](https://github.com/danth/stylix/commit/1ff9d37d27377bfe8994c24a8d6c6c1734ffa116) | `` fzf: use Home Manager color options (#454) `` |