### PR TITLE
chore(flake/nixvim-flake): `4ca611a3` -> `e50da559`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1721042250,
-        "narHash": "sha256-CEOGzI9WFGezwJ3lok0F//1UEq5crzE2kZDLQK2EtfE=",
+        "lastModified": 1721224205,
+        "narHash": "sha256-W0+l7HNzZfEmIx/1Yp3Tow/GZILVjrMjWfTt1Mos7mI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b9ed90003273f0a75151b32948e16b44891f403c",
+        "rev": "55bda0cc3b230255d271e5eef82f3279dae9f859",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721066323,
-        "narHash": "sha256-hpoj7NW/zbg29QDXlXD3rlmNgwE1F60vrzB2YQuHFXk=",
+        "lastModified": 1721233564,
+        "narHash": "sha256-OZ/j6raC7wsVEQtsW1fm28Ga0yGaItBn9z91SFrPC5A=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "4ca611a31bb9c9c7ae8b5bed0168d84671ea9f34",
+        "rev": "e50da5591f0d241d8d34c8ba7ef6f5e72d4a1666",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`e50da559`](https://github.com/alesauce/nixvim-flake/commit/e50da5591f0d241d8d34c8ba7ef6f5e72d4a1666) | `` chore(flake/nixvim): b9ed9000 -> 55bda0cc `` |