### PR TITLE
chore(flake/nixvim-flake): `c962bb21` -> `5a6e6c96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1723778908,
-        "narHash": "sha256-pWxo0rqf6qf2IHtomEASq5gEzkSB78dD1wizytvU/EM=",
+        "lastModified": 1723816538,
+        "narHash": "sha256-h37ltjdifkd7iLtMtBXSBBeYSTuBEKMW6ClFoC7nReQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6ab17b1b2e6bc2c10718025105d452dd929cc058",
+        "rev": "00f32f0430f82c74919c72af84bc95bf5ae434e4",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723796849,
-        "narHash": "sha256-IVLZETOgD2OBd5MEYOOsMIgrCxLewtb0Pp7BX327pJo=",
+        "lastModified": 1723830883,
+        "narHash": "sha256-SWsYYR2wbF5YrkWEmpMbTc8MCiiJAKPQDjxZJjWfqU4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "c962bb21d4c5c9d5aabcf1434d0f5356cf9f2a81",
+        "rev": "5a6e6c9685f4d3c634ce4d7ce8f7738e88d69c03",
         "type": "github"
       },
       "original": {
@@ -730,11 +730,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1723202784,
-        "narHash": "sha256-qbhjc/NEGaDbyy0ucycubq4N3//gDFFH3DOmp1D3u1Q=",
+        "lastModified": 1723803910,
+        "narHash": "sha256-yezvUuFiEnCFbGuwj/bQcqg7RykIEqudOy/RBrId0pc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c7012d0c18567c889b948781bc74a501e92275d1",
+        "rev": "bfef0ada09e2c8ac55bbcd0831bd0c9d42e651ba",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                    |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`5a6e6c96`](https://github.com/alesauce/nixvim-flake/commit/5a6e6c9685f4d3c634ce4d7ce8f7738e88d69c03) | `` feat(nvim-dap) - adding debug adapter support (#187) `` |
| [`36ba4ecd`](https://github.com/alesauce/nixvim-flake/commit/36ba4ecd1138713cb421ceef6c842160797cb1a4) | `` chore(flake/nixvim): 6ab17b1b -> 00f32f04 ``            |
| [`bd7c8727`](https://github.com/alesauce/nixvim-flake/commit/bd7c8727d3371195d315300287c86164432b2406) | `` chore(flake/pre-commit-hooks): c7012d0c -> bfef0ada ``  |