### PR TITLE
chore(flake/stylix): `6bbae4f8` -> `6f36b27a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721429336,
-        "narHash": "sha256-DTJUvI4Xkj4KC5tdq15OEUkPpk7Ebvqcz356dIT6jtY=",
+        "lastModified": 1721478802,
+        "narHash": "sha256-+WMQs0fMAmpWPsKNgIFQoKLtvS4qtTj+mC++cD1May4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6bbae4f85b891df2e6e48b649919420434088507",
+        "rev": "6f36b27afd7b7ac8664bb62b7b27728540972c82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`6f36b27a`](https://github.com/danth/stylix/commit/6f36b27afd7b7ac8664bb62b7b27728540972c82) | `` doc: update tinted-theming repo link (#476) `` |