### PR TITLE
chore(flake/nixvim-flake): `2755ce61` -> `82238dda`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723486214,
+        "lastModified": 1723494018,
         "narHash": "sha256-0UM5id0Yv2z1POmR+uqZzLbQKLAgit5sFHfgI5ERHwk=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "2755ce61c74f112d4327092b1eb418be4d5e3c4f",
+        "rev": "82238ddae25c9ef344445b6e2194154a6f6b1110",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`82238dda`](https://github.com/alesauce/nixvim-flake/commit/82238ddae25c9ef344445b6e2194154a6f6b1110) | `` Revert "feat(core) - enabling lua loader to optimize startup time" `` |
| [`508fedc1`](https://github.com/alesauce/nixvim-flake/commit/508fedc1f5eece085813c31236830a4d4746a05b) | `` feat(core) - enabling lua loader to optimize startup time ``          |