### PR TITLE
chore(flake/nixvim-flake): `c274e467` -> `2201b909`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1723923888,
-        "narHash": "sha256-w+/PG6KqB8en0x1JH5aMuf0QC78Nfei208EaaaRuYG4=",
+        "lastModified": 1724017104,
+        "narHash": "sha256-1pMyOYqBx7L/w1I/HEa8L01Wx7mZH3QrhDk/8XvDSSw=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78fc4be6a830e8dc01f3e66ddbe3243b4bfe8560",
+        "rev": "7a11b66f11d292b59571dad85fd1501dbd9bd0c1",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1723944487,
-        "narHash": "sha256-l6j24IDlpa1GaRk24+hmVLOIOsUNY+CMm7NG/N03gwI=",
+        "lastModified": 1724030687,
+        "narHash": "sha256-0vPVOQQm+A2cWYfiIe3iz/4kEwQ06FrQLXgQdo3E+Ac=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "c274e4675a17adcde716e4c902ede540cf0b346f",
+        "rev": "2201b909325ecc6a104f7f4b76b5554ff7ae2c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`2201b909`](https://github.com/alesauce/nixvim-flake/commit/2201b909325ecc6a104f7f4b76b5554ff7ae2c3d) | `` chore(flake/nixvim): 78fc4be6 -> 7a11b66f `` |