### PR TITLE
chore(flake/nixvim-flake): `404532a4` -> `6d44001f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -704,11 +704,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1724660937,
-        "narHash": "sha256-2wj2+zuEWRbTWEiphAR6mcsC2qZSTlITtoVuuzDTyew=",
+        "lastModified": 1724689807,
+        "narHash": "sha256-8uIxtBoqXgUlDJfAQ2DdiIfFrFzX3MXFFejFFNpxFTQ=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "404532a4b350a1ed1b756188fb247788ee8c8f44",
+        "rev": "6d44001f4a979259d4e6c71640998c962f2fedc1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`6d44001f`](https://github.com/alesauce/nixvim-flake/commit/6d44001f4a979259d4e6c71640998c962f2fedc1) | `` chore(flake/nixpkgs): c374d94f -> d0e1602d `` |