### PR TITLE
chore(flake/home-manager): `afc892db` -> `a6c74398`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722630065,
-        "narHash": "sha256-QfM/9BMRkCmgWzrPDK+KbgJOUlSJnfX4OvsUupEUZvA=",
+        "lastModified": 1722936497,
+        "narHash": "sha256-UBst8PkhY0kqTgdKiR8MtTBt4c1XmjJoOV11efjsC/o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "afc892db74d65042031a093adb6010c4c3378422",
+        "rev": "a6c743980e23f4cef6c2a377f9ffab506568413a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a6c74398`](https://github.com/nix-community/home-manager/commit/a6c743980e23f4cef6c2a377f9ffab506568413a) | `` dunst: use `-config` flag when `configFile` is set `` |