### PR TITLE
chore(flake/darwin): `0f89b73f` -> `fabc6535`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720337362,
-        "narHash": "sha256-9TNQtlwu97NPaJYsKkdObOsy0MLN4NAOBz0pqwH3KnA=",
+        "lastModified": 1720469887,
+        "narHash": "sha256-BwPsGQ/EMqCreUc5j9Efj+wx13AjREtuHhbyHZygcE4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0f89b73f41eaa1dde67b291452c181d9a75f10dd",
+        "rev": "fabc653517106127e2ed435fb52e7e8854354428",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                              |
| ------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`e2a85731`](https://github.com/LnL7/nix-darwin/commit/e2a85731a071811457c151d2da385f9bb4ea5cdb) | `` nextdns: fix argument handling `` |