### PR TITLE
chore(flake/darwin): `91010a56` -> `076b9a90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722924007,
-        "narHash": "sha256-+CQDamNwqO33REJLft8c26NbUi2Td083hq6SvAm2xkU=",
+        "lastModified": 1723859949,
+        "narHash": "sha256-kiaGz4deGYKMjJPOji/JVvSP/eTefrIA3rAjOnOpXl4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "91010a5613ffd7ee23ee9263213157a1c422b705",
+        "rev": "076b9a905af8a52b866c8db068d6da475839d97b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`5afa71b4`](https://github.com/LnL7/nix-darwin/commit/5afa71b4131a97d72804a97a34bd4a916ea5e990) | `` fix: respect user nixPath configuration ``                          |
| [`691a590b`](https://github.com/LnL7/nix-darwin/commit/691a590bff479964d4fe48c4244d3d4486d854fb) | `` feat: allow disabling channels ``                                   |
| [`d5dba1c6`](https://github.com/LnL7/nix-darwin/commit/d5dba1c6f5b4069988f9601df861fff2490fb3d2) | `` refactor: rename environment.postBuild to environment.extraSetup `` |