### PR TITLE
chore(flake/nixvim-flake): `8be3f375` -> `79166f1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -678,11 +678,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1724710305,
-        "narHash": "sha256-qotbY/mgvykExLqRLAKN4yeufPfIjnMaK6hQQFhE2DE=",
+        "lastModified": 1724800090,
+        "narHash": "sha256-7KxGFZ40pidca5gcdI2weGanfB74yDxrErFNElOZWqA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eac092c876e4c4861c6df0cff93e25b972b1842c",
+        "rev": "4814147442cd3f12f8160ecad9e36751f68cdc22",
         "type": "github"
       },
       "original": {
@@ -704,11 +704,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1724726739,
-        "narHash": "sha256-9+Urx9u1V5QmwDpXEU/Ucxk1EdjuBcr2jpBq8fLrH00=",
+        "lastModified": 1724808381,
+        "narHash": "sha256-hXg1gEfJCpNEKveFBvCl/tIVkyfXK86DDaGARXV5iMQ=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8be3f375147593cd2833b199d90e9e67741a2596",
+        "rev": "79166f1ba6d48812b60b726fde162057dd2e1188",
         "type": "github"
       },
       "original": {
@@ -751,11 +751,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1724440431,
-        "narHash": "sha256-9etXEOUtzeMgqg1u0wp+EdwG7RpmrAZ2yX516bMj2aE=",
+        "lastModified": 1724763886,
+        "narHash": "sha256-SzBtZs5z+YGM50oyt67R78qLhxG/wG5/SlVRsCF5kRc=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c8a54057aae480c56e28ef3e14e4960628ac495b",
+        "rev": "1cd12de659fab215624c630c37d1c62aa2b7824e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                        |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`79166f1b`](https://github.com/alesauce/nixvim-flake/commit/79166f1ba6d48812b60b726fde162057dd2e1188) | `` chore(flake/nixvim): 60ea38d2 -> 48141474 ``                                |
| [`e6dbc20d`](https://github.com/alesauce/nixvim-flake/commit/e6dbc20d817292f42a2062fa2b32e6505bc35a09) | `` chore(flake/pre-commit-hooks): c8a54057 -> 1cd12de6 ``                      |
| [`ce28ac95`](https://github.com/alesauce/nixvim-flake/commit/ce28ac95442ac57289da07c627360aa627862154) | `` chore(flake/nixvim): eac092c8 -> 60ea38d2 ``                                |
| [`a73b2dc1`](https://github.com/alesauce/nixvim-flake/commit/a73b2dc1a07d43880d4afe578827633014946736) | `` fix(workflows/ci) - Temporarily removing flake check to unblock pipeline `` |