### PR TITLE
chore(flake/flake-parts): `8471fe90` -> `bcef6817`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -239,11 +239,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1726153070,
+        "narHash": "sha256-HO4zgY0ekfwO5bX0QH/3kJ/h4KvUDFZg8YpkNwIbg1U=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "bcef6817a8b2aa20a5a6dbb19b43e63c5bf8619a",
         "type": "github"
       },
       "original": {
@@ -620,14 +620,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1725233747,
+        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                 |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5766ecf9`](https://github.com/hercules-ci/flake-parts/commit/5766ecf987a46a651e7176a861bc2d24a9d26873) | `` Test unset extraInputsFlake ``                       |
| [`78bf03ce`](https://github.com/hercules-ci/flake-parts/commit/78bf03cea35debdeabe0f8d6ccd9ec8319cd1714) | `` Remove default value of `extraInputsFlake` ``        |
| [`3314f9c9`](https://github.com/hercules-ci/flake-parts/commit/3314f9c931ee7ee75abb21a043820febc7137033) | `` eval-tests: Remove getFlake calls ``                 |
| [`d50b490c`](https://github.com/hercules-ci/flake-parts/commit/d50b490ccc6308ef2d01def3362b86535e3284ba) | `` Add flakeModules.modules, declaring flake.modules `` |
| [`9c92fd15`](https://github.com/hercules-ci/flake-parts/commit/9c92fd1582b5b025c5c9ec86878618c662718288) | `` Set proper type for `flake.nixosModules` ``          |
| [`555010eb`](https://github.com/hercules-ci/flake-parts/commit/555010eb1a80b18ed63df534ce0efa8d0874601e) | `` dev/flake.lock: Update ``                            |
| [`fb8a5210`](https://github.com/hercules-ci/flake-parts/commit/fb8a5210dd5aa6b6ef188b8efb9ac8e70cfd9c4d) | `` flake.lock: Update ``                                |
| [`a7b916ca`](https://github.com/hercules-ci/flake-parts/commit/a7b916caf630ea6124017f5045d9e694b2144e5b) | `` flake.nix: Update nixpkgs-lib tree ``                |
| [`f112e301`](https://github.com/hercules-ci/flake-parts/commit/f112e301b33a8c0fbe7f65eac7a793e2dd8d3bf6) | `` Fix test ``                                          |
| [`1728089f`](https://github.com/hercules-ci/flake-parts/commit/1728089f3e8a28df678f60cc52cff4219ade477d) | `` flakeModules.partitions: Improve and fix docs ``     |
| [`1957ef2c`](https://github.com/hercules-ci/flake-parts/commit/1957ef2c4ba04e213c59380a19e46c9fcee38d0e) | `` Dogfood flakeModules.partitions ``                   |
| [`0d5122e8`](https://github.com/hercules-ci/flake-parts/commit/0d5122e84c0d7606363f89f0924245317c2fe3a0) | `` Add flakeModules.partitions ``                       |
| [`c07ef7e5`](https://github.com/hercules-ci/flake-parts/commit/c07ef7e578fbb1a2e964615e0faee1949371cd22) | `` Dogfood lib.mkFlake ``                               |
| [`3ea68936`](https://github.com/hercules-ci/flake-parts/commit/3ea689365998db56cc4c84aa4de4ddd15d550baa) | `` refact: Add let binding to flake.nix ``              |
| [`358ab837`](https://github.com/hercules-ci/flake-parts/commit/358ab8370e9726e60c16cb299c8138228fb0301e) | `` reference to Nix manual ``                           |
| [`309636f1`](https://github.com/hercules-ci/flake-parts/commit/309636f1b058eb305c974882967577225a3ee29a) | `` correct typo ``                                      |
| [`4a41226e`](https://github.com/hercules-ci/flake-parts/commit/4a41226e755f18ff9cd0d3914698c680ee0b804c) | `` apps: Add `meta` option ``                           |