### PR TITLE
chore(flake/home-manager): `7560dc94` -> `af70fc50`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721714663,
-        "narHash": "sha256-ZDW5+rlROxaOuoEfIQM7Gqhoa+WALEYdYIiZhyJjAu0=",
+        "lastModified": 1721804110,
+        "narHash": "sha256-i4jINRazBKPqlaS+qhlP+kV/UHEq3vs5itfpblqu4ZM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7560dc942a6fbd37ebd1310b3dbda513de2d4b82",
+        "rev": "af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`af70fc50`](https://github.com/nix-community/home-manager/commit/af70fc502a15d7e1e4c5a4c4fc8e06c2ec561e0c) | `` flake.lock: Update ``                    |
| [`465ea1f9`](https://github.com/nix-community/home-manager/commit/465ea1f994a4e2b498b847c35caa205af7b261df) | `` swayosd: avoid restarting too quickly `` |