### PR TITLE
chore(flake/nixvim-flake): `a1d84ce1` -> `b8c7b977`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -663,11 +663,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1722016645,
-        "narHash": "sha256-YQA4oenJwjWVzX+we6Zzv08im5q2n7dVhJ12Nw8wQio=",
+        "lastModified": 1722111246,
+        "narHash": "sha256-5ikGEPb8oqup5tTWpvmC8V/ts9ss0VXsPNtlbz7IAYU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "162ae6354bbf2af5c33b09aa90e9d8d11f14462e",
+        "rev": "59941a5300b1b13d6aac0a5115c8fc5b955b5405",
         "type": "github"
       },
       "original": {
@@ -689,11 +689,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722043214,
-        "narHash": "sha256-R64aJ/xjX2lEvqNgJNedEL/6hOIOL3WYU17C+nDTG2E=",
+        "lastModified": 1722129999,
+        "narHash": "sha256-zkdDkkEvJ0csCALOt0yT55FjkAu6RBkW8CgGHIcwF9M=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "a1d84ce1f3a6c303ec8af091b9b877f9a56b2e84",
+        "rev": "b8c7b97761fe09c3ca09ffd90814191147fc2be6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`b8c7b977`](https://github.com/alesauce/nixvim-flake/commit/b8c7b97761fe09c3ca09ffd90814191147fc2be6) | `` chore(flake/nixvim): 162ae635 -> 59941a53 `` |