### PR TITLE
chore(flake/nixvim-flake): `bb3ca0c7` -> `0a3993ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -628,16 +628,16 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1718811006,
-        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
+        "lastModified": 1720386169,
+        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
+        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1720425287,
-        "narHash": "sha256-iKcXfOtB2XLDSRZdwi2+cxoO/wOEidHIJOQRSRd7rV0=",
+        "lastModified": 1720530938,
+        "narHash": "sha256-kUmpiyPfVFKPPLKfq3p50ddi6MdwcW7g4IqM8b7bRxg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "451beb4ecaf56fea38ffe82588364aae4161a2d8",
+        "rev": "a5e9dbdef1530a76056db12387d489a68eea6f80",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1720488043,
-        "narHash": "sha256-V1Uo2gz7vQ4+6BriY+4C+4LYAdXTi0CqS5kgIkWybi4=",
+        "lastModified": 1720553020,
+        "narHash": "sha256-UuzyZ8/rcEN+RudReIe9debiec1D25Vs76S1KnFhr20=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "bb3ca0c74e0a0ec9f96c6b456b2622887d962bb7",
+        "rev": "0a3993ace5e86ec529252433363e7ab42aad08e1",
         "type": "github"
       },
       "original": {
@@ -707,11 +707,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1720450253,
-        "narHash": "sha256-1in42htN3g3MnE3/AO5Qgs6pMWUzmtPQ7s675brO8uw=",
+        "lastModified": 1720524665,
+        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2b6bd3c87d3a66fb0b8f2f06c985995e04b4fb96",
+        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`0a3993ac`](https://github.com/alesauce/nixvim-flake/commit/0a3993ace5e86ec529252433363e7ab42aad08e1) | `` chore(flake/nixvim): 451beb4e -> a5e9dbde (#120) ``    |
| [`d039b423`](https://github.com/alesauce/nixvim-flake/commit/d039b423dfe51473677abfaf96aea4f7e2caaeff) | `` chore(flake/pre-commit-hooks): 2b6bd3c8 -> 8d6a17d0 `` |