### PR TITLE
chore(flake/git-hooks): `06939f6b` -> `3c977f1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,11 +318,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1722857853,
-        "narHash": "sha256-3Zx53oz/MSIyevuWO/SumxABkrIvojnB7g9cimxkhiE=",
+        "lastModified": 1723056346,
+        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "06939f6b7ec4d4f465bf3132a05367cccbbf64da",
+        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`49b141a7`](https://github.com/cachix/git-hooks.nix/commit/49b141a7659d0c78cad85d75a5a2160604a121bb) | `` hook(shfmt): add `simplify` toggle to settings `` |
| [`c22803ea`](https://github.com/cachix/git-hooks.nix/commit/c22803eaa20a9ae43e04354d1c83d2ae1862d5de) | `` fix: fixup args and exclude_types ``              |
| [`d1948b48`](https://github.com/cachix/git-hooks.nix/commit/d1948b48c9857727f2c44eec85fa511714bc6e9c) | `` Added `args` and `exclude_types` to hook type ``  |