### PR TITLE
chore(flake/nixvim-flake): `5d9bcc36` -> `4260c959`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1727713911,
-        "narHash": "sha256-GJGQqJOVAR4MEOFgVX3EIioh2+DoKdvvuf2nDIMkccY=",
+        "lastModified": 1727832694,
+        "narHash": "sha256-UqTFKCLRSZMBThwh0RebDrPCXNMnb/p8qdUMAKdpCSc=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5d9bcc364467096112282635d6bb674db22168b9",
+        "rev": "4260c9594d7903dc51d0dfac2ae24ad5404beab1",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1727514110,
-        "narHash": "sha256-0YRcOxJG12VGDFH8iS8pJ0aYQQUAgo/r3ZAL+cSh9nk=",
+        "lastModified": 1727805723,
+        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "85f7a7177c678de68224af3402ab8ee1bcee25c8",
+        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`4260c959`](https://github.com/alesauce/nixvim-flake/commit/4260c9594d7903dc51d0dfac2ae24ad5404beab1) | `` chore(flake/pre-commit-hooks): 85f7a717 -> 2f5ae3fc `` |