### PR TITLE
chore(flake/home-manager): `b18f3ebc` -> `c2cd2a52`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -454,11 +454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724412708,
-        "narHash": "sha256-tLr1k+UZLVumyqXRU8E5lBtLjsvHSy8e2NiamfkjpYg=",
+        "lastModified": 1724435763,
+        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b18f3ebc4029c22d437e3424014c8597a8b459a0",
+        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`c2cd2a52`](https://github.com/nix-community/home-manager/commit/c2cd2a52e02f1dfa1c88f95abeb89298d46023be) | `` submodule-support: add default values for top-level configs `` |
| [`5dc25356`](https://github.com/nix-community/home-manager/commit/5dc25356567119127f046b347c3060a8dd607365) | `` Translate using Weblate (Hungarian) ``                         |