### PR TITLE
chore(flake/git-hooks): `7570de7b` -> `4e743a69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1725513492,
-        "narHash": "sha256-tyMUA6NgJSvvQuzB7A1Sf8+0XCHyfSPRx/b00o6K0uo=",
+        "lastModified": 1726745158,
+        "narHash": "sha256-D5AegvGoEjt4rkKedmxlSEmC+nNLMBPWFxvmYnVLhjk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "7570de7b9b504cfe92025dd1be797bf546f66528",
+        "rev": "4e743a6920eab45e8ba0fbe49dc459f1423a4b74",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0ec644ce`](https://github.com/cachix/git-hooks.nix/commit/0ec644cee9abdf81ea1b3ce9303d59e6c9764b0b) | `` add trufflehog to tools ``                          |
| [`0b4048d9`](https://github.com/cachix/git-hooks.nix/commit/0b4048d9b7da3e1ded5d3e5fbc2e8250efd51d0e) | `` add working but unconfigurable trufflehog module `` |
| [`b8fafdec`](https://github.com/cachix/git-hooks.nix/commit/b8fafdec45b0846ba970377a269322f33cd541a0) | `` modules/hooks.nix: restore alphabetical order ``    |