### PR TITLE
chore(flake/nixvim-flake): `6ff5e398` -> `dd305c0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1728145679,
-        "narHash": "sha256-qd1nr2b+WUiyzJva650LBX/3hDBru0ZSVxKHSm1BE0w=",
+        "lastModified": 1728176751,
+        "narHash": "sha256-hVmdzrZMFC/5q3dSjbKX9qocWN9coPBhs8muLsL3738=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6594472fd275f6dcf5a9fba4a83d2f7fa2cf2b8a",
+        "rev": "d42c804ad515f45f8addaf5a4bb0b8ce405ea140",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1728203236,
-        "narHash": "sha256-kXVRYk+WXqA8lh7VurOb6rJUsjcAyufKJzrYyvT7D/o=",
+        "lastModified": 1728255773,
+        "narHash": "sha256-YF3IZUSdhD9oX8pzt5zCNRWvQmZuvu9MKXO0zJlS5ls=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "6ff5e398f2904d3c631e7257ce517964b6b4addd",
+        "rev": "dd305c0ccb9495d6eaccae733e62b9bbed40d14e",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1727854478,
-        "narHash": "sha256-/odH2nUMAwkMgOS2nG2z0exLQNJS4S2LfMW0teqU7co=",
+        "lastModified": 1728092656,
+        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5f58871c9657b5fc0a7f65670fe2ba99c26c1d79",
+        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`dd305c0c`](https://github.com/alesauce/nixvim-flake/commit/dd305c0ccb9495d6eaccae733e62b9bbed40d14e) | `` chore(flake/pre-commit-hooks): 5f58871c -> 1211305a `` |
| [`417f23da`](https://github.com/alesauce/nixvim-flake/commit/417f23dabd3318b47dfa3103bb39c7e2b0e88ce8) | `` chore(flake/nixvim): 6594472f -> d42c804a ``           |