### PR TITLE
chore(flake/nixvim-flake): `38538b63` -> `f8082a57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721956811,
-        "narHash": "sha256-nUNATn0vHbzvFf3TLfGyr4VQa+57SKEKIypax+a7y+k=",
+        "lastModified": 1721982338,
+        "narHash": "sha256-Oi2bUHpucZx8eW6PylsnhLZxFGOD/hxTNxh8gXQio6k=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "38538b638bbe44ab4dac00486727f1a8257b588f",
+        "rev": "f8082a571d28663f3042b1ad97eb0d05937c55f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`f8082a57`](https://github.com/alesauce/nixvim-flake/commit/f8082a571d28663f3042b1ad97eb0d05937c55f0) | `` chore(flake/nixpkgs): 68c9ed8b -> dc14ed91 `` |