### PR TITLE
chore(flake/nixvim-flake): `392c5a5b` -> `3dbb9950`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1722531900,
-        "narHash": "sha256-COtoy+Y/j2QLX818mRI7BweRJOltf0bndxbps/eoH0s=",
+        "lastModified": 1722605918,
+        "narHash": "sha256-eWVY6hM2IlxRIVUgKBlPCX4pJ1Nmh3Nvw/Io2LaE0Y4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7c39d77b9f1fbcbd8f2a575c4f2948dd54efc5c1",
+        "rev": "0bc169903705c94fda7934ecc27dd9038ad5f0e9",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722656091,
-        "narHash": "sha256-HpejysV5WvuISogItS2aMb30EIRbWwJ0zKcrlX3Eg7U=",
+        "lastModified": 1722702382,
+        "narHash": "sha256-ERO5AwCXi4oLX/Yl79shhf7C07F8FW13GfNxUZBbGI0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "392c5a5be76b355b8e5a332465f90002d9eaba49",
+        "rev": "3dbb9950046dc63cf63403acd173d55733188cba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`3dbb9950`](https://github.com/alesauce/nixvim-flake/commit/3dbb9950046dc63cf63403acd173d55733188cba) | `` chore(flake/nixvim): 7c39d77b -> 0bc16990 `` |