### PR TITLE
chore(flake/nixvim-flake): `8868d2de` -> `676055bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719923315,
-        "narHash": "sha256-VdE7exYp03S+1qiTML+u6pwte1F3CDcXWUEWARfLa38=",
+        "lastModified": 1719979107,
+        "narHash": "sha256-aoPr4iqDOMm8fqA5FFcUihWXunCAqL3Xo1UkkQNGaog=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8868d2de4f1c0e763e4efeebd8544cdfba038287",
+        "rev": "676055bddef7cfdc5e0ad4d297f8ab30894c6ae6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                      |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`676055bd`](https://github.com/alesauce/nixvim-flake/commit/676055bddef7cfdc5e0ad4d297f8ab30894c6ae6) | `` adding workaround to add all vimPlugins attributes ``                     |
| [`d924690b`](https://github.com/alesauce/nixvim-flake/commit/d924690b0a803c84e4c244399c47097ca5877248) | `` removing bashls to fix build ``                                           |
| [`dd12f2e4`](https://github.com/alesauce/nixvim-flake/commit/dd12f2e40587dc4d0d2d40017cc4129bb6af5271) | `` removing deprecated rust-tools options prior to moving to rustaceanvim `` |
| [`f58e9227`](https://github.com/alesauce/nixvim-flake/commit/f58e92276cec0310a0f4a426962dc76a296f85e8) | `` updating incorrect options for rust-tools ``                              |