### PR TITLE
chore(flake/nixvim-flake): `19e5c161` -> `37679a4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1722763580,
-        "narHash": "sha256-LgYIYkNYzqCldWJ/xJRQ156WDp6P9hHb4EsIXsRa+u4=",
+        "lastModified": 1722837994,
+        "narHash": "sha256-WyLnA63P///8gUYCNW8OBrLxTOcVCtcjlPDGTCzFdR4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6f7cf23b226ceaee0a2d479c505652065dfe526f",
+        "rev": "4d6d3bd722520ab26b924210a25f67117afb1747",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1722821045,
-        "narHash": "sha256-Zuz0sPLYn7YhOE+qEzxThJwDNfQmm5rcUa9hXx2srs0=",
+        "lastModified": 1722846398,
+        "narHash": "sha256-SCmtAfFzBGw/WXNwUdwjC/qp5Hvi1CUfkzX1xqosFmU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "19e5c161fed5e916241ececdd69c00a4e4c38286",
+        "rev": "37679a4c27afc98001c2273e7189a7def7aa48b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`37679a4c`](https://github.com/alesauce/nixvim-flake/commit/37679a4c27afc98001c2273e7189a7def7aa48b9) | `` chore(flake/nixvim): 6f7cf23b -> 4d6d3bd7 `` |