### PR TITLE
chore(flake/darwin): `bd7d1e39` -> `f2e1c4aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727003835,
-        "narHash": "sha256-Cfllbt/ADfO8oxbT984MhPHR6FJBaglsr1SxtDGbpec=",
+        "lastModified": 1727507295,
+        "narHash": "sha256-I/FrX1peu4URoj5T5odfuKR2rm4GjYJJpCGF9c0/lDA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bd7d1e3912d40f799c5c0f7e5820ec950f1e0b3d",
+        "rev": "f2e1c4aa29fc211947c3a7113cba1dd707433b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                              |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`3d19b90f`](https://github.com/LnL7/nix-darwin/commit/3d19b90fc74fa316cfb37b514e006d37c51e22a8) | `` fix: karabiner elements virtualhiddeviceclient `` |