### PR TITLE
chore(flake/nixvim-flake): `51b4d1e4` -> `32c9fc7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -704,11 +704,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1726763373,
-        "narHash": "sha256-qvHc8nND2bQA9Z5sVx1Fjt+IpxCg8PcHdZGZKszJkHw=",
+        "lastModified": 1726849668,
+        "narHash": "sha256-SIGD+JD9xgIBhYjUpWurdDnx6GRv9tH5odAT9Q5jQpE=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "51b4d1e4976b1f6564d6b2236e0b78c32c325294",
+        "rev": "32c9fc7b075c7bab0a14f2542de002622be9ccd2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`32c9fc7b`](https://github.com/alesauce/nixvim-flake/commit/32c9fc7b075c7bab0a14f2542de002622be9ccd2) | `` chore(flake/nixpkgs): 99dc8785 -> c04d5652 `` |