### PR TITLE
chore(flake/nixvim-flake): `9c31794a` -> `ff6182b2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1721421992,
-        "narHash": "sha256-4Mu+O2/S5XU1D8HLTU53pv20hEH6aiTkUqjLHowYdY8=",
+        "lastModified": 1721571110,
+        "narHash": "sha256-W4KLBlN3g5fABz1Hv/O9Vwq0mFwY3XYuAyGLege1tVM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "e80a8874accd45cac90616a7b5faa49c5a68e6b9",
+        "rev": "8eb5763bbbb414c432ced741c5fe8052154d0816",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721463843,
-        "narHash": "sha256-TIq9NQTKxeFuJipxtINHSJNZYAhZSGs71K0nN9YnzVs=",
+        "lastModified": 1721579152,
+        "narHash": "sha256-ez79w2Aplcm5CGzA1lh8+Jm1MnunD3+xzqKwIap9SK8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "9c31794adb3b7c24178f94f6c29d972028e96683",
+        "rev": "ff6182b224db6cc47be9cc34cdcde372f0002604",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`ff6182b2`](https://github.com/alesauce/nixvim-flake/commit/ff6182b224db6cc47be9cc34cdcde372f0002604) | `` chore(flake/nixvim): e80a8874 -> 8eb5763b `` |