### PR TITLE
chore(flake/home-manager): `c085b984` -> `90ae324e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720646128,
-        "narHash": "sha256-BivO5yIQukDlJL+1875Sqf3GuOPxZDdA48dYDi3PkL8=",
+        "lastModified": 1720734513,
+        "narHash": "sha256-neWQ8eNtLTd+YMesb7WjKl1SVCbDyCm46LUgP/g/hdo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c085b984ff2808bf322f375b10fea5a415a9c43d",
+        "rev": "90ae324e2c56af10f20549ab72014804a3064c7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`90ae324e`](https://github.com/nix-community/home-manager/commit/90ae324e2c56af10f20549ab72014804a3064c7f) | `` sd-switch: respect xdg directory specifications `` |