### PR TITLE
chore(flake/nixvim-flake): `969b7b44` -> `1cd9681f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1720427169,
-        "narHash": "sha256-U+3kwSH7O6J7gPQVa0m9ufoMrKGSKJIVete70AcoZNI=",
+        "lastModified": 1720455948,
+        "narHash": "sha256-ClxuqV/jiYB6yLy21nMF94vWEMyR5X+x6mcTyeuxSZ0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "969b7b44ecfdcfd74b3c741ba50a6d70965682e3",
+        "rev": "1cd9681fe248dea6750c751c78dfce11dd8a3060",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1719259945,
-        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "lastModified": 1720450253,
+        "narHash": "sha256-1in42htN3g3MnE3/AO5Qgs6pMWUzmtPQ7s675brO8uw=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "rev": "2b6bd3c87d3a66fb0b8f2f06c985995e04b4fb96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`1cd9681f`](https://github.com/alesauce/nixvim-flake/commit/1cd9681fe248dea6750c751c78dfce11dd8a3060) | `` chore(flake/pre-commit-hooks): 0ff4381b -> 2b6bd3c8 `` |