### PR TITLE
chore(flake/home-manager): `d0240a06` -> `792757f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722119539,
-        "narHash": "sha256-2kU90liMle0vKR8exJx1XM4hZh9CdNgZGHCTbeA9yzY=",
+        "lastModified": 1722203588,
+        "narHash": "sha256-91V5FMSQ4z9bkhTCf0f86Zjw0bh367daSf0mzCIW0vU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0240a064db3987eb4d5204cf2400bc4452d9922",
+        "rev": "792757f643cedc13f02098d8ed506d82e19ec1da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`792757f6`](https://github.com/nix-community/home-manager/commit/792757f643cedc13f02098d8ed506d82e19ec1da) | `` firefox: support firefox derivatives ``                    |
| [`587fcca6`](https://github.com/nix-community/home-manager/commit/587fcca66e9d11c8e2357053c096a8a727c120ab) | `` eww: add terminal integration options ``                   |
| [`a11cfcd0`](https://github.com/nix-community/home-manager/commit/a11cfcd0a18fdf6257808da631a956800af764bf) | `` micro: add package option ``                               |
| [`ea72cf54`](https://github.com/nix-community/home-manager/commit/ea72cf548fafb2876232a3ae22fcc03d5fb354de) | `` jujutsu: support darwin guidelines for config placement `` |
| [`9fdadb1c`](https://github.com/nix-community/home-manager/commit/9fdadb1cb65093015fc8cd65a592c983b490c75c) | `` flake.lock: Update ``                                      |
| [`cd520fbd`](https://github.com/nix-community/home-manager/commit/cd520fbd31934deaa1cda11297a99ef1fa369dbf) | `` maintainers: remove polykernel ``                          |