### PR TITLE
chore(flake/nix-index-database): `f9fdf828` -> `0f7169d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727658919,
-        "narHash": "sha256-YAePt2GldkkRJ08LvZNHcuS6shIVStj+K+1DZN3gbnM=",
+        "lastModified": 1728185226,
+        "narHash": "sha256-W+wWyNjFywVfFrbErXhGwgO2HlR0yMHqd1doEEbW9yw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f9fdf8285690a351e8998f1e703ebdf9cdf51dee",
+        "rev": "0f7169d3ec7ef1477af6e39731e67a1dc7a9f6e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`0f7169d3`](https://github.com/nix-community/nix-index-database/commit/0f7169d3ec7ef1477af6e39731e67a1dc7a9f6e7) | `` update generated.nix to release 2024-10-06-031622 `` |
| [`b7e381af`](https://github.com/nix-community/nix-index-database/commit/b7e381afe2c00bc1d9a793a341424abb2431c55a) | `` flake.lock: Update ``                                |