### PR TITLE
chore(flake/nixvim-flake): `676055bd` -> `e00f26fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -695,11 +695,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1719979107,
-        "narHash": "sha256-aoPr4iqDOMm8fqA5FFcUihWXunCAqL3Xo1UkkQNGaog=",
+        "lastModified": 1719995173,
+        "narHash": "sha256-HRp1Awm19B27VdE52Yvv/lMo85G+KSXC1fpgy3mJZsU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "676055bddef7cfdc5e0ad4d297f8ab30894c6ae6",
+        "rev": "e00f26fb4ae0f8f3971d3dc76fbdf52015f1849d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`e00f26fb`](https://github.com/alesauce/nixvim-flake/commit/e00f26fb4ae0f8f3971d3dc76fbdf52015f1849d) | `` chore(flake/flake-parts): 4e358342 -> 9227223f `` |