### PR TITLE
chore(flake/nixvim-flake): `f8082a57` -> `be185428`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -689,11 +689,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1721982338,
-        "narHash": "sha256-Oi2bUHpucZx8eW6PylsnhLZxFGOD/hxTNxh8gXQio6k=",
+        "lastModified": 1722011242,
+        "narHash": "sha256-ZO/9tplx3i+naUW0W16TAOgiHrBAXEGbyshKOWzgxVc=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "f8082a571d28663f3042b1ad97eb0d05937c55f0",
+        "rev": "be185428fbff0be99ba6f8dd502b25a3aa9619d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`be185428`](https://github.com/alesauce/nixvim-flake/commit/be185428fbff0be99ba6f8dd502b25a3aa9619d2) | `` chore(flake/nixpkgs): dc14ed91 -> 5ad6a14c `` |