### PR TITLE
chore(flake/darwin): `0413754b` -> `7e08a9dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722082646,
-        "narHash": "sha256-od8dBWVP/ngg0cuoyEl/w9D+TCNDj6Kh4tr151Aax7w=",
+        "lastModified": 1722445220,
+        "narHash": "sha256-PW5FRqLhqg0xGpPjY2Poa464tyBQiyKd0tQGZ0HnMiU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0413754b3cdb879ba14f6e96915e5fdf06c6aab6",
+        "rev": "7e08a9dd34314fb8051c28b231a68726c54daa7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`dc8e1f48`](https://github.com/LnL7/nix-darwin/commit/dc8e1f4839b735ffed17cb5368d9bd7f19577eb6) | `` github-runners: move `workDir` outside of `/run` ``        |
| [`a6903cf7`](https://github.com/LnL7/nix-darwin/commit/a6903cf7e3a451347160c92edb44ba288ebce747) | `` activation-scripts: add extra comment ``                   |
| [`5c8fb551`](https://github.com/LnL7/nix-darwin/commit/5c8fb551822a137848a666472a17aeb651ee033d) | `` Revert "github-runnners: fix workDir missing on reboot" `` |