### PR TITLE
chore(flake/stylix): `c0309fc3` -> `5853f1a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722872544,
-        "narHash": "sha256-zxj4FLaqvBw7AR2ppEwn4qK//XpapKG33l8kcfY+QXs=",
+        "lastModified": 1722946882,
+        "narHash": "sha256-mxtnMye8gs82tdQbVC+g6v3aPOZlH150f9WyntHIkTg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c0309fc3f4315cfb7e1e588a43ed19516c8b6022",
+        "rev": "5853f1a8bd072f2ebabfc3de3973084353cf6f1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`5853f1a8`](https://github.com/danth/stylix/commit/5853f1a8bd072f2ebabfc3de3973084353cf6f1e) | `` neovim: fix incorrect use of `mkIf` (#498) ``              |
| [`94aa0fc0`](https://github.com/danth/stylix/commit/94aa0fc0fbe9ed37a7bfa156cff0bfacc3b0a8cb) | `` nixvim: rename transparency options to camelCase (#497) `` |
| [`3499dff3`](https://github.com/danth/stylix/commit/3499dff34d2ac683bcb011fb2f2075d75336822a) | `` neovim: init (#496) ``                                     |