### PR TITLE
chore(flake/nix-index-database): `e333d62b` -> `0a2fba62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -589,11 +589,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724576102,
-        "narHash": "sha256-uM7n5nNL6fmA0bwMJBNll11f4cMWOFa2Ni6F5KeIldM=",
+        "lastModified": 1726370017,
+        "narHash": "sha256-CJOV4JiLhd++w9K+h2z00DiB4R1CCuElWzhldrXSq5w=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "e333d62b70b179da1dd78d94315e8a390f2d12e5",
+        "rev": "0a2fba621b6bbf06be0b4edd974236e3d2fcc1a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0a2fba62`](https://github.com/nix-community/nix-index-database/commit/0a2fba621b6bbf06be0b4edd974236e3d2fcc1a9) | `` flake.lock: Update ``                                |
| [`64227544`](https://github.com/nix-community/nix-index-database/commit/642275444c5a9defce57219c944b3179bf2adaa9) | `` update generated.nix to release 2024-09-08-030302 `` |
| [`0fbe4bbd`](https://github.com/nix-community/nix-index-database/commit/0fbe4bbdd0cd8b255f0182653814dec3accde827) | `` flake.lock: Update ``                                |
| [`32058e91`](https://github.com/nix-community/nix-index-database/commit/32058e9138248874773630c846563b1a78ee7a5b) | `` update generated.nix to release 2024-09-01-031416 `` |
| [`78ccfbc4`](https://github.com/nix-community/nix-index-database/commit/78ccfbc4a41fa8461b23aa1a999f9c3ced1882c9) | `` flake.lock: Update ``                                |