### PR TITLE
chore(flake/nixvim-flake): `42b7baad` -> `d05ed9dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1721224205,
-        "narHash": "sha256-W0+l7HNzZfEmIx/1Yp3Tow/GZILVjrMjWfTt1Mos7mI=",
+        "lastModified": 1721389534,
+        "narHash": "sha256-2/HMbB2TazAGpfIGmzjElwxxPQScJQG/bmMBQMTnWlA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "55bda0cc3b230255d271e5eef82f3279dae9f859",
+        "rev": "c9a6912be575ffa83512c4dcdd9918f794ac401e",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721319973,
-        "narHash": "sha256-5TdDDpCVv0UypNzlaUda2LypovzfQcPeNoAtATV9LDw=",
+        "lastModified": 1721406340,
+        "narHash": "sha256-vQSIt2Nr8EvaYFNhhTOuQ0n+EBhEw+K4vPCwiAweAZI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "42b7baad863fbf5f477153ba1c53077f4483586e",
+        "rev": "d05ed9ddb5f41d49ad9899a4db8e41990e2494a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`d05ed9dd`](https://github.com/alesauce/nixvim-flake/commit/d05ed9ddb5f41d49ad9899a4db8e41990e2494a2) | `` chore(flake/nixvim): 55bda0cc -> c9a6912b `` |