### PR TITLE
chore(flake/nixvim-flake): `3cd4d945` -> `5d3f055b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722529552,
-        "narHash": "sha256-/KI0yYo3FFwaztR8Ks0Mq3oWz/9u5HiJstAt9O7pyD0=",
+        "lastModified": 1722573317,
+        "narHash": "sha256-vs4TcuBFkBrX9IuotFwEcp+ltOGCMKXnpShaboCMpYA=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "3cd4d94550202062513ec2e221a2f95d439b3e8a",
+        "rev": "5d3f055b1179a7e4ea5a8dd747bc085b6f72b128",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
| [`5d3f055b`](https://github.com/alesauce/nixvim-flake/commit/5d3f055b1179a7e4ea5a8dd747bc085b6f72b128) | `` feat(navigation/harpoon) - adding new keymaps for managing harpoon marks ``                   |
| [`5895d76b`](https://github.com/alesauce/nixvim-flake/commit/5895d76b1450d208909c0c67efa08aa1921c4af5) | `` chore(config/basic-plugins) - moving guess indent to use the Nixvim guess-indent submodule `` |
| [`4b43364f`](https://github.com/alesauce/nixvim-flake/commit/4b43364f688a9460e92fdbe6a2160db280ec23d1) | `` chore(flake/nixpkgs): 52ec9ac3 -> 9f918d61 ``                                                 |