### PR TITLE
chore(flake/nixvim-flake): `fd9673e8` -> `8eb49bc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1722720144,
-        "narHash": "sha256-YWZGpQxrq1NjNNrCP/xyYKShzHpHrYM2ITsM5ObuK/g=",
+        "lastModified": 1722763580,
+        "narHash": "sha256-LgYIYkNYzqCldWJ/xJRQ156WDp6P9hHb4EsIXsRa+u4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2f85c012ced350ccdb84561c91fbf59b0838ee67",
+        "rev": "6f7cf23b226ceaee0a2d479c505652065dfe526f",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722734809,
-        "narHash": "sha256-LckkAqTQurEgB8Rpb8W9r0Ue8yR4YvLedA2n7CNg9i0=",
+        "lastModified": 1722788610,
+        "narHash": "sha256-1j6VnyS5UGMnPtb3Ky1A6qoqMBsDeNJX8BjRuXiAzMg=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "fd9673e890d4292ae41efbd7e00530cb2c41770f",
+        "rev": "8eb49bc5d28d05ca024eaf51f4d7df593f16e4b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`8eb49bc5`](https://github.com/alesauce/nixvim-flake/commit/8eb49bc5d28d05ca024eaf51f4d7df593f16e4b0) | `` chore(flake/nixvim): 2f85c012 -> 6f7cf23b `` |