### PR TITLE
chore(flake/nixpkgs): `655a58a7` -> `feb2849f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`22e2f200`](https://github.com/NixOS/nixpkgs/commit/22e2f200f8a8748d49aff16d99bd9faac50f5bf1) | `` python312Packages.pynose: drop ``                                                 |
| [`fae12c59`](https://github.com/NixOS/nixpkgs/commit/fae12c5929ec2d53fb599e4146f83f741f8eb571) | `` hydrus: revert to nose, disable tests on 3.12 ``                                  |
| [`400cb9b7`](https://github.com/NixOS/nixpkgs/commit/400cb9b73a3a5a017a7f31be7fee85827d3c8211) | `` python312Packages.pytest-mpl: drop (py)nose dependency ``                         |
| [`95a7ecdd`](https://github.com/NixOS/nixpkgs/commit/95a7ecdd4dfb2cd1534120b66fb1395e7583cc7d) | `` tarsnapper: revert to nose, disable tests on 3.12 ``                              |
| [`06505fc4`](https://github.com/NixOS/nixpkgs/commit/06505fc4a6023531a04d67f1293babf7a81481cc) | `` python312Packages.opuslib: migrate to pytest ``                                   |
| [`3184ac13`](https://github.com/NixOS/nixpkgs/commit/3184ac1359734a89d4e473a3187d8565bbf57cb3) | `` python312Packages.statsd: migrate to pytest ``                                    |
| [`700e31b3`](https://github.com/NixOS/nixpkgs/commit/700e31b3bda5ca86b7b501cf5b8c498d4cedefaf) | `` python312Packages.pycron: remove nose dependency ``                               |
| [`06ebece3`](https://github.com/NixOS/nixpkgs/commit/06ebece3224810a7211d2a3f80a0148df21f4f47) | `` python312Packages.python-whois: drop pynose dependency ``                         |
| [`a9ceebae`](https://github.com/NixOS/nixpkgs/commit/a9ceebaed6ef0e0ce97455df10b3afb958a72836) | `` python312Packages.hkdf: revert to nose, disable tests on 3.12 ``                  |
| [`c886f78a`](https://github.com/NixOS/nixpkgs/commit/c886f78af3c1d4e78765d24e412693da1d5c9b92) | `` python312Packages.apricot-select: replace pynose with nose ``                     |
| [`4749b5d7`](https://github.com/NixOS/nixpkgs/commit/4749b5d70b59c1d5055bed665e665eb497c211a0) | `` python312Pacakges.bc-python-hcl2: drop (py)nose dependency ``                     |
| [`61bcf524`](https://github.com/NixOS/nixpkgs/commit/61bcf5240c61997fa7b6335f0edc279c30d5cb45) | `` python312Packages.svgutils: revert to nose, disable tests on 3.12 ``              |
| [`0b06e773`](https://github.com/NixOS/nixpkgs/commit/0b06e7731dddfeeea1756613828c2eda7b8a8818) | `` python312Packages.flask-assets: disable tests, add imports check ``               |
| [`7e97b878`](https://github.com/NixOS/nixpkgs/commit/7e97b878e87f05fb2be08e6c331b1b10ddd988cd) | `` python312Packages.agate: replace nose with pytests ``                             |
| [`8ec1f158`](https://github.com/NixOS/nixpkgs/commit/8ec1f158a75f6fbe6c85b6534919ecdd2551b726) | `` python312Packages.nwdiag: revert to nose, disable tests on 3.12 ``                |
| [`75f90230`](https://github.com/NixOS/nixpkgs/commit/75f9023006323a7e2ea2816eec370653e144ad23) | `` python312Packages.ipython-genutils: migrate to pytest ``                          |
| [`ff55f8fb`](https://github.com/NixOS/nixpkgs/commit/ff55f8fbfb5c2deacdabdde412e295977dd0b223) | `` python312Packages.pydy: revert to nose, disable tests on 3.12 ``                  |
| [`75228216`](https://github.com/NixOS/nixpkgs/commit/75228216b1aa197e8d5c1b7be209f84a623357cd) | `` python312Packages.hdmedians: replace nose with pytest ``                          |
| [`34a07e8f`](https://github.com/NixOS/nixpkgs/commit/34a07e8f52df768b5a8943010f28ce86ce6a9ff2) | `` python312Packages.segdiag: revert to nose, disable tests on 3.12 ``               |
| [`db4f14a4`](https://github.com/NixOS/nixpkgs/commit/db4f14a4f36cab5f87b4f4a2abecda14f64ca464) | `` python312Packages.pytimeparse: revert to nose, disable tests on 3.12 ``           |
| [`ac1eeed1`](https://github.com/NixOS/nixpkgs/commit/ac1eeed1eb692ebfd5f857dde84d51572c9880ae) | `` python312Packages.annoy: migrate to pytest ``                                     |
| [`0cf8b76d`](https://github.com/NixOS/nixpkgs/commit/0cf8b76db9a5b4412a84fa8b96eaa93ed7435949) | `` python312Packages.xlwt: revert to nose, disable tests on 3.12 ``                  |
| [`f8214edc`](https://github.com/NixOS/nixpkgs/commit/f8214edc5b614e27ede77703ed8fd63e960ec6c1) | `` python312Packages.biopandas: revert to nose, disable tests on 3.12 ``             |
| [`a78d2e17`](https://github.com/NixOS/nixpkgs/commit/a78d2e175ced2634fccb1aa3d8cc03e037c2a911) | `` python312Packages.pygatt: revert to nose, disable tests on 3.12 ``                |
| [`14956c0e`](https://github.com/NixOS/nixpkgs/commit/14956c0eff400241d61217fc86b4299fec3a0887) | `` python312Packages.pprintpp: revert to nose, disable tests on 3.12 ``              |
| [`15c17309`](https://github.com/NixOS/nixpkgs/commit/15c17309672ee5447adfd715623146dba45b3009) | `` python312Packages.case: drop ``                                                   |
| [`d998e535`](https://github.com/NixOS/nixpkgs/commit/d998e535b9ca3740fda3ec56e47ce27946d7b8fb) | `` python312Packages.django-celery-beat: remove case dependency ``                   |
| [`72102c06`](https://github.com/NixOS/nixpkgs/commit/72102c0626b66bf54988d6b1ed5c24ddeaf67f53) | `` python312Packages.billiard: remove case dependency ``                             |
| [`832e7d33`](https://github.com/NixOS/nixpkgs/commit/832e7d33d6907c4148022e0fb713036672d0e091) | `` python312Packages.kombu: remove case dependency ``                                |
| [`01bd09bb`](https://github.com/NixOS/nixpkgs/commit/01bd09bbe4c5b9bfc52399c56fb9fdf252584746) | `` python312Packages.amqp: drop case dependency ``                                   |
| [`7a4a40d0`](https://github.com/NixOS/nixpkgs/commit/7a4a40d048f2ce95c7ef50e9a993c3eedfb230cd) | `` python312Packages.vine: drop case dependency ``                                   |
| [`6fccf03a`](https://github.com/NixOS/nixpkgs/commit/6fccf03a30dd43cc64e28ba68e894dc080c7ca6c) | `` python312Packages.aiounittest: migrate to pytest ``                               |
| [`72a1b22d`](https://github.com/NixOS/nixpkgs/commit/72a1b22d6831a18d1985ebc4af6081b30b332730) | `` python312Packages.envs: revert to nose, disable tests on 3.12 ``                  |
| [`b12ff378`](https://github.com/NixOS/nixpkgs/commit/b12ff378fe5795032b0f19bfbca0a48817fc0ebf) | `` python312Packages.lockfile: revert to nose, disable tests on 3.12 ``              |
| [`fedea1e0`](https://github.com/NixOS/nixpkgs/commit/fedea1e0faf4bc77a8b7e316da90f7b5ee24e49d) | `` python312Packages.forbiddenfruit: drop ``                                         |
| [`64a824ad`](https://github.com/NixOS/nixpkgs/commit/64a824adc33694c72f1915697cb9f276db8aeb54) | `` python312Packages.uvcclient: revert to nose, disable tests on 3.12 ``             |
| [`bf04c9e4`](https://github.com/NixOS/nixpkgs/commit/bf04c9e4bda4914fed1c3fb7620c9f1b37ba1579) | `` python312Packages.enocean: revert to nose, disable tests on 3.12 ``               |
| [`a378586b`](https://github.com/NixOS/nixpkgs/commit/a378586b503d635ef54fd46bd5ab247fdf1caa41) | `` python312Packages.sphinx-rtd-dark-theme: revert to nose, disable tests on 3.12 `` |
| [`3bd1aeb9`](https://github.com/NixOS/nixpkgs/commit/3bd1aeb99faff8c8a64c5c3bc42b6ff392189c16) | `` python312Packages.http-ece: revert to nose, disable tests on 3.12 ``              |
| [`cb1a1c91`](https://github.com/NixOS/nixpkgs/commit/cb1a1c916465442a9eff4153f2d36b058019984d) | `` python312Packages.actdiag: revert to nose, disable tests on 3.12 ``               |
| [`48b283e7`](https://github.com/NixOS/nixpkgs/commit/48b283e71f4b953334e88a9b6bdffc20613ca0d8) | `` python312Packages.blockdiag: revert to nose, disable tests on 3.12 ``             |
| [`304cf627`](https://github.com/NixOS/nixpkgs/commit/304cf6275e0fd726ceb92508a3f563aefc7c5dce) | `` python312Packages.pylacrosse: revert to nose, disable tests on 3.12 ``            |
| [`241da09d`](https://github.com/NixOS/nixpkgs/commit/241da09d501d01b5f4e08d81a80ae86af476f2c4) | `` python312Packages.cle: remove unused dependency on pynose ``                      |
| [`01f6deed`](https://github.com/NixOS/nixpkgs/commit/01f6deed20063e35e9ee78ca1fa74bf3341adedf) | `` python312Packages.aadict: drop ``                                                 |
| [`9d8691d3`](https://github.com/NixOS/nixpkgs/commit/9d8691d37c51c8be91f949c5c6ebc94b183b94fc) | `` python312Packages.influxdb: patch out nose ``                                     |
| [`1a4a79ab`](https://github.com/NixOS/nixpkgs/commit/1a4a79ab61ff831ad138f4f0633c9724db62c94e) | `` python312Packaegs.kazoo: remove pynose ``                                         |
| [`78f94353`](https://github.com/NixOS/nixpkgs/commit/78f943535f499c87972213eb44943c915a5b31fe) | `` python312Packages.xlib: don't use nose ``                                         |
| [`6c82ba40`](https://github.com/NixOS/nixpkgs/commit/6c82ba40136f0191f53a31d69def74c4a3b0a8ce) | `` Revert "python312Packages.xlib: disable tests for python 3.12" ``                 |
| [`55b0b1be`](https://github.com/NixOS/nixpkgs/commit/55b0b1beab82384ad61a1f71410c02715cf53885) | `` nrfutil: modernize ``                                                             |
| [`1b22329b`](https://github.com/NixOS/nixpkgs/commit/1b22329bc0fb9cdc37b1689cbaf5a2b1e8209d82) | `` nrfutil: use pytest instead of nose ``                                            |
| [`84a5d6db`](https://github.com/NixOS/nixpkgs/commit/84a5d6db4098677b4bae1b01703220ec09278083) | `` asciinema: modernize ``                                                           |
| [`bf321bbb`](https://github.com/NixOS/nixpkgs/commit/bf321bbb85e76d3f2a2a8672c291c722d44869ad) | `` asciinema: don't use nose ``                                                      |
| [`75bc8aa0`](https://github.com/NixOS/nixpkgs/commit/75bc8aa03a38155457c72c6d80f8fcb9c25c9b4d) | `` python312Packages.jaconv: modernize ``                                            |
| [`195215f7`](https://github.com/NixOS/nixpkgs/commit/195215f7e048f44b79e8b7dad33cf790dc019af1) | `` python312Packages.jaconv: don't use nose ``                                       |
| [`c97a3ace`](https://github.com/NixOS/nixpkgs/commit/c97a3ace23de27a80012cb95db5a55d29ae55fb0) | `` Revert "python312Packages.jaconv: disable tests for python 3.12" ``               |
| [`e5fce3ca`](https://github.com/NixOS/nixpkgs/commit/e5fce3ca480c039246405e807f581df3c8c137b7) | `` python3Packages.openai-triton: fix build module ``                                |
| [`85b5ae21`](https://github.com/NixOS/nixpkgs/commit/85b5ae21375f7210452c989914b8e1d595a1b1fe) | `` bitwarden-desktop: export _logHook for sub-shell ``                               |
| [`5f3d7136`](https://github.com/NixOS/nixpkgs/commit/5f3d71366db473365857866d630d780916ff991f) | `` yutto: format ``                                                                  |
| [`f40cb8ed`](https://github.com/NixOS/nixpkgs/commit/f40cb8ed714e0d2856ed30a709bbc46285e54a01) | `` yutto: 2.0.0-beta.37 -> 2.0.0-beta.40 ``                                          |
| [`c19f4c52`](https://github.com/NixOS/nixpkgs/commit/c19f4c52582c3a29a81bf2919570d1646ab41552) | `` nn: init at 2.0.8-unstable-2024-04-08 ``                                          |
| [`4c0a290a`](https://github.com/NixOS/nixpkgs/commit/4c0a290a4f635cec70d36ef831b43b6476466e2c) | `` lxd-ui: 0.9 -> 0.10 ``                                                            |
| [`126c44ef`](https://github.com/NixOS/nixpkgs/commit/126c44ef2ac938b26ba2cbc22937e66ea3936a96) | `` python312Packages.tesserocr: 2.6.3 -> 2.7.0 ``                                    |
| [`d0ae2b83`](https://github.com/NixOS/nixpkgs/commit/d0ae2b83ae6aa86c1288cad0cd4279616d433cc1) | `` python3Packages.django-timezone-field: 5.1 -> 7.0 ``                              |
| [`9984f09b`](https://github.com/NixOS/nixpkgs/commit/9984f09bb1b658a282dda02ff160cf8ae90c8c9d) | `` mkdocs-awesome-pages-plugin: init at 2.9.2 (#320709) ``                           |
| [`d24d59a3`](https://github.com/NixOS/nixpkgs/commit/d24d59a37a4734108bf889c0455732d322b323e2) | `` maintainers: remove spacefault ``                                                 |
| [`4065496c`](https://github.com/NixOS/nixpkgs/commit/4065496c9fe33f244942cb7968b0a7e56f611715) | `` openocd: allow building for Windows ``                                            |
| [`630eb446`](https://github.com/NixOS/nixpkgs/commit/630eb4460b9074ecca6e2fa9bdbc554ca4929173) | `` linux-firmware: 20240610 -> 20240709 ``                                           |
| [`aa820833`](https://github.com/NixOS/nixpkgs/commit/aa820833895c257958b5f77f7bff7c81e285068d) | `` calibre: 7.12 -> 7.13 ``                                                          |
| [`c9dfa5fc`](https://github.com/NixOS/nixpkgs/commit/c9dfa5fc25c3104f938b86888778c6aa759dc0bc) | `` qt6packages.qtwayland: pull pending upstream fix for popup parents ``             |
| [`7ccddbdc`](https://github.com/NixOS/nixpkgs/commit/7ccddbdcd59d8223749a504715332506aef3d600) | `` pypass: disables tests on python 3.12 as nose does not support it ``              |
| [`4d4223ab`](https://github.com/NixOS/nixpkgs/commit/4d4223abc26533cfe4a1f0d5eae056a519251727) | `` hypre: init at 2.31.0 ``                                                          |
| [`2a16961b`](https://github.com/NixOS/nixpkgs/commit/2a16961ba7e581da3a72a5a9b202eb4553bb117e) | `` azure-cli: document update procedure ``                                           |
| [`a46bc380`](https://github.com/NixOS/nixpkgs/commit/a46bc380ca0a755496d2f6c23fca23c4d9bc5364) | `` azure-cli: 2.61.0 -> 2.62.0 ``                                                    |
| [`4ab447c0`](https://github.com/NixOS/nixpkgs/commit/4ab447c062006f4ba384e9592df0524532f46282) | `` fluent-bit: 3.0.7 -> 3.1.0 ``                                                     |
| [`11e6e900`](https://github.com/NixOS/nixpkgs/commit/11e6e900884ec31416d1315bc9f4714cbbd1515b) | `` {warp-terminal,vscode}: add johnrtitor as maintainer ``                           |
| [`93837d78`](https://github.com/NixOS/nixpkgs/commit/93837d788cda788e660bc5db731bec9f6df4a6cb) | `` ocamlPackages.merlin: 4.14-501 → 4.16-501, 5.1-502 ``                             |
| [`eb725313`](https://github.com/NixOS/nixpkgs/commit/eb725313bcaa538abc35cb4ae32a0dd3e8f79661) | `` treewide: remove Enzime ``                                                        |
| [`94366fe3`](https://github.com/NixOS/nixpkgs/commit/94366fe3365cdff363c8b1bf9c3478a64de4c34e) | `` ocamlPackages.phylogenetics: 0.2.0 → 0.3.0 ``                                     |
| [`96f3e44e`](https://github.com/NixOS/nixpkgs/commit/96f3e44ef9348531315bc242362a733a1fd1185e) | `` cpeditor: file desktop exec path ``                                               |
| [`4495fc33`](https://github.com/NixOS/nixpkgs/commit/4495fc33866ebf69e9bd42f760a83be5e4a96e72) | `` ocamlPackages.biotk: 0.2.0 → 0.3 ``                                               |
| [`d66c2b0b`](https://github.com/NixOS/nixpkgs/commit/d66c2b0b5d55dbd2194e24bafdc5bcdd246d6761) | `` python312Packages.google-cloud-vpc-access: 1.10.3 -> 1.10.4 ``                    |
| [`eefb6aa2`](https://github.com/NixOS/nixpkgs/commit/eefb6aa2e2636338afab229efc428111b29d5a23) | `` python312Packages.google-cloud-vision: 3.7.2 -> 3.7.3 ``                          |
| [`3c21cb30`](https://github.com/NixOS/nixpkgs/commit/3c21cb305b033a7ff8c94f826dd9d7daec0ef71d) | `` python312Packages.google-cloud-appengine-logging: 1.4.3 -> 1.4.4 ``               |
| [`66745b04`](https://github.com/NixOS/nixpkgs/commit/66745b04a83602f35da90401da74beb1e06bfbae) | `` python312Packages.google-cloud-translate: 3.15.3 -> 3.15.4 ``                     |
| [`9d1d3c5e`](https://github.com/NixOS/nixpkgs/commit/9d1d3c5eea8b09049e52f7f3fd7b0e9d481867b5) | `` python312Packages.google-cloud-os-config: 1.17.3 -> 1.17.4 ``                     |
| [`a2c69084`](https://github.com/NixOS/nixpkgs/commit/a2c69084d984224e045302cab6c4537b8ecfd441) | `` python312Packages.google-cloud-automl: 2.13.3 -> 2.13.4 ``                        |
| [`e4b521fe`](https://github.com/NixOS/nixpkgs/commit/e4b521fefbc73828d60035cc9ebd6729f4874521) | `` fail2ban: install setuptools ``                                                   |
| [`79a5e9bf`](https://github.com/NixOS/nixpkgs/commit/79a5e9bfc58334fa558e94d8010d356bb0af7113) | `` python312Packages.jaconv: disable tests for python 3.12 ``                        |
| [`e0e95085`](https://github.com/NixOS/nixpkgs/commit/e0e95085aeb1d2bc0f67f02c14526010aa1cf66c) | `` python312Packages.xlib: disable tests for python 3.12 ``                          |
| [`e35d56a7`](https://github.com/NixOS/nixpkgs/commit/e35d56a79e1c88f783da648189dc3f47d63efa1c) | `` opensnitch-ui: 1.6.5.1 -> 1.6.6 ``                                                |
| [`a0da4af2`](https://github.com/NixOS/nixpkgs/commit/a0da4af28c613f2f5ca150dc5d4b848b359810b7) | `` opensnitch-ui: set updateScript ``                                                |
| [`5219e205`](https://github.com/NixOS/nixpkgs/commit/5219e205c6b1102eaa05fb2007e6898eac3087a1) | `` terraform-providers.yandex: 0.122.0 -> 0.123.0 ``                                 |
| [`86e977e8`](https://github.com/NixOS/nixpkgs/commit/86e977e8267cc2064f9e7679b76ed250b7d7e8ec) | `` terraform-providers.tencentcloud: 1.81.105 -> 1.81.107 ``                         |
| [`19d0aa24`](https://github.com/NixOS/nixpkgs/commit/19d0aa24c6bae5b0d2b5c4c9e2cb11f95ed9ade3) | `` terraform-providers.vsphere: 2.8.1 -> 2.8.2 ``                                    |
| [`5db853d3`](https://github.com/NixOS/nixpkgs/commit/5db853d38199b54039d9ec6b0f5a9f9c8d6e598d) | `` terraform-providers.vcd: 3.12.1 -> 3.13.0 ``                                      |
| [`8dec9f7c`](https://github.com/NixOS/nixpkgs/commit/8dec9f7cfadcf6e662c683a5963a49756d1cc498) | `` terraform-providers.temporalcloud: 0.0.8 -> 0.0.9 ``                              |
| [`d5cbf5c9`](https://github.com/NixOS/nixpkgs/commit/d5cbf5c972e0619b786dca9e372b031acead1806) | `` terraform-providers.sumologic: 2.30.1 -> 2.31.1 ``                                |
| [`bc38c2fe`](https://github.com/NixOS/nixpkgs/commit/bc38c2fe64021db74b53a53301fc4fb87083f894) | `` terraform-providers.spotinst: 1.178.0 -> 1.180.2 ``                               |
| [`885e03e6`](https://github.com/NixOS/nixpkgs/commit/885e03e6219768e179f62501523ffc8d2935eaf4) | `` terraform-providers.oci: 5.46.0 -> 6.1.0 ``                                       |
| [`16b25f8f`](https://github.com/NixOS/nixpkgs/commit/16b25f8fb1e22156e5ef8ad759bc704de9effd45) | `` terraform-providers.pagerduty: 3.14.3 -> 3.14.5 ``                                |
| [`b59dc2b0`](https://github.com/NixOS/nixpkgs/commit/b59dc2b00ac240133669c9d616408e2acccaf447) | `` terraform-providers.ns1: 2.3.0 -> 2.3.1 ``                                        |
| [`806a6c77`](https://github.com/NixOS/nixpkgs/commit/806a6c77d767e4dc742092834c245c5ade169636) | `` terraform-providers.newrelic: 3.38.1 -> 3.39.1 ``                                 |
| [`cc3a1d80`](https://github.com/NixOS/nixpkgs/commit/cc3a1d801c59e0bfcef91182ca035c80d564a957) | `` terraform-providers.mongodbatlas: 1.17.2 -> 1.17.3 ``                             |
| [`0b13e030`](https://github.com/NixOS/nixpkgs/commit/0b13e030a5650c9e33cbc1ddeca0f4178ce75237) | `` terraform-providers.ibm: 1.64.0 -> 1.67.1 ``                                      |
| [`2f4d969a`](https://github.com/NixOS/nixpkgs/commit/2f4d969a2c8e23cde89ae453cd69b00edbc1ec2f) | `` terraform-providers.linode: 2.23.0 -> 2.23.1 ``                                   |
| [`b631a464`](https://github.com/NixOS/nixpkgs/commit/b631a46441a8f085020caa9275f6886b4ae441f3) | `` terraform-providers.huaweicloud: 1.65.2 -> 1.66.0 ``                              |
| [`a01cb13e`](https://github.com/NixOS/nixpkgs/commit/a01cb13ef84b803f8437718cd54a907860f54d49) | `` terraform-providers.google-beta: 5.35.0 -> 5.36.0 ``                              |
| [`ca8f30fa`](https://github.com/NixOS/nixpkgs/commit/ca8f30fa83cdd1bb828443ce834a0f2840e93a3e) | `` terraform-providers.google: 5.35.0 -> 5.36.0 ``                                   |
| [`9288a7e6`](https://github.com/NixOS/nixpkgs/commit/9288a7e6b37fea77e5b0cf98da7d1dd4e05b3cac) | `` terraform-providers.gitlab: 16.10.0 -> 17.1.0 ``                                  |
| [`446eb42a`](https://github.com/NixOS/nixpkgs/commit/446eb42a88f0fc1ef32b088d2a866d4a54365a41) | `` terraform-providers.fastly: 5.10.0 -> 5.11.0 ``                                   |
| [`af72941e`](https://github.com/NixOS/nixpkgs/commit/af72941edb57194898ab046ae00051d1d9e628e9) | `` terraform-providers.equinix: 1.38.1 -> 2.0.1 ``                                   |
| [`e91cf36a`](https://github.com/NixOS/nixpkgs/commit/e91cf36a3fc027f4e8471a7812e0b83826af9132) | `` terraform-providers.aws: 5.43.0 -> 5.57.0 ``                                      |
| [`73af54f6`](https://github.com/NixOS/nixpkgs/commit/73af54f6f7952dd3f3ddaa43fb62ad7a77ee0550) | `` terraform-providers.datadog: 3.39.0 -> 3.40.0 ``                                  |
| [`08e52a9a`](https://github.com/NixOS/nixpkgs/commit/08e52a9a03cb16422f32a93290a3fc424302b67d) | `` terraform-providers.azurerm: 3.109.0 -> 3.111.0 ``                                |
| [`505f2cbf`](https://github.com/NixOS/nixpkgs/commit/505f2cbf996a43e945f7d89412be29b150c93112) | `` terraform-providers.checkly: 1.7.8 -> 1.8.0 ``                                    |
| [`64889c8a`](https://github.com/NixOS/nixpkgs/commit/64889c8aefd1dbfd687ed3f871f8b23459090f36) | `` terraform-providers.buildkite: 1.10.0 -> 1.10.1 ``                                |
| [`3cf70648`](https://github.com/NixOS/nixpkgs/commit/3cf706484ff2b841e8535d19bd4c73389ebc4353) | `` terraform-providers.alicloud: 1.225.1 -> 1.226.0 ``                               |
| [`0e9f2ecf`](https://github.com/NixOS/nixpkgs/commit/0e9f2ecf349135ec3fd4c98f1fb9e438e4662094) | `` terraform-providers.azuread: 2.52.0 -> 2.53.1 ``                                  |
| [`3830a90d`](https://github.com/NixOS/nixpkgs/commit/3830a90d1c8671105148c9bae2d01b88572cdb2c) | `` terraform-providers.acme: 2.23.2 -> 2.24.2 ``                                     |
| [`70fb518c`](https://github.com/NixOS/nixpkgs/commit/70fb518cb05fd1682879dc55d272fc3711eed6d3) | `` terraform-providers.artifactory: 11.0.0 -> 11.1.0 ``                              |
| [`946ca027`](https://github.com/NixOS/nixpkgs/commit/946ca027d4d966666092163d53d080fc84a06f88) | `` terraform-providers.aiven: 4.19.1 -> 4.20.0 ``                                    |
| [`bd567605`](https://github.com/NixOS/nixpkgs/commit/bd5676058c27dabee27808690401927bbe19a196) | `` terraform-providers.aci: 2.14.0 -> 2.15.0 ``                                      |
| [`09e2d2e3`](https://github.com/NixOS/nixpkgs/commit/09e2d2e32d8632477cdab1888c30f74ef0da4d75) | `` emacs.pkgs.org-xlatex: 20230820 -> 20240707 ``                                    |
| [`e67ce8d4`](https://github.com/NixOS/nixpkgs/commit/e67ce8d490e0d1ad4c0569dbb07512ddd6175800) | `` Lemmy 0.19.3 -> 0.19.5 ``                                                         |
| [`fc8576c0`](https://github.com/NixOS/nixpkgs/commit/fc8576c06299d613a8b79ff86d264fb5698a0237) | `` hplip: fix ``                                                                     |
| [`cfe063d1`](https://github.com/NixOS/nixpkgs/commit/cfe063d174d955f88ce73e39a6de2bced18de065) | `` overrideSDK: fix missing host platform inside of override ``                      |
| [`80e3c2c5`](https://github.com/NixOS/nixpkgs/commit/80e3c2c5d0d2138fad54896a19dc64260a066304) | `` llvmPackages_{13,14,15,16,17,18,git}: commonify the default.nix ``                |
| [`e56afd06`](https://github.com/NixOS/nixpkgs/commit/e56afd060b725b32d3922c887e8b97ca5be2f16f) | `` mopidy-youtube: replace youtube-dl with yt-dlp ``                                 |
| [`355152d4`](https://github.com/NixOS/nixpkgs/commit/355152d4b16b2dab685bdd7e39ff3b02e7060fbf) | `` gotrue-supabase: 2.105.0 -> 2.155.1 ``                                            |
| [`d2925a61`](https://github.com/NixOS/nixpkgs/commit/d2925a613601ab749a98fef4ce8960c2cd815a0b) | `` python3Packages.django-cors-headers: 3.13.0 -> 4.4.0 ``                           |