### PR TITLE
chore(flake/nix-index-database): `97ca0a0f` -> `ec78079a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -568,11 +568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722740924,
-        "narHash": "sha256-UQPgA5d8azLZuDHZMPmvDszhuKF1Ek89SrTRtqsQ4Ss=",
+        "lastModified": 1723352546,
+        "narHash": "sha256-WTIrvp0yV8ODd6lxAq4F7EbrPQv0gscBnyfn559c3k8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "97ca0a0fca0391de835f57e44f369a283e37890f",
+        "rev": "ec78079a904d7d55e81a0468d764d0fffb50ac06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ec78079a`](https://github.com/nix-community/nix-index-database/commit/ec78079a904d7d55e81a0468d764d0fffb50ac06) | `` document which channel is indexed ``                 |
| [`4d99d0ca`](https://github.com/nix-community/nix-index-database/commit/4d99d0ca3cd57d65481a1ba749818b52b5a3fb3b) | `` update generated.nix to release 2024-08-11-025748 `` |
| [`89681e85`](https://github.com/nix-community/nix-index-database/commit/89681e856ae1f342d0de07454b3d6a702b253db9) | `` flake.lock: Update ``                                |