### PR TITLE
chore(flake/nixvim-flake): `ccbf6ebf` -> `8868d2de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719883204,
+        "lastModified": 1719923315,
         "narHash": "sha256-VdE7exYp03S+1qiTML+u6pwte1F3CDcXWUEWARfLa38=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "ccbf6ebfcb1ac266a855d0d966eb71b4a72b0261",
+        "rev": "8868d2de4f1c0e763e4efeebd8544cdfba038287",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                          |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
| [`8868d2de`](https://github.com/alesauce/nixvim-flake/commit/8868d2de4f1c0e763e4efeebd8544cdfba038287) | `` Revert "disabling rust-tools due to rust-analyzer breaking nixpkgs update" `` |
| [`3ae6576f`](https://github.com/alesauce/nixvim-flake/commit/3ae6576f132f763afb9c72b56c031b3f62e93fcc) | `` Revert "removing rust-tools references prior to moving to rustaceanvim" ``    |
| [`0167ae62`](https://github.com/alesauce/nixvim-flake/commit/0167ae629c4d3b2ca4d4c828f4e4d95c124971dd) | `` Revert "finishing removing rust-tools references" ``                          |
| [`4af10260`](https://github.com/alesauce/nixvim-flake/commit/4af1026024760c7d041d1b0050796101951fe646) | `` finishing removing rust-tools references ``                                   |
| [`bec603b0`](https://github.com/alesauce/nixvim-flake/commit/bec603b02ab6ed253848c15da2f78fd5a178fba9) | `` removing rust-tools references prior to moving to rustaceanvim ``             |
| [`9bd4c687`](https://github.com/alesauce/nixvim-flake/commit/9bd4c68780771d05b653cfe1eb3b6afe7d76e4d5) | `` disabling rust-tools due to rust-analyzer breaking nixpkgs update ``          |