### PR TITLE
chore(flake/nixvim-flake): `c25c299a` -> `78133d2f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -704,11 +704,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1726561994,
-        "narHash": "sha256-8D45AwtrruXpWBcgCzWyoi/uAA4Q4p7NkQvERfEDR20=",
+        "lastModified": 1726603346,
+        "narHash": "sha256-Y02kQlkxF5dRPW/tDww/j6MgLBtiHbReENLSIqcm/Ow=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "c25c299a6418bcf7887cc81a2b22730f8ce3e7b0",
+        "rev": "78133d2fef5f76f8e86898986559c5125bfd436e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`78133d2f`](https://github.com/alesauce/nixvim-flake/commit/78133d2fef5f76f8e86898986559c5125bfd436e) | `` chore(deps): bump DeterminateSystems/magic-nix-cache-action from 7 to 8 (#246) `` |
| [`8a29865e`](https://github.com/alesauce/nixvim-flake/commit/8a29865e2b2a84d4dd42c535a97c1295905c9051) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 13 to 14 (#247) `` |