### PR TITLE
chore(flake/nixpkgs): `693bc46d` -> `ad0b5eed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -584,11 +584,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1721138476,
+        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a5b8316e`](https://github.com/NixOS/nixpkgs/commit/a5b8316e53bec5801deef176599a1f72f74605f1) | `` kdePackages: Plasma 6.1.2 -> 6.1.3 ``                                        |
| [`0ba57b39`](https://github.com/NixOS/nixpkgs/commit/0ba57b396f101a161e18675d35d40b21af4dfdcd) | `` souffle: add markusscherer as maintainer ``                                  |
| [`a441e6a6`](https://github.com/NixOS/nixpkgs/commit/a441e6a6a6a0a92daad074c92f886e96bf2f2528) | `` maintainers: add markusscherer ``                                            |
| [`c8c340b4`](https://github.com/NixOS/nixpkgs/commit/c8c340b4683d6025abb73430ef7ae0e211892c54) | `` souffle: add some package tests ``                                           |
| [`9a0a4ca9`](https://github.com/NixOS/nixpkgs/commit/9a0a4ca9ce875e42c590b977b7a5521bda0e7003) | `` souffle: fix souffle-compile.py ``                                           |
| [`c5613a93`](https://github.com/NixOS/nixpkgs/commit/c5613a93f8c4a3ef350e654c78778ce10f914e6e) | `` python311Packages.huggingface-hub: 0.23.4 -> 0.23.5 ``                       |
| [`e1770bd1`](https://github.com/NixOS/nixpkgs/commit/e1770bd11952fb40cf134b809f15debdfde168c2) | `` realm-studio: init at 15.2.1 (#325967) ``                                    |
| [`7a0d1c51`](https://github.com/NixOS/nixpkgs/commit/7a0d1c51783f02fe874ee990d438469573c2e689) | `` kryptor: init at 4.1.0 (#326334) ``                                          |
| [`0ac0801e`](https://github.com/NixOS/nixpkgs/commit/0ac0801e101a3bf66cc9c730c850c0f3d290208b) | `` picocrypt-cli: init at 2.04 (#326360) ``                                     |
| [`b0b0285c`](https://github.com/NixOS/nixpkgs/commit/b0b0285ce6f8feebbed2c05ab51dd6ebabbfba12) | `` python311Packages.python-lsp-ruff: 2.2.1 -> 2.2.2 ``                         |
| [`c8dfaee8`](https://github.com/NixOS/nixpkgs/commit/c8dfaee895788edbb9cbb0a09e340cb485ccb038) | `` lib25519: init at 20240321 (#319618) ``                                      |
| [`e3dc4b2b`](https://github.com/NixOS/nixpkgs/commit/e3dc4b2bcbf675219f4bd9ab528debc8b35e347f) | `` lan-mouse: switch to cargoHash ``                                            |
| [`c7bb9bf6`](https://github.com/NixOS/nixpkgs/commit/c7bb9bf6b0119f9ed5c3f14f54950fd560199cab) | `` python312Packages.beancount-black: 1.0.2 -> 1.0.4 ``                         |
| [`03de0c29`](https://github.com/NixOS/nixpkgs/commit/03de0c2960056671b0447a7cbe2e83d4d541b11b) | `` python312Packages.colored-traceback: 0.3.0 -> 0.4.2 ``                       |
| [`d4e9d5a1`](https://github.com/NixOS/nixpkgs/commit/d4e9d5a11348f8c4a7eeec5121dc4445a1abbfc2) | `` keet: 1.2.1 -> 2.2.0 (#308337) ``                                            |
| [`c0a9d48d`](https://github.com/NixOS/nixpkgs/commit/c0a9d48d1a0cc4b546d5f3cfe843e565276c46f6) | `` refactor: move mcfly to by-name ``                                           |
| [`feb20da9`](https://github.com/NixOS/nixpkgs/commit/feb20da98fe546ab5342e0d7720da8fcda53daab) | `` or-tools: 9.4 -> 9.7 ``                                                      |
| [`8093ed7a`](https://github.com/NixOS/nixpkgs/commit/8093ed7a5171d8f916398d40fda30e353cc04120) | `` scope-tui: add aleksana to maintainers ``                                    |
| [`5f134632`](https://github.com/NixOS/nixpkgs/commit/5f134632ffe92112d6e9870049c1553fd3032bca) | `` scope-tui: 0-unstable-2024-03-16 -> 0.3.0-unstable-2024-05-06 ``             |
| [`85fbe210`](https://github.com/NixOS/nixpkgs/commit/85fbe210ba99b7f1ce34ec0e2c4afa84200365e9) | `` vdrPlugins.softhddevice: 2.3.4 -> 2.3.5 ``                                   |
| [`99d79168`](https://github.com/NixOS/nixpkgs/commit/99d791681bf20252d7db4a667428081f867c0cc2) | `` python3Packages.pyinstaller: init at 6.8.0 ``                                |
| [`90d89c4c`](https://github.com/NixOS/nixpkgs/commit/90d89c4c639e5ba87a924080c240f6dc0a2a654b) | `` python3Packages.altgraph: add missing dependency ``                          |
| [`8564cb15`](https://github.com/NixOS/nixpkgs/commit/8564cb1517f118e1e90b8bc9ba052678f1aa4603) | `` coqPackages.multinomials switched back to coq_makefile ``                    |
| [`c3cedb8b`](https://github.com/NixOS/nixpkgs/commit/c3cedb8bb8aea90d0ff6f900ccdffe6143b2ff66) | `` ananicy-rules-cachyos: 0-unstable-2024-07-03 -> 0-unstable-2024-07-11 ``     |
| [`598bc1e6`](https://github.com/NixOS/nixpkgs/commit/598bc1e6d498e08bbd103bba5c517d771d3be439) | `` python312Packages.apkinspector: 1.2.4 -> 1.3.0 ``                            |
| [`fbc274ec`](https://github.com/NixOS/nixpkgs/commit/fbc274ec809716cae5fa9b50c919ff5b17473d58) | `` python3Packages.dohq-artifactory: init at 0.10.0 ``                          |
| [`3007cb41`](https://github.com/NixOS/nixpkgs/commit/3007cb41936117ea8d2be2d10fc12386faed18cb) | `` python3Packages.pyinstaller-hooks-contrib: init at 2024.7 ``                 |
| [`206d68e8`](https://github.com/NixOS/nixpkgs/commit/206d68e865a65419570a95d6ffa7a3287bf339c3) | `` wcurl: init at 2024.07.10 ``                                                 |
| [`a68cb202`](https://github.com/NixOS/nixpkgs/commit/a68cb202a25c0320d11bdbe7aeeebe6d9c870141) | `` dnsproxy: 0.71.2 -> 0.72.0 ``                                                |
| [`be420db1`](https://github.com/NixOS/nixpkgs/commit/be420db169e476c1e85dc9278974099d857bd2f2) | `` rabbit: 1.0.5 -> 2.0.0 ``                                                    |
| [`cc2790ff`](https://github.com/NixOS/nixpkgs/commit/cc2790ff1ed42d625bfe9073c390c215b8b52e72) | `` nixos/k3s: accept a list of extraFlags ``                                    |
| [`ca919544`](https://github.com/NixOS/nixpkgs/commit/ca919544d3444004ebad346808e750e24a4bbcb1) | `` python311Packages.pytensor: 2.25.1 -> 2.25.2 ``                              |
| [`6be09ce2`](https://github.com/NixOS/nixpkgs/commit/6be09ce2922f12205601ea79037d1f75ff9c37f1) | `` grype: 0.79.2 -> 0.79.3 ``                                                   |
| [`d8a85c7d`](https://github.com/NixOS/nixpkgs/commit/d8a85c7d96d06c2adaa9510485915687f5b71f13) | `` kubescape: 3.0.13 -> 3.0.14 ``                                               |
| [`2e17c4a4`](https://github.com/NixOS/nixpkgs/commit/2e17c4a4daba78edd5dc027eea2eeb74f9da6f6b) | `` nixos/amazon-image: avoid top-level with statements ``                       |
| [`3ba72e28`](https://github.com/NixOS/nixpkgs/commit/3ba72e28340373ef25ad20c8c75bdfbc3202612f) | `` nixos/amazon-image: avoid top-level with statements in maintainers script `` |
| [`6af0e185`](https://github.com/NixOS/nixpkgs/commit/6af0e1855f2360472604b88b319eeb26da4c8bf7) | `` libreoffice: add Korean language pack ``                                     |
| [`896db9a5`](https://github.com/NixOS/nixpkgs/commit/896db9a56db3df8d825bed8da4e7c00ad8db1ddf) | `` bitwarden-cli: 2024.6.1 -> 2024.7.0 ``                                       |
| [`699e2e9d`](https://github.com/NixOS/nixpkgs/commit/699e2e9d1aa0e58382b0956c22e41ad52dc08d3d) | `` chance: init at 4.0.0 ``                                                     |
| [`d91cb30d`](https://github.com/NixOS/nixpkgs/commit/d91cb30da5c11b030b80a9cc3125a42f3866e9f0) | `` redocly: 1.17.0 -> 1.18.0 ``                                                 |
| [`01056a31`](https://github.com/NixOS/nixpkgs/commit/01056a3121b63b934a142a661c0826842a51e191) | `` pinentry-rofi: 2.1.1 -> 2.2.0 ``                                             |
| [`4ecc64bb`](https://github.com/NixOS/nixpkgs/commit/4ecc64bb2356a096f88447effa54ad657599d41e) | `` python312Packages.govee-ble: 0.31.3 -> 0.33.1 ``                             |
| [`5c125469`](https://github.com/NixOS/nixpkgs/commit/5c12546986e51c380cb01b35864c0f2a85f61864) | `` zed: 1.16.0 -> 1.17.0 ``                                                     |
| [`cb2d3572`](https://github.com/NixOS/nixpkgs/commit/cb2d357291f6f446dfa4f9c8b48f0ca593dec0fd) | `` patch2pr: 0.25.0 -> 0.26.1 ``                                                |
| [`d92dd651`](https://github.com/NixOS/nixpkgs/commit/d92dd651b4ad5aae9f34962bb311c711bd32b865) | `` python312Packages.manifestoo-core: 1.6 -> 1.7 ``                             |
| [`7534840b`](https://github.com/NixOS/nixpkgs/commit/7534840b68b840762a496c3a0f343a380c7b736f) | `` python312Packages.model-checker: 0.4.9 -> 0.4.12 ``                          |
| [`eba41fa9`](https://github.com/NixOS/nixpkgs/commit/eba41fa905c433b653198cdc6d31452668892d8a) | `` ignite-cli: 28.4.0 -> 28.5.0 ``                                              |
| [`0c936986`](https://github.com/NixOS/nixpkgs/commit/0c936986c211c54f1a757cde28fd25d3fb872945) | `` maa-cli: 0.4.7 -> 0.4.8 ``                                                   |
| [`0ffc09a7`](https://github.com/NixOS/nixpkgs/commit/0ffc09a73eff3a3c725c77e6223fceed288fbd07) | `` emacs.pkgs.llvm-mode: replace trivialBuild with melpaBuild ``                |
| [`3eb974fb`](https://github.com/NixOS/nixpkgs/commit/3eb974fbbe6e7e2649e145b3f42dfe5151cb095b) | `` polylith: 0.2.19 -> 0.2.20 ``                                                |
| [`3568cc41`](https://github.com/NixOS/nixpkgs/commit/3568cc41f1e382427a263ca04a897b2154fe5450) | `` python312Packages.chacha20poly1305-reuseable: 0.12.1 -> 0.12.2 ``            |
| [`db10106d`](https://github.com/NixOS/nixpkgs/commit/db10106dbc08ac5ffd4c314a7de08d71159844de) | `` chawan: 0-unstable-2024-03-01 -> 0-unstable-2024-07-14 ``                    |
| [`c1c63238`](https://github.com/NixOS/nixpkgs/commit/c1c63238b3e8fd179b6f1d373d35d980444a921a) | `` libcpucycles: init at 20240318 ``                                            |
| [`8166a4cc`](https://github.com/NixOS/nixpkgs/commit/8166a4cc8bb029a47fa86ce143e7d42865001e89) | `` bcachefs-tools: 1.9.2 -> 1.9.3 ``                                            |
| [`3d1c1c0f`](https://github.com/NixOS/nixpkgs/commit/3d1c1c0fceff9c91ec88ca56d58d340bf0c91439) | `` just: 1.30.1 -> 1.31.0 ``                                                    |
| [`0d66f562`](https://github.com/NixOS/nixpkgs/commit/0d66f562a733a7cd8fa1fd4bd8ef9ade2ac394ad) | `` afplusplus: format ``                                                        |
| [`33ce82fa`](https://github.com/NixOS/nixpkgs/commit/33ce82fab45db0efb65a141d0686918119a4bdc1) | `` aflplusplus: modernize ``                                                    |
| [`b2c1f10b`](https://github.com/NixOS/nixpkgs/commit/b2c1f10bfbb3f617ea8e8669ac13f3f56ceb2ea2) | `` helix: 24.03 -> 24.07 ``                                                     |
| [`94a133b2`](https://github.com/NixOS/nixpkgs/commit/94a133b22ef34b73eaf75f7712146fb5837ddd2f) | `` maintainers: add max ``                                                      |
| [`6e3fb85a`](https://github.com/NixOS/nixpkgs/commit/6e3fb85a49b74457cb983c8db02e7042b9ffebc7) | `` aflplusplus: 4.20c: update qemuafl to match 4.20c ``                         |
| [`0613e470`](https://github.com/NixOS/nixpkgs/commit/0613e470539d8f913e4783d463957e578fb74300) | `` renovate: 37.424.3 -> 37.431.7 ``                                            |
| [`cef5e780`](https://github.com/NixOS/nixpkgs/commit/cef5e7801a30fb693d21a1785d6970b1a151d81c) | `` kodiPackages.inputstreamhelper: fix compatibility with Python 3.12 ``        |
| [`7009c733`](https://github.com/NixOS/nixpkgs/commit/7009c7331e956fc2265b19c59b3239f134285deb) | `` python311Packages.testcontainers: 4.7.1 -> 4.7.2 ``                          |
| [`788306fc`](https://github.com/NixOS/nixpkgs/commit/788306fc82c05e46855e72478156ccb85651563c) | `` kodiPackages.sendtokodi: remove dependency on youtube_dl ``                  |
| [`05709d19`](https://github.com/NixOS/nixpkgs/commit/05709d196810a3e01a31d1e0450c64720a318478) | `` live555: 2024.05.15 -> 2024.05.30 ``                                         |
| [`d582f13e`](https://github.com/NixOS/nixpkgs/commit/d582f13e5e6f68b6207a5ad8ba3a3ade470fefae) | `` treewide: switch to cargoHash (#327127) ``                                   |
| [`cb8be278`](https://github.com/NixOS/nixpkgs/commit/cb8be2781ecac23ddd1489aeb4ebe52cfe850fd8) | `` redmine: 5.1.2 -> 5.1.3 ``                                                   |
| [`9a2d00c2`](https://github.com/NixOS/nixpkgs/commit/9a2d00c2e0e8866b146d5f9a838b92e33b0741b9) | `` kdePackages.ark: cherry-pick fix for temp directory cleanup ``               |
| [`8e4a87c5`](https://github.com/NixOS/nixpkgs/commit/8e4a87c54f7a8434c0efdc53ffbd5ce153a54c1d) | `` kdePackages.kio: cherry-pick fix for drag and drop on Wayland ``             |
| [`c342bba1`](https://github.com/NixOS/nixpkgs/commit/c342bba1bce97b3f0e037a70680ef45f2679a417) | `` electron-source.electron_30: 30.1.1 -> 30.2.0 ``                             |
| [`e6ac4936`](https://github.com/NixOS/nixpkgs/commit/e6ac493615b712ee267069b949ad8b0584052c3e) | `` electron-source.electron_29: 29.4.2 -> 29.4.4 ``                             |
| [`bff159a6`](https://github.com/NixOS/nixpkgs/commit/bff159a6ff2bafd943921de3c8a4a00fe8617c1e) | `` electron_30-bin: 30.1.1 -> 30.2.0 ``                                         |
| [`d8b61cd0`](https://github.com/NixOS/nixpkgs/commit/d8b61cd06ed85c8bbc1b76a37d0708a04bb70912) | `` electron_29-bin: 29.4.2 -> 29.4.4 ``                                         |
| [`185601b9`](https://github.com/NixOS/nixpkgs/commit/185601b9b181a5977179dbd97c45d63f659e9149) | `` sonarr: 4.0.5.1710 -> 4.0.7.1863 ``                                          |
| [`6ba20fc4`](https://github.com/NixOS/nixpkgs/commit/6ba20fc4228ce1b3e2e9c9f47896fa012918456c) | `` opencomposite: fix build ``                                                  |
| [`7bbda31f`](https://github.com/NixOS/nixpkgs/commit/7bbda31fc0575ab51801f14e82a32b353aec40b3) | `` qnial: 6.3 -> 6.3_1 ``                                                       |
| [`35644e53`](https://github.com/NixOS/nixpkgs/commit/35644e53d7a0b486ea69bc84b98ad20853e64a0a) | `` qnial: migrate to by-name ``                                                 |
| [`268c1678`](https://github.com/NixOS/nixpkgs/commit/268c167841a8a6573dc2244d5dc6d55ee2e68372) | `` parsedmarc: update dependencies ``                                           |
| [`00cc5a05`](https://github.com/NixOS/nixpkgs/commit/00cc5a05ecdcd4c51da258a9d3dab8448654baf0) | `` python312Packages.kafka-python-ng: init at 2.2.2 ``                          |
| [`2aef9e0b`](https://github.com/NixOS/nixpkgs/commit/2aef9e0b3a7256eef43ab56b66393455feeb110d) | `` python312Packages.expiringdict: modernize ``                                 |
| [`4ea0150b`](https://github.com/NixOS/nixpkgs/commit/4ea0150b7e9860b9aaea7bc04ca56c442c7d3ddb) | `` python312Packages.msgraph-core: 1.1.0 -> 1.1.1 ``                            |
| [`ccf595ee`](https://github.com/NixOS/nixpkgs/commit/ccf595eed373ca2528a8c2092cd387ec5891fae0) | `` vesktop: add updateScript ``                                                 |
| [`5215b63e`](https://github.com/NixOS/nixpkgs/commit/5215b63e7c3b422b064c7a710247d57621d45ea1) | `` python312Packages.stripe: 9.12.0 -> 10.3.0 ``                                |
| [`b8c330e5`](https://github.com/NixOS/nixpkgs/commit/b8c330e598b2009d24ff84671bd09742777c5704) | `` python312Packages.free-proxy: correct src and dependencies ``                |
| [`6a47bb2c`](https://github.com/NixOS/nixpkgs/commit/6a47bb2ca49c9c650a3a1845efc9703dfb5f4173) | `` home-assistant-custom-components.frigate: 5.1.0 -> 5.2.0 ``                  |
| [`55a050b0`](https://github.com/NixOS/nixpkgs/commit/55a050b0d714f96dbc3c1e0eb2d16948a9837dcc) | `` bearer: 1.45.0 -> 1.45.1 ``                                                  |
| [`7de303b4`](https://github.com/NixOS/nixpkgs/commit/7de303b4518766db2ddca9dfcbdc823430fe3869) | ``  maintainers/team-list: add autra to geospatial ``                           |
| [`01fa8e07`](https://github.com/NixOS/nixpkgs/commit/01fa8e07140df7768b831881c9d7228d03228d0d) | `` partclone: 0.3.31 -> 0.3.32 ``                                               |
| [`93a6079c`](https://github.com/NixOS/nixpkgs/commit/93a6079c14e89275689a36865b2b910f214c438a) | `` spotifyd: only use dbus on linux ``                                          |
| [`55a0e841`](https://github.com/NixOS/nixpkgs/commit/55a0e8417b4cc020e44ec1d429082c787a7d0e3a) | `` collector: init at 1.0.1 ``                                                  |
| [`0ef7b67d`](https://github.com/NixOS/nixpkgs/commit/0ef7b67d2415f58b0cfa2b373fc775bb1adb0644) | `` cargo-deb: 2.4.0 -> 2.5.0 ``                                                 |
| [`a04d89c8`](https://github.com/NixOS/nixpkgs/commit/a04d89c8140bf3a5cac9dad487f468b9d01d9d3e) | `` _86Box: Add optional wayland support to 86Box ``                             |
| [`b4dbbdf3`](https://github.com/NixOS/nixpkgs/commit/b4dbbdf34e32e0fc49d05439f772a11acfbd2863) | `` chawan: set updateScript ``                                                  |
| [`856651fd`](https://github.com/NixOS/nixpkgs/commit/856651fda8be67aeb8fb843a9ca9a1bcf6c14f41) | `` nixos/incus: INCUS_OVMF_PATH -> INCUS_EDK2_PATH ``                           |
| [`1b1801d9`](https://github.com/NixOS/nixpkgs/commit/1b1801d94add2d3241999c10dd09bc42e400912a) | `` starboard: 0.15.20 -> 0.15.21 ``                                             |
| [`050f873c`](https://github.com/NixOS/nixpkgs/commit/050f873c0eea4a5ceb91710f5bf8b13f77491009) | `` linode-cli: nixfmt format ``                                                 |
| [`f7c05d86`](https://github.com/NixOS/nixpkgs/commit/f7c05d862df52325b24917531e3edd0481ed961a) | `` linode-cli: 5.45.0 -> 5.50.0 ``                                              |
| [`694f2edc`](https://github.com/NixOS/nixpkgs/commit/694f2edcbf0310cd662e4a36f3fe8f3541be358f) | `` python3Packages.linode-metadata: init at 0.3.0 ``                            |
| [`2bc864f5`](https://github.com/NixOS/nixpkgs/commit/2bc864f50e5b5182c3c88cdc3445dd14f188b85d) | `` librandombytes: init at 20240318 ``                                          |