### PR TITLE
chore(flake/nixvim-flake): `01e2bb03` -> `2953ca0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1721592379,
-        "narHash": "sha256-pJzkjy4+sM9+5IfrZMTWAiB0m/m4eiV4fmnqxtVNonI=",
+        "lastModified": 1721651056,
+        "narHash": "sha256-GOm1qWrT0MurD/84RzWj/E6GPmzPT5nH/hrSYohtlxs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d2f733efb4962903b77af330c4c03a63f2f72968",
+        "rev": "6dc0bda459bcfb2a38cf7b6ed1d6a5d6a8105f00",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721611397,
-        "narHash": "sha256-FxF40b42Fy5B6KO8PnguHbQn7lrDE4TZqax4kf9gwBU=",
+        "lastModified": 1721665597,
+        "narHash": "sha256-+Mk1o9G0kH5uFA8M7QNDTixR2DloVZqiXFt6vgxjUaM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "01e2bb03be1a1071b7d419ff17d1602b03354e55",
+        "rev": "2953ca0d9750306e457c30013a61f9b3247e6459",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`2953ca0d`](https://github.com/alesauce/nixvim-flake/commit/2953ca0d9750306e457c30013a61f9b3247e6459) | `` chore(flake/nixvim): d2f733ef -> 6dc0bda4 `` |