### PR TITLE
chore(flake/darwin): `5ce8503c` -> `7522a30d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720845312,
-        "narHash": "sha256-yPhAsJTpyoIPQZJGC8Fw8W2lAXyhLoTn+HP20bmfkfk=",
+        "lastModified": 1721086468,
+        "narHash": "sha256-OF642LVDj5Icr0tXlY9P54vna4OP10IMhIhhiKwIRpw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5ce8503cf402cf76b203eba4b7e402bea8e44abc",
+        "rev": "7522a30d328f885d20c2815bd05eb711bc69644c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                      |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
| [`395e4d37`](https://github.com/LnL7/nix-darwin/commit/395e4d3794465f7d68b588c1bd7f5f357e88d8d2) | `` Update modules/nix/linux-builder.nix ``                                                   |
| [`b34d1bee`](https://github.com/LnL7/nix-darwin/commit/b34d1bee4875ad7dbb2f030c451e07fb27ef67ca) | `` Add `User` and  already generated `IdentityFile` to ssh_config for `nix.linux-builder` `` |