### PR TITLE
chore(flake/git-hooks): `8d6a17d0` -> `f451c193`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -319,11 +319,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1720524665,
-        "narHash": "sha256-ni/87oHPZm6Gv0ECYxr1f6uxB0UKBWJ6HvS7lwLU6oY=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8d6a17d0cdf411c55f12602624df6368ad86fac1",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`2c2eb0d4`](https://github.com/cachix/git-hooks.nix/commit/2c2eb0d42ef93f85d151a7ecff840cd78a7d9893) | `` Update Ruff check ``                                     |
| [`587776af`](https://github.com/cachix/git-hooks.nix/commit/587776afda8e6a57a8a8db9c2fe9cf11e3ecfc16) | `` Allow importing modules into the inner module system. `` |