### PR TITLE
chore(flake/nixvim-flake): `8484dd40` -> `6e3bc538`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1721832650,
-        "narHash": "sha256-naQCM5KqT+i8W/84aaXUsr/6oWR8fkjXDPdWCwLiCRQ=",
+        "lastModified": 1721854976,
+        "narHash": "sha256-iWTGRfYoq0ppT3P4D2bRDVkLuTZAzuud/gsxVzPTHDg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0ac10f6776c6650b18ebe45913e06b7ce1a2e2b1",
+        "rev": "216d64c158da5523d5b3db0895e1345175c21502",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721838311,
-        "narHash": "sha256-SvRLLmz6WOfmZ4+JVgzriM6BMaJcGlzYuNmHmMu8hyc=",
+        "lastModified": 1721870461,
+        "narHash": "sha256-aoHgrKo1nMvhQ5VqkFp/r62KRRQ2dFSJmBiLq8o8x4E=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8484dd404f821b0ba93859c5c512e52acc560c1d",
+        "rev": "6e3bc53892f9c423a3b5f6fda28eeed1aa438cb6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`6e3bc538`](https://github.com/alesauce/nixvim-flake/commit/6e3bc53892f9c423a3b5f6fda28eeed1aa438cb6) | `` chore(flake/nixvim): 0ac10f67 -> 216d64c1 `` |