### PR TITLE
chore(flake/darwin): `c03f85fa` -> `bd7d1e39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726742753,
-        "narHash": "sha256-QclpWrIFIg/yvWRiOUaMp1WR+TGUE9tb7RE31xHlxWc=",
+        "lastModified": 1727003835,
+        "narHash": "sha256-Cfllbt/ADfO8oxbT984MhPHR6FJBaglsr1SxtDGbpec=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "c03f85fa42d68d1056ca1740f3113b04f3addff2",
+        "rev": "bd7d1e3912d40f799c5c0f7e5820ec950f1e0b3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                       |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
| [`034c45dd`](https://github.com/LnL7/nix-darwin/commit/034c45dd0cac806b527e64c143020676e1070769) | `` feat: use wait4path with script launchd option ``          |
| [`db92fac3`](https://github.com/LnL7/nix-darwin/commit/db92fac3a9552ac3338977dcaf4cd15acf4aac08) | `` flake: match NixOS definition of `nixpkgs.flake.source` `` |