### PR TITLE
chore(flake/nix-index-database): `838a910d` -> `2917972e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719726405,
-        "narHash": "sha256-DqeKlvYQ5Z1rC02we9ufHr8UTfqBRPhiPrGLqdJ91dQ=",
+        "lastModified": 1719832725,
+        "narHash": "sha256-dr8DkeS74KVNTgi8BE0BiUKALb+EKlMIV86G2xPYO64=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "838a910df0f7e542de2327036b2867fd68ded3a2",
+        "rev": "2917972ed34ce292309b3a4976286f8b5c08db27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                           |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`5f154bf6`](https://github.com/nix-community/nix-index-database/commit/5f154bf6c2b17d5751e45fbcf1bc520a92066089) | `` nixos-module: disable programs.command-not-found by default `` |