### PR TITLE
chore(flake/darwin): `72bbc11a` -> `0413754b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722009762,
-        "narHash": "sha256-KV3H6BA9UNPDdkubDMQCWKz6Z4XokHsYazRkJJZZurA=",
+        "lastModified": 1722082646,
+        "narHash": "sha256-od8dBWVP/ngg0cuoyEl/w9D+TCNDj6Kh4tr151Aax7w=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "72bbc11aedcaba6f9a748786bb0aff9213d8fb36",
+        "rev": "0413754b3cdb879ba14f6e96915e5fdf06c6aab6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`e88eb66c`](https://github.com/LnL7/nix-darwin/commit/e88eb66c2b5e7066786f5d6343f3737567a71734) | `` `mapAttrsFlatten` -> `mapAttrsToList` ``              |
| [`a5662388`](https://github.com/LnL7/nix-darwin/commit/a566238826fc77b2322b62cd52c321db8c30a1f4) | `` defaults: only restart Dock when user is logged in `` |