### PR TITLE
chore(flake/git-hooks): `4509ca64` -> `7570de7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1725513492,
+        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`cbb1a986`](https://github.com/cachix/git-hooks.nix/commit/cbb1a986424bfb874eacc4d50e0374a647126efe) | `` nixfmt: deprecate `nixfmt` and redirect to `nixfmt-classic` or `nixfmt-rfc-style` `` |