### PR TITLE
chore(flake/nixvim-flake): `cb2b306e` -> `2d69d70a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1727557953,
-        "narHash": "sha256-xe8JQaNOPTyzWsSlLu2yC6qw4SjOMHrXk4Iq+pIgLhM=",
+        "lastModified": 1727617301,
+        "narHash": "sha256-koyciD3ZlRqYUSC44U/b1+Y0M4oL7QjP332i+Fq8CIg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2c4e4681db658deeceb2f781136d7ba1d0009521",
+        "rev": "cd76b4feb87766e76ca48e31d85c7d58d5ae354a",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1727574291,
-        "narHash": "sha256-rTt/5Q4/qhCCj1Vj2ycIZv1SYRUuhJuQL+oDsKvlh30=",
+        "lastModified": 1727627354,
+        "narHash": "sha256-tiMPVA8meh8qth8m/VgcvPsU6/nRLMK8C2uz6DjPsKE=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "cb2b306ebfe6752281b685845541061b32a5a6e0",
+        "rev": "2d69d70a47abecbe45bbb5b9338bbe0eab47efe4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`2d69d70a`](https://github.com/alesauce/nixvim-flake/commit/2d69d70a47abecbe45bbb5b9338bbe0eab47efe4) | `` chore(flake/nixvim): 2c4e4681 -> cd76b4fe `` |