### PR TITLE
chore(flake/nixvim-flake): `a11371b1` -> `84fa050b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1727222872,
-        "narHash": "sha256-V+ejpzrnpqmhVhMI5PDo83rAUfgIW1Q16ZFjFEWKHls=",
+        "lastModified": 1727339432,
+        "narHash": "sha256-+trMOoM8pw8gqm1JKzk3cyLwDLLpkNVbpfoJNovfN/Y=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "a11371b15597c8474d31971d069dcf8acaba78a4",
+        "rev": "84fa050b909f758a1fe18a006349903e335b27ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`84fa050b`](https://github.com/alesauce/nixvim-flake/commit/84fa050b909f758a1fe18a006349903e335b27ef) | `` chore(flake/nixpkgs): 9357f4f2 -> 30439d93 `` |