### PR TITLE
chore(flake/stylix): `6c895c6b` -> `35233f92`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1724702977,
-        "narHash": "sha256-bP1/BHbEigLjTTmqyy1t8w5EVWHuLuABtOd/BBXVLtA=",
+        "lastModified": 1726170940,
+        "narHash": "sha256-sobkRkGBaMX9pD0bwU1iVPWi0WtQvZqlHyl1YtvNDio=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "6c895c6b42ca205017abe72a7263baf36a197972",
+        "rev": "35233f929629c8eb64e939e35260fc8347f94df9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`35233f92`](https://github.com/danth/stylix/commit/35233f929629c8eb64e939e35260fc8347f94df9) | `` emacs: explicitly set font size (#553) ``                            |
| [`ef81ad9e`](https://github.com/danth/stylix/commit/ef81ad9e85e60420cc83d4642619c14b57139d33) | `` gnome: move gnome-shell overlay out of gnome scope (#541) ``         |
| [`c95de362`](https://github.com/danth/stylix/commit/c95de3625235390b7a5160bddaae7243a89f811f) | `` hyprland: only enable hyprpaper when hyprland is installed (#544) `` |
| [`3a4101c4`](https://github.com/danth/stylix/commit/3a4101c4f4abee41859c0cb98f6250f04c80d0f6) | `` fish: remove obsolete $base16_theme check ``                         |