### PR TITLE
chore(flake/home-manager): `8d7e352a` -> `0b052dd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726818292,
-        "narHash": "sha256-sFI+LTeRTPOAZe9ewhQpIq5CkIr4IpzfzuyIFCz6ugY=",
+        "lastModified": 1726825546,
+        "narHash": "sha256-HiBzfzgqojA9OjPB+vdi2o+gy4Zw/MEipuGopgGsZEw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8d7e352a4b25ac2d88a881ffa3472680af916ddc",
+        "rev": "0b052dd8119005c6ba819db48bcc657e48f401b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`0b052dd8`](https://github.com/nix-community/home-manager/commit/0b052dd8119005c6ba819db48bcc657e48f401b7) | `` swayidle: minor cleanups ``   |
| [`4803bf55`](https://github.com/nix-community/home-manager/commit/4803bf558bdf20cb067aceb8830b7ad70113f4e3) | `` swayidle: make -w optional `` |