### PR TITLE
chore(flake/home-manager): `87c7d4df` -> `1786e2af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726762959,
-        "narHash": "sha256-EQSG411oIcc5ZsTwMfTkhLq4j6zGdn+foJdfwCJ6kdg=",
+        "lastModified": 1726785354,
+        "narHash": "sha256-SLorVhoorZwjM1aS04bBX4fufEXIfkMdAGkj9bu2QAQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87c7d4df161d0eafc0c8fe93a98ba5247a83d969",
+        "rev": "1786e2afdbc48e9038f7cff585069736e1d0ed44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`1786e2af`](https://github.com/nix-community/home-manager/commit/1786e2afdbc48e9038f7cff585069736e1d0ed44) | `` firefox: fix incorrect condition ``                   |
| [`b5e09b85`](https://github.com/nix-community/home-manager/commit/b5e09b85f22675923a61ef75e6e9188bd113a6e1) | `` firefox: only add Version = 2 on non-darwin ``        |
| [`1f7b8188`](https://github.com/nix-community/home-manager/commit/1f7b8188a9c9c5ba32f9a8351c55f42ecc22b77c) | `` zoxide: replace outdated flag in "options" example `` |