### PR TITLE
chore(flake/home-manager): `792757f6` -> `4fcd54df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722203588,
-        "narHash": "sha256-91V5FMSQ4z9bkhTCf0f86Zjw0bh367daSf0mzCIW0vU=",
+        "lastModified": 1722321190,
+        "narHash": "sha256-WeVWVRqkgrbLzmk6FfJoloJ7Xe7HWD27Pv950IUG2kI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "792757f643cedc13f02098d8ed506d82e19ec1da",
+        "rev": "4fcd54df7cbb1d79cbe81209909ee8514d6b17a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`4fcd54df`](https://github.com/nix-community/home-manager/commit/4fcd54df7cbb1d79cbe81209909ee8514d6b17a4) | `` firefox: fix userChrome example ``                    |
| [`d34aaf7b`](https://github.com/nix-community/home-manager/commit/d34aaf7b3b4c98f2aefe0429b8946f2bcd36a59a) | `` nix-gc: set service type to oneshot ``                |
| [`db40fead`](https://github.com/nix-community/home-manager/commit/db40fead89db185dfd863aed5dad1d675f82a3fc) | `` nix-gc: call nix-collect-garbage in a shell script `` |
| [`89670e27`](https://github.com/nix-community/home-manager/commit/89670e27e101b9b30f5900fc1eb6530258d316b1) | `` home-manager: ignore hostname -f lookup errors ``     |