### PR TITLE
chore(flake/nixpkgs): `00d80d13` -> `9f4128e0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -596,11 +596,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719848872,
-        "narHash": "sha256-H3+EC5cYuq+gQW8y0lSrrDZfH71LB4DAf+TDFyvwCNA=",
+        "lastModified": 1720031269,
+        "narHash": "sha256-rwz8NJZV+387rnWpTYcXaRNvzUSnnF9aHONoJIYmiUQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "00d80d13810dbfea8ab4ed1009b09100cca86ba8",
+        "rev": "9f4128e00b0ae8ec65918efeba59db998750ead6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`19bbe0b3`](https://github.com/NixOS/nixpkgs/commit/19bbe0b3eb9cb49ca1c92c84ffb57c041afb432c) | `` doc/meta: make meta.description consistent with contributing document ``         |
| [`66f2bf71`](https://github.com/NixOS/nixpkgs/commit/66f2bf71eb459ec22892fb981fdf1b00f0a148dc) | `` coqPackages.smtcoq: 2.1 → 2.2 ``                                                 |
| [`47cb3e61`](https://github.com/NixOS/nixpkgs/commit/47cb3e61656c02b2e096a1a5a9ff9c3f3e396c2a) | `` datadog-agent: fix ``                                                            |
| [`eed67077`](https://github.com/NixOS/nixpkgs/commit/eed6707798b8a26a671be596b585221f233dd695) | `` znc: fix modtcl rce ``                                                           |
| [`f13e08ac`](https://github.com/NixOS/nixpkgs/commit/f13e08ac0e6964fc0087987b08ffc05a979fa548) | `` nixos/espanso: fix wayland option ``                                             |
| [`e5d13765`](https://github.com/NixOS/nixpkgs/commit/e5d13765ec9c1b0ddb3841ff897c380f6bbf7f13) | `` python3Packages.process-tests: optional ignore_case param to wait_for_strings `` |
| [`4ea313c2`](https://github.com/NixOS/nixpkgs/commit/4ea313c21841acbca87d3c1da89f01cc71539971) | `` balena-cli: 18.2.10 -> 18.2.17 ``                                                |
| [`5112012d`](https://github.com/NixOS/nixpkgs/commit/5112012d9eb862d32605a95fab67d019ac07884c) | `` raycast: 1.77.3 -> 1.78.0 ``                                                     |
| [`01aa0779`](https://github.com/NixOS/nixpkgs/commit/01aa0779989b2c7a4c04bdac0bf0354d54cf6a44) | `` maintainers: remove delan ``                                                     |
| [`9b4703cf`](https://github.com/NixOS/nixpkgs/commit/9b4703cf1442e32c8d8cafac6b0118083bdc4951) | `` pkgs/misc: remove licenses.gpl2 ``                                               |
| [`708807d6`](https://github.com/NixOS/nixpkgs/commit/708807d6825cbc51a58884780b2dec68e115ee3b) | `` treefmt2: 2.0.1 -> 2.0.2 (#323995) ``                                            |
| [`1290947c`](https://github.com/NixOS/nixpkgs/commit/1290947c3f3dfff197214bc711fd0901243335b1) | `` python312Packages.oletools: 0.60.1 -> 0.60.2 ``                                  |
| [`e03a1b32`](https://github.com/NixOS/nixpkgs/commit/e03a1b329aecab4c39551d1a210ffadf3f5ae015) | `` fastapi-cli: init at 0.0.4 ``                                                    |
| [`c7f1f672`](https://github.com/NixOS/nixpkgs/commit/c7f1f672021ef1685c8eb4490238e6e68c42949a) | `` python312Packages.reolink-aio: 0.9.3 -> 0.9.4 ``                                 |
| [`85f72b28`](https://github.com/NixOS/nixpkgs/commit/85f72b289838f2a6ce9c8d991c9bc90442ba30ea) | `` python312Packages.std-uritemplate: 1.0.2 -> 1.0.3 ``                             |
| [`c8eb2bdc`](https://github.com/NixOS/nixpkgs/commit/c8eb2bdc2cde0723c209d83e3939050be937066e) | `` python312Packages.twilio: 9.2.1 -> 9.2.3 ``                                      |
| [`2633ccda`](https://github.com/NixOS/nixpkgs/commit/2633ccda874c374bc3ac8f1e99bf0ce61f7bd58a) | `` python312Packages.velbus-aio: 2024.7.0 -> 2024.7.1 ``                            |
| [`15cf743c`](https://github.com/NixOS/nixpkgs/commit/15cf743cb21c3203bc85b71670befb6ef717d06a) | `` python312Packages.velbus-aio: 2024.4.1 -> 2024.7.0 ``                            |
| [`006911b0`](https://github.com/NixOS/nixpkgs/commit/006911b0741c2b2902096e1dbe04554f077e84a9) | `` python312Packages.pyenphase: 1.20.3 -> 1.20.5 ``                                 |
| [`69598c52`](https://github.com/NixOS/nixpkgs/commit/69598c5288bbf2f8dcb1b18e4ee2639fe8dcce4e) | `` python312Packages.pyexploitdb: 0.2.23 -> 0.2.24 ``                               |
| [`e621426d`](https://github.com/NixOS/nixpkgs/commit/e621426dcafb7396532914a2fb15393faeb94065) | `` python312Packages.python-technove: 1.2.3 -> 1.3.0 ``                             |
| [`1755fa11`](https://github.com/NixOS/nixpkgs/commit/1755fa11d878990cc2a68588595b67ca79245910) | `` python312Packages.python-technove: 1.2.2 -> 1.2.3 ``                             |
| [`ce99d9a5`](https://github.com/NixOS/nixpkgs/commit/ce99d9a5b725d50f0a2c099a7e346a25ebcdf96a) | `` python312Packages.laundrify-aio: 1.2.0 -> 1.2.1 ``                               |
| [`61d256f3`](https://github.com/NixOS/nixpkgs/commit/61d256f3725c35f0f82c7a259e88c8ae4406e07d) | `` python312Packages.inkbird-ble: 0.5.6 -> 0.5.7 ``                                 |
| [`84195d79`](https://github.com/NixOS/nixpkgs/commit/84195d79114b492f1204ed1d95f12795956f7a71) | `` python312Packages.holidays: 0.51 -> 0.52 ``                                      |
| [`dd554a9e`](https://github.com/NixOS/nixpkgs/commit/dd554a9ea1df8b9fac68e1df11d8a5d37f38150d) | `` python312Packages.google-ai-generativelanguage: 0.6.5 -> 0.6.6 ``                |
| [`99bf8a8c`](https://github.com/NixOS/nixpkgs/commit/99bf8a8cff289168f74ee75f7e5b68a28964fa33) | `` python312Packages.cyclopts: 2.8.0 -> 2.9.1 ``                                    |
| [`d625dfd5`](https://github.com/NixOS/nixpkgs/commit/d625dfd536159c1b568d63051984e36dbcf6eebc) | `` exploitdb: 2024-06-27 -> 2024-07-02 ``                                           |
| [`60b60d4b`](https://github.com/NixOS/nixpkgs/commit/60b60d4bfb750db9b74a971a6908e64b73f6d604) | `` parrot: use unstableGitUpdater ``                                                |
| [`9c7da092`](https://github.com/NixOS/nixpkgs/commit/9c7da092308186da79646e81aee24159b32ecbdf) | `` checkov: 3.2.164 -> 3.2.168 ``                                                   |
| [`8b9af965`](https://github.com/NixOS/nixpkgs/commit/8b9af965417f4f7e6ee41007c5c268e5aeb56437) | `` python312Packages.asteval: 0.9.33 -> 1.0.0 ``                                    |
| [`d23449e9`](https://github.com/NixOS/nixpkgs/commit/d23449e9335144b7dfbc90f5f454389d52d7ef82) | `` python312Packages.botocore-stubs: 1.34.137 -> 1.34.138 ``                        |
| [`14a7bfc9`](https://github.com/NixOS/nixpkgs/commit/14a7bfc92296e9db077cc65f062220fb20177d08) | `` python312Packages.boto3-stubs: 1.34.137 -> 1.34.138 ``                           |
| [`a6d0ace5`](https://github.com/NixOS/nixpkgs/commit/a6d0ace59c343664fc20fe75bc16925d2b16c7c3) | `` superfile: 1.1.2 -> 1.1.3 (#323021) ``                                           |
| [`f3d9e298`](https://github.com/NixOS/nixpkgs/commit/f3d9e298c41d8992d33f93de6cab5cb4a9aa285b) | `` python312Packages.tencentcloud-sdk-python: 3.0.1180 -> 3.0.1181 ``               |
| [`15927edc`](https://github.com/NixOS/nixpkgs/commit/15927edc6db99e97cf36e7f6c793dbb7bbfb10f4) | `` memento: 1.4.0 -> 1.4.1 ``                                                       |
| [`7bf38979`](https://github.com/NixOS/nixpkgs/commit/7bf389797a18c28a1158ef1402c6cce96786264b) | `` vimPlugins.codesnap-nvim: 1.3.1 -> 1.4.0 ``                                      |
| [`35c710d2`](https://github.com/NixOS/nixpkgs/commit/35c710d25bdae8cf5f732f2e9d59e0f47f452e7a) | `` kdiagram: remove licenses.gpl2 ``                                                |
| [`9ebb25bd`](https://github.com/NixOS/nixpkgs/commit/9ebb25bd622bfe2bd1c33d25925293ac4fe67b50) | `` yt-dlp: 2024.7.1 -> 2024.7.2 ``                                                  |
| [`9b72ff71`](https://github.com/NixOS/nixpkgs/commit/9b72ff7182613858044558714642b2c3d1b4136d) | `` ollama: 0.1.47 -> 0.1.48 ``                                                      |
| [`f9f41717`](https://github.com/NixOS/nixpkgs/commit/f9f41717b54478cf89373dbf361a16e648d0f902) | `` catppuccin-gtk: fix inconsistent theme name ``                                   |
| [`c3a56c4d`](https://github.com/NixOS/nixpkgs/commit/c3a56c4dad2deb943947e742d384e8771c0ab68a) | `` roddhjav-apparmor-rules: 0-unstable-2024-06-27 -> 0-unstable-2024-07-02 ``       |
| [`f278ebb4`](https://github.com/NixOS/nixpkgs/commit/f278ebb4e93b23943417a80b711a26cff40a3aaa) | `` yazi-unwrapped: format with nixfmt ``                                            |
| [`b53e0dae`](https://github.com/NixOS/nixpkgs/commit/b53e0dae4e738b00a7899c73500735aea65e975e) | `` yazi-unwrapped: build new yazi-cli tool ``                                       |
| [`bc82a438`](https://github.com/NixOS/nixpkgs/commit/bc82a438427416faa1221555bdd93ad7c0dae612) | `` tagparser: set meta.platforms ``                                                 |
| [`e4207a14`](https://github.com/NixOS/nixpkgs/commit/e4207a145f8762c4b0b7f8314ac239567fe6a564) | `` vimPlugins.nvim-treesitter: update grammars ``                                   |
| [`d1360851`](https://github.com/NixOS/nixpkgs/commit/d13608511b3891cde2a205b0db52bcd2cf92b143) | `` vimPlugins: resolve github repository redirects ``                               |
| [`ba223032`](https://github.com/NixOS/nixpkgs/commit/ba223032b1deb3a09a043853ceb846a9545e6884) | `` picom-pijulius: 8.2-unstable-2024-06-13 -> 8.2-unstable-2024-07-01 ``            |
| [`626531c7`](https://github.com/NixOS/nixpkgs/commit/626531c7d6d330e96919fabf63d42b50bb78cbea) | `` vimPlugins: update on 2024-07-03 ``                                              |
| [`c6efd596`](https://github.com/NixOS/nixpkgs/commit/c6efd596529270f6b2caecb160cf71597e5825e9) | `` global: 6.6.12 -> 6.6.13 ``                                                      |
| [`99f4beaa`](https://github.com/NixOS/nixpkgs/commit/99f4beaaec8f4201e4e7b61c5e9ef0e5cc666be4) | `` nixos/scion: improve robustness testing ``                                       |
| [`b7bd9f06`](https://github.com/NixOS/nixpkgs/commit/b7bd9f06e0bc976b48a4784108babdec4629411b) | `` scion: use mattn/go-sqlite3 instead of modernc.org/sqlite ``                     |
| [`9604aba3`](https://github.com/NixOS/nixpkgs/commit/9604aba3f690a1007b5b0244fcc92eb94fecfe5f) | `` quickemu: fix Samba shares ``                                                    |
| [`300fb4f4`](https://github.com/NixOS/nixpkgs/commit/300fb4f4262537dac8a1cb70deee9a31253d34e9) | `` albert: 0.24.1 -> 0.24.2 ``                                                      |
| [`90714007`](https://github.com/NixOS/nixpkgs/commit/90714007e3c13137ac0bbe78087babef11d21cd3) | `` lmstudio: 0.2.25 -> 0.2.27 ``                                                    |
| [`428a4979`](https://github.com/NixOS/nixpkgs/commit/428a49799099940622dce9d3606d5622eebfc7a3) | `` android-studio-for-platform: remove gnome_vfs & GConf ``                         |
| [`0b36b8a5`](https://github.com/NixOS/nixpkgs/commit/0b36b8a5f026f7adc1d7d6f6655f187b20e65e7a) | `` roxctl: 4.4.3 -> 4.4.4 ``                                                        |
| [`f2c901e2`](https://github.com/NixOS/nixpkgs/commit/f2c901e294807199fbbd72a3c5b5aff896bfbe8e) | `` phraze: init at 0.3.11 ``                                                        |
| [`c50d7334`](https://github.com/NixOS/nixpkgs/commit/c50d7334c3455395b391249778cb8b323f6bce1c) | `` grype: 0.79.1 -> 0.79.2 ``                                                       |
| [`30e90f22`](https://github.com/NixOS/nixpkgs/commit/30e90f2230bedf2ae7e4d63c419c4a0a9498bd6d) | `` flyctl: 0.2.75 -> 0.2.79 ``                                                      |
| [`89b1c8b0`](https://github.com/NixOS/nixpkgs/commit/89b1c8b08749db1feeae81a4c8ba5e1a9b3106ed) | `` mongoc: 1.27.3 -> 1.27.4 ``                                                      |
| [`68c92b26`](https://github.com/NixOS/nixpkgs/commit/68c92b267fbcc80f4a8f72c5216bf8e2849e2454) | `` factorio: 1.1.107 -> 1.1.109 ``                                                  |
| [`474cfb9a`](https://github.com/NixOS/nixpkgs/commit/474cfb9a0df9f2fbce01964784dd748b651ac9c3) | `` bitwarden-cli: 2024.6.0 -> 2024.6.1 ``                                           |
| [`dde69bc0`](https://github.com/NixOS/nixpkgs/commit/dde69bc0f82c4cfc2428cc128776f467bfcba88e) | `` containerd: 1.7.18 -> 1.7.19 ``                                                  |
| [`a7327a8b`](https://github.com/NixOS/nixpkgs/commit/a7327a8b45f6589d5d7688391bd5e8b15ae0e446) | `` gopls: 0.16.0 -> 0.16.1 ``                                                       |
| [`203fb14f`](https://github.com/NixOS/nixpkgs/commit/203fb14ff3032c0fd64018f479bc6c3975e1bfa2) | `` tailscale: 1.68.1 -> 1.68.2 ``                                                   |
| [`3a062705`](https://github.com/NixOS/nixpkgs/commit/3a0627051aa360ac7327548af008e5b4e5d8e60d) | `` cpp-utilities: 5.24.9 -> 5.25.0 ``                                               |
| [`63dc8362`](https://github.com/NixOS/nixpkgs/commit/63dc83627214b0105c2b30a321d9be82c8f0774f) | `` c2fmzq: 0.4.20 -> 0.4.21 ``                                                      |
| [`d87ff327`](https://github.com/NixOS/nixpkgs/commit/d87ff327d820e7a182cf4ce4f40eb3bdd279e3c3) | `` clipse: 0.0.71 -> 1.0.0 ``                                                       |
| [`8ff9f339`](https://github.com/NixOS/nixpkgs/commit/8ff9f339cc881a06848bebe741f373bbc53eebe5) | `` rapidfuzz-cpp: 3.0.4 -> 3.0.5 ``                                                 |
| [`2e750d41`](https://github.com/NixOS/nixpkgs/commit/2e750d417d6bae5a8588d08ca921c4b9d43ac537) | `` ollama: add necessary `/lib` suffix to fix rocm ``                               |
| [`72ae7e0c`](https://github.com/NixOS/nixpkgs/commit/72ae7e0c8aa68a24c6002d40bc450ae5d3e6534b) | `` nixfmt: unstable-2024-05-28 -> unstable-2024-07-03 ``                            |
| [`3156107d`](https://github.com/NixOS/nixpkgs/commit/3156107d650bd451e1b39c816a52711251652a9f) | `` {libthai,glee,xscope,bemenu,muso}: add crertel as maintainer ``                  |
| [`51fc729d`](https://github.com/NixOS/nixpkgs/commit/51fc729d9d117b4aa9b916a2c5646ff693d6b5e8) | `` manifest-tool: 2.1.6 -> 2.1.7 ``                                                 |
| [`4a509316`](https://github.com/NixOS/nixpkgs/commit/4a509316fd8781479ce12e585f723df72d43d55f) | `` go_1_21: 1.21.11 -> 1.21.12 (#324126) ``                                         |
| [`22b43d85`](https://github.com/NixOS/nixpkgs/commit/22b43d853652ef8c9460fbabce5218250bdd58ec) | `` flex-ncat: 0.4-20231210.1 -> 0.4-20240702 ``                                     |
| [`cfd26b13`](https://github.com/NixOS/nixpkgs/commit/cfd26b1370b5c8b85b12a49bcef5dffd3757852f) | `` docker_27: 27.0.2 -> 27.0.3 ``                                                   |
| [`5fa70987`](https://github.com/NixOS/nixpkgs/commit/5fa70987331095ff8d18faca1c3c73713a08a816) | `` maintainers: add crertel ``                                                      |
| [`c5ea455f`](https://github.com/NixOS/nixpkgs/commit/c5ea455f64d2f19868d3871167e276e8c78726c4) | `` python311Packages.openai: 1.35.5 -> 1.35.9 ``                                    |
| [`cb958043`](https://github.com/NixOS/nixpkgs/commit/cb95804388c3b02a56ece8c5630fadba75c9d6cc) | `` tagparser: 12.1.0 -> 12.2.0 ``                                                   |
| [`02398a8b`](https://github.com/NixOS/nixpkgs/commit/02398a8b49bb8a9ba16dcf92324b7a12c389e3d4) | `` moarvm: 2024.05 -> 2024.06 ``                                                    |
| [`a31177f3`](https://github.com/NixOS/nixpkgs/commit/a31177f3d02c0efca1ae16a0dbf751e0702be0dd) | `` nqp: 2024.01 -> 2024.06 ``                                                       |
| [`1a787fd6`](https://github.com/NixOS/nixpkgs/commit/1a787fd64cf60944c69c96459fae90f2a368e156) | `` rakudo: 2024.01 -> 2024.06 ``                                                    |
| [`a4b5a582`](https://github.com/NixOS/nixpkgs/commit/a4b5a5827304065490878919fd34b052abeb5c6c) | `` terragrunt: 0.59.3 -> 0.59.6 ``                                                  |
| [`b1f384c6`](https://github.com/NixOS/nixpkgs/commit/b1f384c6f7b1610ddacdbaa00fe869019ac0da71) | `` rainbowcrack: init at 1.8 ``                                                     |
| [`d75d8099`](https://github.com/NixOS/nixpkgs/commit/d75d8099f95bc32cbdcaf69c29dae6bfce48a16f) | `` zigbee2mqtt: 1.38.0 -> 1.39.0 ``                                                 |
| [`53089bd0`](https://github.com/NixOS/nixpkgs/commit/53089bd0c2a8a5976200f431867c2e77f98b2b9f) | `` docker-credential-helpers: 0.8.1 -> 0.8.2 ``                                     |
| [`199991b7`](https://github.com/NixOS/nixpkgs/commit/199991b72d705b89e7b3893100e7ead4b17877b3) | `` cnquery: 11.10.0 -> 11.11.0 ``                                                   |
| [`7066c3bf`](https://github.com/NixOS/nixpkgs/commit/7066c3bf3e967c86c47710f3d1af03ff95920518) | `` python311Packages.faster-whisper: 1.0.2 -> 1.0.3 ``                              |
| [`35d2ffe6`](https://github.com/NixOS/nixpkgs/commit/35d2ffe69d827b216c2a90007528d96881979347) | `` keybase: add missing darwin framework ``                                         |
| [`45fdebdf`](https://github.com/NixOS/nixpkgs/commit/45fdebdfbadcc5e18b10346d026dad0f29674390) | `` keybase: 6.2.8 -> 6.3.1 ``                                                       |