### PR TITLE
chore(flake/home-manager): `59ce796b` -> `36e2f9da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1719827439,
-        "narHash": "sha256-tneHOIv1lEavZ0vQ+rgz67LPNCgOZVByYki3OkSshFU=",
+        "lastModified": 1719992360,
+        "narHash": "sha256-SRq0ZRkqagqpMGVf4z9q9CIWRbPYjO7FTqSJyWh7nes=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "59ce796b2563e19821361abbe2067c3bb4143a7d",
+        "rev": "36e2f9da91ce8b63a549a47688ae60d47c50de4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`36e2f9da`](https://github.com/nix-community/home-manager/commit/36e2f9da91ce8b63a549a47688ae60d47c50de4b) | `` maintainers: remove ivar `` |