### PR TITLE
chore(flake/darwin): `076b9a90` -> `d6703b98`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723859949,
-        "narHash": "sha256-kiaGz4deGYKMjJPOji/JVvSP/eTefrIA3rAjOnOpXl4=",
+        "lastModified": 1724219898,
+        "narHash": "sha256-7PwlnEQDIbww8+nk0CHLeYTYMA23F/CkynHsX7Mxk+s=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "076b9a905af8a52b866c8db068d6da475839d97b",
+        "rev": "d6703b988728b89456b32bac242c8689902e5a5b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                |
| ------------------------------------------------------------------------------------------------ | -------------------------------------- |
| [`8ef57d17`](https://github.com/LnL7/nix-darwin/commit/8ef57d17a46e385c187813a8383ef3d6b45777ec) | `` .github: add sponsorship details `` |