### PR TITLE
chore(flake/nix-index-database): `5fe5b0cd` -> `b6db9fd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -569,11 +569,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720926593,
-        "narHash": "sha256-fW6e27L6qY6s+TxInwrS2EXZZfhMAlaNqT0sWS49qMA=",
+        "lastModified": 1721531260,
+        "narHash": "sha256-O72uxk4gYFQDwNkoBioyrR3GK9EReZmexCStBaORMW8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5fe5b0cdf1268112dc96319388819b46dc051ef4",
+        "rev": "b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b6db9fd8`](https://github.com/nix-community/nix-index-database/commit/b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d) | `` update generated.nix to release 2024-07-21-025749 `` |
| [`bd8d2d4a`](https://github.com/nix-community/nix-index-database/commit/bd8d2d4adca7fc53dd1e8ae150bb6a26953eebb0) | `` flake.lock: Update ``                                |