### PR TITLE
chore(flake/darwin): `f7142b80` -> `91010a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722609272,
-        "narHash": "sha256-Kkb+ULEHVmk07AX+OhwyofFxBDpw+2WvsXguUS2m6e4=",
+        "lastModified": 1722924007,
+        "narHash": "sha256-+CQDamNwqO33REJLft8c26NbUi2Td083hq6SvAm2xkU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f7142b8024d6b70c66fd646e1d099d3aa5bfec49",
+        "rev": "91010a5613ffd7ee23ee9263213157a1c422b705",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`636d1a09`](https://github.com/LnL7/nix-darwin/commit/636d1a09d8a4fc2306aee0c8a33dac21bd9e201a) | `` (feature) Add swapLeftCtrlAndFn `` |