### PR TITLE
chore(flake/nixvim-flake): `7e000a65` -> `5b99b845`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1720735864,
-        "narHash": "sha256-5WKKGVJK5wVrQhifcSaopHv3rSDzg853z2mmWMjILY8=",
+        "lastModified": 1720749941,
+        "narHash": "sha256-BzbeGZkaoULayiNK2BYEzX6XYqbzF8t2DN8eD+e+i20=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "7e000a653a90255600e11b63af26522aeff3c16d",
+        "rev": "5b99b8451479bf75e2c0764d8d9c2ba12901b69f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                        |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`5b99b845`](https://github.com/alesauce/nixvim-flake/commit/5b99b8451479bf75e2c0764d8d9c2ba12901b69f) | `` chore(flake.nix) - refactoring creation of nixvim module in flake (#126) `` |
| [`47029ebc`](https://github.com/alesauce/nixvim-flake/commit/47029ebc374e55e5a84af2bad4cf74629b1a2677) | `` chore(flake/nixpkgs): 655a58a7 -> feb2849f ``                               |