### PR TITLE
chore(flake/stylix): `c5f8f065` -> `d042af47`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,6 +292,27 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": [
+          "stylix",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "fromYaml": {
       "flake": false,
       "locked": {
@@ -767,20 +788,22 @@
         "base16-tmux": "base16-tmux",
         "base16-vim": "base16-vim",
         "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_2",
         "gnome-shell": "gnome-shell",
         "home-manager": [
           "home-manager"
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1724260414,
-        "narHash": "sha256-EP1yFDEm/f7+j+fE3TI7KZb5xJH6KNMtmlZciktC71c=",
+        "lastModified": 1724444244,
+        "narHash": "sha256-fH1lyJvJjUhZ8xMlmiI18EZNzodDSe74rFuwlZDL0aQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c5f8f06543b70248a076f888177c7362a24d5dcc",
+        "rev": "d042af478ce87e188139480922a3085218194106",
         "type": "github"
       },
       "original": {
@@ -790,6 +813,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                  |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`5ca31b60`](https://github.com/danth/stylix/commit/5ca31b606838137b9303cc579943c74dca275c1b) | `` ci: update Actions related to GitHub Pages (#524) ``                  |
| [`9b5a65b6`](https://github.com/danth/stylix/commit/9b5a65b6815b68a4248d344e3227663107da0c18) | `` doc: extract Commit Convention section (#518) ``                      |
| [`825490bb`](https://github.com/danth/stylix/commit/825490bb5ed256065fd40f52a560db167e75b43e) | `` ci: add GitHub Dependabot to keep GitHub Actions up-to-date (#517) `` |
| [`77a65800`](https://github.com/danth/stylix/commit/77a65800e6b1389f7e0a90090297048720c99017) | `` stylix: adopt flake-utils.lib.eachDefaultSystem ``                    |
| [`ab67c509`](https://github.com/danth/stylix/commit/ab67c509836d5292fcb645327d0432310459ab3f) | `` stylix: delegate to upstream default architecture list ``             |
| [`15fed84d`](https://github.com/danth/stylix/commit/15fed84dec2ecf19e110bad1c47292e172b46a44) | `` stylix: drop i686-linux architecture support ``                       |
| [`9447b17f`](https://github.com/danth/stylix/commit/9447b17f70806e987e38461c70c1de893d381a87) | `` stylix: re-add flake-utils dependency and interface flake systems ``  |