### PR TITLE
chore(flake/nixvim-flake): `5b99b845` -> `a34ed490`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1720425287,
-        "narHash": "sha256-iKcXfOtB2XLDSRZdwi2+cxoO/wOEidHIJOQRSRd7rV0=",
+        "lastModified": 1720804407,
+        "narHash": "sha256-mLVzkOpfOqYPmwjAAHRmeVUoOUmpLpxmfKDObT1FVtc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "451beb4ecaf56fea38ffe82588364aae4161a2d8",
+        "rev": "89d74cdce173223f57754c6a315c929f8fc14229",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1720749941,
-        "narHash": "sha256-BzbeGZkaoULayiNK2BYEzX6XYqbzF8t2DN8eD+e+i20=",
+        "lastModified": 1720844029,
+        "narHash": "sha256-K6kNzj+uNiZvHcUpcIeZ83qeqtayWlXyv4/Kcf+3mxg=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5b99b8451479bf75e2c0764d8d9c2ba12901b69f",
+        "rev": "a34ed4900207a06ac53a5dc9ac47e21d02c26bbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                                  |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
| [`a34ed490`](https://github.com/alesauce/nixvim-flake/commit/a34ed4900207a06ac53a5dc9ac47e21d02c26bbd) | `` feat(config/treesitter) - updating treesitter settings with highlight, indent, and parsers" (#127) `` |
| [`1ce1bc9c`](https://github.com/alesauce/nixvim-flake/commit/1ce1bc9c88ae4eb2a4114b6bd1cc5e19fdbb1a4a) | `` removing ensureInstalled, setting nixGrammars to false and setting parser dir ``                      |
| [`aafa473b`](https://github.com/alesauce/nixvim-flake/commit/aafa473b0081d289e4df12f5da72e3f5303fdee0) | `` adding xdg_data_home variable to github ci workflow ``                                                |
| [`8613290a`](https://github.com/alesauce/nixvim-flake/commit/8613290a2c423bd842ee58af37d7ae7cc8d0ba47) | `` removing all ensure_installed grammars ``                                                             |
| [`2a1ed566`](https://github.com/alesauce/nixvim-flake/commit/2a1ed566641e4fe325b60089897b620275dac236) | `` simplifying usage of nixvimLib to align with simple flake template ``                                 |
| [`49ad2265`](https://github.com/alesauce/nixvim-flake/commit/49ad22656afff354fb958cf23bf44cb6d4699efa) | `` chore(flake/nixvim): 451beb4e -> 89d74cdc ``                                                          |