### PR TITLE
chore(flake/git-hooks): `1cd12de6` -> `4509ca64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724763886,
-        "narHash": "sha256-SzBtZs5z+YGM50oyt67R78qLhxG/wG5/SlVRsCF5kRc=",
+        "lastModified": 1724857454,
+        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "1cd12de659fab215624c630c37d1c62aa2b7824e",
+        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                             |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`334af94e`](https://github.com/cachix/git-hooks.nix/commit/334af94e9c4375784beedec943b8c94bfa474e44) | `` Add support for nixfmt-rfc-style ``              |
| [`90999f96`](https://github.com/cachix/git-hooks.nix/commit/90999f9641e46184aedb797718d63eb68febe2f0) | `` alejandra: fix shell escape for file excludes `` |