### PR TITLE
chore(flake/nixvim-flake): `a16f22a2` -> `2c715108`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723166623,
-        "narHash": "sha256-CQzliE+vFhmIKkk9MsULKD0Nf/Lck6pTsCmMuyYgvQI=",
+        "lastModified": 1723247476,
+        "narHash": "sha256-arFTQHsXomwZc1n+stY+86xnyVLv7ukEnlwSEf+h8mU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "a16f22a24c4cb30a8b2f2bbce438f80828fdd7fe",
+        "rev": "2c7151085e2df12598556d05297a62d60645c8f2",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723056346,
-        "narHash": "sha256-YpzywjTAUHRRHcO8zz9x2gYqJ0JmZlcB9+RaUvD89qM=",
+        "lastModified": 1723202784,
+        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "3c977f1c9930f54066c085305b4b2291385e7a73",
+        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                           |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| [`2c715108`](https://github.com/alesauce/nixvim-flake/commit/2c7151085e2df12598556d05297a62d60645c8f2) | `` chore(lang/java) - Moving java config to lang folder. Removing extraneous LSP client setup. `` |
| [`51f80aab`](https://github.com/alesauce/nixvim-flake/commit/51f80aab4936bbdef7792d6e3f100954d0fba5bb) | `` feat(lang/haskell) - Adding haskell-tools-nvim support ``                                      |
| [`0e4b387d`](https://github.com/alesauce/nixvim-flake/commit/0e4b387d53f48af359757bd9e4f457b967fb488f) | `` chore(flake/pre-commit-hooks): 3c977f1c -> c7012d0c ``                                         |