### PR TITLE
chore(flake/nix-index-database): `4293f532` -> `838a910d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719111455,
-        "narHash": "sha256-rnIxHx+fLpydjMQsbpZ21kblUr/lMqSaAtMA4+qMMEE=",
+        "lastModified": 1719726405,
+        "narHash": "sha256-DqeKlvYQ5Z1rC02we9ufHr8UTfqBRPhiPrGLqdJ91dQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "4293f532d0107dfb7e6f8b34a0421dc8111320e6",
+        "rev": "838a910df0f7e542de2327036b2867fd68ded3a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`838a910d`](https://github.com/nix-community/nix-index-database/commit/838a910df0f7e542de2327036b2867fd68ded3a2) | `` Add comma option to darwin module ``                 |
| [`2b0d5f3a`](https://github.com/nix-community/nix-index-database/commit/2b0d5f3a4229c581e2bb839ac0b992feb366eba5) | `` update generated.nix to release 2024-06-30-025731 `` |
| [`33ff922c`](https://github.com/nix-community/nix-index-database/commit/33ff922c8f1d070a530cf6a7215d8673baeeb9ed) | `` flake.lock: Update ``                                |