### PR TITLE
chore(flake/nixvim-flake): `4260c959` -> `b922880c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1727832694,
-        "narHash": "sha256-UqTFKCLRSZMBThwh0RebDrPCXNMnb/p8qdUMAKdpCSc=",
+        "lastModified": 1727857840,
+        "narHash": "sha256-Mq1EOSUmpZmW1pfcxWuI8yjJiitcvgAN4LoZw8uOEDs=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "4260c9594d7903dc51d0dfac2ae24ad5404beab1",
+        "rev": "b922880cfbf967811a8838530cfbef43a6a91bb9",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1727805723,
-        "narHash": "sha256-b8flytpuc4Ey/g3mcvpS/ICORcD4h56QDZeP5LogevY=",
+        "lastModified": 1727854478,
+        "narHash": "sha256-/odH2nUMAwkMgOS2nG2z0exLQNJS4S2LfMW0teqU7co=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2f5ae3fc91db865eff2c5a418da85a0fbe6238a3",
+        "rev": "5f58871c9657b5fc0a7f65670fe2ba99c26c1d79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`b922880c`](https://github.com/alesauce/nixvim-flake/commit/b922880cfbf967811a8838530cfbef43a6a91bb9) | `` chore(flake/pre-commit-hooks): 2f5ae3fc -> 5f58871c `` |