### PR TITLE
chore(flake/nixvim-flake): `552d6320` -> `71bd9b4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1723064649,
-        "narHash": "sha256-J7p/kv0GHAnvg2HH3vJ3JVz1LEzCtdhcH0prmdYfRog=",
+        "lastModified": 1723123215,
+        "narHash": "sha256-PZbdO1N8zpmkFsGWk3rLUal/TnpqAXgItsIj6IUCswY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "593f5215cb1df010451675c19f2ad5c5481ccee3",
+        "rev": "1b135dedc4b6256faad9dae2f625e821425a60dd",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723105617,
-        "narHash": "sha256-vXVsl1Ko8Ssb8tuJYrE8GqUL5q3cH5e6xYsvKcHC1Hw=",
+        "lastModified": 1723134407,
+        "narHash": "sha256-NwDcq5mSD1bsK3bBwX+vbiM65TGGp7bwZ+py+QA85n4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "552d6320bd0dbda1c584b812a0de87e4d40fb3ea",
+        "rev": "71bd9b4af135ff65c4a307a669f599479d8dc918",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`71bd9b4a`](https://github.com/alesauce/nixvim-flake/commit/71bd9b4af135ff65c4a307a669f599479d8dc918) | `` chore(flake/nixvim): 593f5215 -> 1b135ded `` |