### PR TITLE
chore(flake/nixvim-flake): `1cd0f178` -> `70cf63a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723048071,
-        "narHash": "sha256-V/kjCiOIKagpS2TFHAQJECL6ebwWXKXi8e2PUM2CNRo=",
+        "lastModified": 1723089067,
+        "narHash": "sha256-6/dksSDrqlSGX4H1HYECUnBeKT+ymglDYDRumk0D/NU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "1cd0f178d74e66cf6614f11be41d97a8138901d7",
+        "rev": "70cf63a374d5b0375a968683accdf1d1ce575289",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1722857853,
-        "narHash": "sha256-3Zx53oz/MSIyevuWO/SumxABkrIvojnB7g9cimxkhiE=",
+        "lastModified": 1723056346,
+        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06939f6b7ec4d4f465bf3132a05367cccbbf64da",
+        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                           |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`70cf63a3`](https://github.com/alesauce/nixvim-flake/commit/70cf63a374d5b0375a968683accdf1d1ce575289) | `` feat(lang/typescript) - adding configuration for inlay/property completions `` |
| [`57971885`](https://github.com/alesauce/nixvim-flake/commit/5797188559de81c2199ffc987e9b662e81e27e03) | `` chore(flake/pre-commit-hooks): 06939f6b -> 3c977f1c ``                         |