### PR TITLE
chore(flake/nix-index-database): `b6db9fd8` -> `c0ca47e8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -574,11 +574,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721531260,
-        "narHash": "sha256-O72uxk4gYFQDwNkoBioyrR3GK9EReZmexCStBaORMW8=",
+        "lastModified": 1722136042,
+        "narHash": "sha256-x3FmT4QSyK28itMiR5zfYhUrG5nY+2dv+AIcKfmSp5A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b6db9fd8dc59bb2ccb403f76d16ba8bbc1d5263d",
+        "rev": "c0ca47e8523b578464014961059999d8eddd4aae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`c0ca47e8`](https://github.com/nix-community/nix-index-database/commit/c0ca47e8523b578464014961059999d8eddd4aae) | `` update generated.nix to release 2024-07-28-025730 `` |
| [`6d367e9d`](https://github.com/nix-community/nix-index-database/commit/6d367e9d5e8941d73ae73d43ec7f3661ecc2dcdb) | `` flake.lock: Update ``                                |