### PR TITLE
chore(flake/home-manager): `c2cd2a52` -> `7edf6cca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724435763,
-        "narHash": "sha256-UNky3lJNGQtUEXT2OY8gMxejakSWPTfWKvpFkpFlAfM=",
+        "lastModified": 1726298287,
+        "narHash": "sha256-wvtyOH5X2euU7CISBg2jNVpc2cGP1rJ2bsatBLDwjGc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c2cd2a52e02f1dfa1c88f95abeb89298d46023be",
+        "rev": "7edf6ccaec8001cb20368bf1bf6a677178cae07b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`7edf6cca`](https://github.com/nix-community/home-manager/commit/7edf6ccaec8001cb20368bf1bf6a677178cae07b) | `` Add translation using Weblate (Hindi) ``               |
| [`e94bee95`](https://github.com/nix-community/home-manager/commit/e94bee957400c8f871d9b9ea54308e15d664242c) | `` Translate using Weblate (Hindi) ``                     |
| [`898eaef7`](https://github.com/nix-community/home-manager/commit/898eaef7ea906ddc8e86d57957f2a701878bfb05) | `` Translate using Weblate (Russian) ``                   |
| [`f084d653`](https://github.com/nix-community/home-manager/commit/f084d653199345ad294abca921a0e25872bd75c0) | `` swaync: fix example configuration ``                   |
| [`43845d04`](https://github.com/nix-community/home-manager/commit/43845d04f83d44d744206ea9884b8206e7640633) | `` git: add diff-highlight diff pager option ``           |
| [`503af483`](https://github.com/nix-community/home-manager/commit/503af483e1b328691ea3a434d331995595fb2e3d) | `` eza: add support for fish abbreviations ``             |
| [`076c78ed`](https://github.com/nix-community/home-manager/commit/076c78edede4e7abc71af0b1610fb1fc1c0fac29) | `` fish: add `preferAbbrs` option ``                      |
| [`7923c691`](https://github.com/nix-community/home-manager/commit/7923c691527d2ee85fe028c6e780ac3bf8606f06) | `` neovide: add module ``                                 |
| [`4c8647b1`](https://github.com/nix-community/home-manager/commit/4c8647b1ed35d0e1822c7997172786dfa18cd7da) | `` trayscale: add module ``                               |
| [`daaf0c2f`](https://github.com/nix-community/home-manager/commit/daaf0c2f8da6c7b5dc04dd62a3d98422f259551b) | `` kanshi: add support for output aliases ``              |
| [`cb3ab592`](https://github.com/nix-community/home-manager/commit/cb3ab5928cbe8ac3cfee7010ccad4c31dbc1fb5f) | `` helix: add example for use with evil-helix ``          |
| [`ea244c5a`](https://github.com/nix-community/home-manager/commit/ea244c5ae2205f0fced24dde2e555440303d63bc) | `` helix: remove outdated language-server comment ``      |
| [`433e6866`](https://github.com/nix-community/home-manager/commit/433e686675ba24176fe3383916a4bd1c9799c676) | `` autorandr: configModule.extraConfig ``                 |
| [`ef506124`](https://github.com/nix-community/home-manager/commit/ef506124579ff6280a43a9596bb2a5049872bf8e) | `` gpg-agent: add launchd service agent and sockets ``    |
| [`c82fc8cf`](https://github.com/nix-community/home-manager/commit/c82fc8cf3f75e667ad9dd3e5df721119b63723b3) | `` home-manager: use `hostname` from GNU inetutils ``     |
| [`2b1957a0`](https://github.com/nix-community/home-manager/commit/2b1957a0a3db7d63c1844abb84223655c30a7eb0) | `` home-manager: fix early exit due to FQDN error ``      |
| [`da8406a6`](https://github.com/nix-community/home-manager/commit/da8406a6ff556b86dc368e96ca8bd81b2704a91a) | `` systemd: use getExe for sd-switch ``                   |
| [`e1c60940`](https://github.com/nix-community/home-manager/commit/e1c6094075d28d496a1b0db208afd31e0b213d67) | `` systemd: unify handling of switch environment ``       |
| [`51e46643`](https://github.com/nix-community/home-manager/commit/51e46643429b3dc96dadf3014757582eca6adf28) | `` treewide: use non-deprecated substitute arguments ``   |
| [`8a167164`](https://github.com/nix-community/home-manager/commit/8a1671642826633586d12ac3158e463c7a50a112) | `` flake.lock: Update ``                                  |
| [`e5fa72ba`](https://github.com/nix-community/home-manager/commit/e5fa72bad0c6f533e8d558182529ee2acc9454fe) | `` Translate using Weblate (Romanian) ``                  |
| [`10541f19`](https://github.com/nix-community/home-manager/commit/10541f19c584fe9633c921903d8c095d5411e041) | `` pqiv: add boolean support ``                           |
| [`be47a2bd`](https://github.com/nix-community/home-manager/commit/be47a2bdf278c57c2d05e747a13ed31cef54a037) | `` k9s: remove katexochen as maintainer ``                |
| [`77c94148`](https://github.com/nix-community/home-manager/commit/77c94148285563113246eaf9f8df5488e00c81d0) | `` k9s: allow defining custom theme file ``               |
| [`8a175a89`](https://github.com/nix-community/home-manager/commit/8a175a89137fe798b33c476d4dae17dba5fb3fd3) | `` tests: change quoting to match new Nixpkgs behavior `` |
| [`ec4c6928`](https://github.com/nix-community/home-manager/commit/ec4c6928bbacc89cf10e9c959a7a47cbaad95344) | `` firefox: fix selection of lastUserContextId ``         |
| [`aaebdea7`](https://github.com/nix-community/home-manager/commit/aaebdea769a5c10f1c6e50ebdf5924c1a13f0cda) | `` taskwarrior: support taskwarrior3 migration ``         |
| [`127ccc3e`](https://github.com/nix-community/home-manager/commit/127ccc3eb7e36fa75e8c3fbd8a343154f66cc1c6) | `` i3/sway: support str type for font size ``             |
| [`7d569851`](https://github.com/nix-community/home-manager/commit/7d569851e95e8b360a3d7a2f52c5fc6a597a7657) | `` flake.lock: Update ``                                  |
| [`5b95e061`](https://github.com/nix-community/home-manager/commit/5b95e0611b498fac7c8425d1b1bc4cacfd64e7f0) | `` Translate using Weblate (Hungarian) ``                 |
| [`b00bdf59`](https://github.com/nix-community/home-manager/commit/b00bdf59c0aa5515a0a8e1773fa19128e7efa181) | `` xdg: add option 'xdg.stateFile' ``                     |
| [`03b49187`](https://github.com/nix-community/home-manager/commit/03b49187a2e41f042896a26761ca86ce90cb7f2c) | `` sway: indent sway configuration options ``             |
| [`5130249a`](https://github.com/nix-community/home-manager/commit/5130249ab20229480aa732942c9c555a38fb910a) | `` taskwarrior-sync: add package option ``                |
| [`471e3eb0`](https://github.com/nix-community/home-manager/commit/471e3eb0a114265bcd62d11d58ba8d3421ee68eb) | `` git: add option to provide difftastic package ``       |