### PR TITLE
chore(flake/home-manager): `e3582e51` -> `10486e6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -467,11 +467,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720188602,
-        "narHash": "sha256-lC3byBmhVZFzWl/dCic8+cKUEEAXAswWOYjq4paFmbo=",
+        "lastModified": 1720289319,
+        "narHash": "sha256-E3CjSsXNDWYqoNjrKQLPdEZDLR+mVI9HMa+jY//FjBY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3582e5151498bc4d757e8361431ace8529e7bb7",
+        "rev": "10486e6b311b3c5ae1c3477fee058704cea7cb4a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`10486e6b`](https://github.com/nix-community/home-manager/commit/10486e6b311b3c5ae1c3477fee058704cea7cb4a) | `` starship: fix type of settings to allow all valid value `` |