### PR TITLE
chore(flake/stylix): `5853f1a8` -> `6858d08e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722946882,
-        "narHash": "sha256-mxtnMye8gs82tdQbVC+g6v3aPOZlH150f9WyntHIkTg=",
+        "lastModified": 1723834469,
+        "narHash": "sha256-PkJTr9DWBQcR5Ru1fJpG80dtw0MLSxAZlKnhHHFAGIA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5853f1a8bd072f2ebabfc3de3973084353cf6f1e",
+        "rev": "6858d08ed012bc6491cc92c13142104e56badf31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                           |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`6858d08e`](https://github.com/danth/stylix/commit/6858d08ed012bc6491cc92c13142104e56badf31) | `` treewide: add soft deprecation dates (#506) `` |