### PR TITLE
chore(flake/stylix): `6f36b27a` -> `0ef70039`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -753,11 +753,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721478802,
-        "narHash": "sha256-+WMQs0fMAmpWPsKNgIFQoKLtvS4qtTj+mC++cD1May4=",
+        "lastModified": 1721573849,
+        "narHash": "sha256-pHfzFzjADtCqMswGwrfC5klBWJZ6h94bxVrVObJLrEM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6f36b27afd7b7ac8664bb62b7b27728540972c82",
+        "rev": "0ef70039a6435446472182c8f8106947abfc523d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                   |
| --------------------------------------------------------------------------------------------- | ------------------------- |
| [`0ef70039`](https://github.com/danth/stylix/commit/0ef70039a6435446472182c8f8106947abfc523d) | `` ncspot: init (#475) `` |