### PR TITLE
chore(flake/nixvim-flake): `3fb1d82b` -> `94adecb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1722248209,
-        "narHash": "sha256-yYoxx5hVrI7JaiPy44sgnr5YIRXWY7ttNoN/l5fJOgI=",
+        "lastModified": 1722431209,
+        "narHash": "sha256-qBxvnoQuzhCHTej5JMw1EpjavufRgpMNP9klpO7mbI4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2089eb407d8c5dbd6ca6e93d4988a439ca6446fd",
+        "rev": "8945b3b5e336a42972448e2f07ed5bc465a40c83",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722356853,
-        "narHash": "sha256-wIOq2YZu4u3W1f7oVRNXMp583eaDR+3BcEdfK68hKpI=",
+        "lastModified": 1722443182,
+        "narHash": "sha256-naN+etRsiIxa9GEx3e9mfUfv7dm9EcivwrtfqDICe1Q=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "3fb1d82bfc962cb3724567a24c44244ef386da48",
+        "rev": "94adecb201889ee71884afa3ca7daa08069f8206",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`94adecb2`](https://github.com/alesauce/nixvim-flake/commit/94adecb201889ee71884afa3ca7daa08069f8206) | `` chore(flake/nixvim): 2089eb40 -> 8945b3b5 `` |