### PR TITLE
chore(flake/nixvim-flake): `2201b909` -> `d7758947`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1724017104,
-        "narHash": "sha256-1pMyOYqBx7L/w1I/HEa8L01Wx7mZH3QrhDk/8XvDSSw=",
+        "lastModified": 1724036242,
+        "narHash": "sha256-/+gGF0tsAg2dF7Ds9Yt9Sne7ETmILKz1QVnDr+T2S2g=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7a11b66f11d292b59571dad85fd1501dbd9bd0c1",
+        "rev": "312db6b6e2d98dd8d22223fe383c7e0b4bab60c6",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1724030687,
-        "narHash": "sha256-0vPVOQQm+A2cWYfiIe3iz/4kEwQ06FrQLXgQdo3E+Ac=",
+        "lastModified": 1724056042,
+        "narHash": "sha256-46zI4mhGZmqOHwr9u5aczbJpnztcRaZniqp7D37dRXM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "2201b909325ecc6a104f7f4b76b5554ff7ae2c3d",
+        "rev": "d77589479262d35503f45234bc1beaa2189104bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`d7758947`](https://github.com/alesauce/nixvim-flake/commit/d77589479262d35503f45234bc1beaa2189104bc) | `` chore(flake/nixvim): 7a11b66f -> 312db6b6 `` |