### PR TITLE
chore(flake/darwin): `ac5694a0` -> `21fe31f2`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,6 @@ jobs:
           extra-conf: ${{ env.nix-conf }}
       - uses: DeterminateSystems/magic-nix-cache-action@v7
       - name: nix-fast-build
-        if: ${{ env.system != 'aarch64-darwin' }}
         run: |
           declare -a args=(
             '--no-nom'
@@ -141,10 +140,6 @@ jobs:
           )
           args+=('--flake=${{ env.flake }}#${{ matrix.attrs.attr }}')
           nix run '${{ env.flake }}#nix-fast-build' -- "${args[@]}"
-      - name: nix-build
-        if: ${{ env.system == 'aarch64-darwin' }}
-        run: |
-          nix build --keep-going '${{ env.flake }}#${{ matrix.attrs.attr }}'
 
   check:
     runs-on: ubuntu-latest

--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -25,7 +25,7 @@
     variables = {
       SHELL = lib.getExe pkgs.zsh;
     };
-    postBuild = ''
+    extraSetup = ''
       ln -sv ${pkgs.path} $out/nixpkgs
     '';
   };

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724561770,
-        "narHash": "sha256-zv8C9RNa86CIpyHwPIVO/k+5TfM8ZbjGwOOpTe1grls=",
+        "lastModified": 1726188813,
+        "narHash": "sha256-Vop/VRi6uCiScg/Ic+YlwsdIrLabWUJc57dNczp0eBc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "ac5694a0b855a981e81b4d9f14052e3ff46ca39e",
+        "rev": "21fe31f26473c180390cfa81e3ea81aca0204c80",
         "type": "github"
       },
       "original": {

--- a/nix/darwin.nix
+++ b/nix/darwin.nix
@@ -22,7 +22,6 @@
         (../hosts + "/${hostname}")
         {
           nix.registry = {
-            nixpkgs.flake = nixpkgs;
             p.flake = nixpkgs;
           };
         }


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`953d02ba`](https://github.com/LnL7/nix-darwin/commit/953d02ba5958df017d9682f727d10a75cb8a0391) | `` {bash,zsh}: remove nix-shell early return in /etc/{bashrc,zshenv} ``    |
| [`04e3cfc8`](https://github.com/LnL7/nix-darwin/commit/04e3cfc822568d354b540a3207121af27b699057) | `` version: make `system.stateVersion` mandatory ``                        |
| [`537097b3`](https://github.com/LnL7/nix-darwin/commit/537097b3312b6089535d715b5f4a6e22ce4c5b41) | `` ci/update-manual: use Nixpkgs 24.05 ``                                  |
| [`b64c1d03`](https://github.com/LnL7/nix-darwin/commit/b64c1d036ffb9a4c4eaaea056e132775de62fc1d) | `` tools: fix darwin-rebuild changelog ``                                  |
| [`6ad463a7`](https://github.com/LnL7/nix-darwin/commit/6ad463a76421022de6762e6f50128febb970dcfc) | `` zsh: don't be noisy when scripts are run with -u ``                     |
| [`7e6c548e`](https://github.com/LnL7/nix-darwin/commit/7e6c548eef2372cef1287ef45350e29ca5740159) | `` zsh: let children shells set their fpath ``                             |
| [`8714f9e2`](https://github.com/LnL7/nix-darwin/commit/8714f9e28529183d65d9f42ac92cdc5d70dbb6f7) | `` flake: put nixpkgs in NIX_PATH and system registry for flake configs `` |
| [`88b97aa4`](https://github.com/LnL7/nix-darwin/commit/88b97aa49c451070d2978b291a6280f2e1c5c2b6) | `` {ids,checks}: update for new builder UID/GID values ``                  |
| [`9c60c950`](https://github.com/LnL7/nix-darwin/commit/9c60c95008e2862c45d01d3d453508f644adeff6) | `` checks: make `oldBuildUsers` check fail hard ``                         |
| [`2af5f0fb`](https://github.com/LnL7/nix-darwin/commit/2af5f0fb9e554ea3c85e57d35a5f2ed5a10b8867) | `` checks: factor out `nix.useDaemon` check ``                             |
| [`98189683`](https://github.com/LnL7/nix-darwin/commit/98189683a4674d26fab2b5a7134bcfb5aa05cdf1) | `` ci: use Determinate Systems installer for stable Nix ``                 |
| [`f29c6fc0`](https://github.com/LnL7/nix-darwin/commit/f29c6fc015f3cf2b7fb8b6fc98e2471a2acc53d6) | `` ci: use Nix 2.24.6 for unstable jobs ``                                 |
| [`bda49fe0`](https://github.com/LnL7/nix-darwin/commit/bda49fe089795d8d387419cd2ad877b345f3f840) | `` ci: update stable Nixpkgs to 24.05 ``                                   |
| [`95f063ea`](https://github.com/LnL7/nix-darwin/commit/95f063ea069e1752ddede8c9823a1b75ddd7858a) | `` tests/users-groups: update for `lib.escapeShellArg` change ``           |
| [`dea497f6`](https://github.com/LnL7/nix-darwin/commit/dea497f67a641d2d85f5673c3695f0fe43d46f64) | `` tests/networking-hostname: update for `lib.escapeShellArg` change ``    |
| [`15f64efc`](https://github.com/LnL7/nix-darwin/commit/15f64efcaf936f3b77955018d29b4802be6b144f) | `` zsh: prefer Nix completions these from Zsh package ``                   |
| [`4d59f660`](https://github.com/LnL7/nix-darwin/commit/4d59f660bc41ba35b1f6df829e8e0b7706b35ee7) | `` zsh: move fpath init from /etc/zshrc to /etc/zshenv ``                  |
| [`ec76c31d`](https://github.com/LnL7/nix-darwin/commit/ec76c31dbd084016d6cb2dc4796aef7b2536ff19) | `` checks.nix: fix typo ``                                                 |
| [`c3341753`](https://github.com/LnL7/nix-darwin/commit/c334175319949f6887dcab89afb32f1bb38e9f88) | `` nixos/github-runner: quote comma separators so as to pass shellcheck `` |
| [`97e0f727`](https://github.com/LnL7/nix-darwin/commit/97e0f7275966cfab018aaee1a0d1e5ce74cd8901) | `` users: allow arbitrary group IDs ``                                     |
| [`e1b6f307`](https://github.com/LnL7/nix-darwin/commit/e1b6f307ecfa88e9759646b22c8b9ece580e1b78) | `` linux-builder: make `package.nixosConfig` accurate ``                   |
| [`75d14c62`](https://github.com/LnL7/nix-darwin/commit/75d14c62cbc4360cbd1a1b5c52dbd17b8bd08892) | `` gpg: Suppress stderr from gpg-connect-agent on shell init ``            |
| [`544db369`](https://github.com/LnL7/nix-darwin/commit/544db3691c98a9bcc56b360cf3cf20bd41257ca3) | `` Add sha256 for DeterminateSystems Nix installer 0.22.0 ``               |