### PR TITLE
chore(flake/nix-fast-build): `2ba025ea` -> `1775c732`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -495,11 +495,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1728133641,
-        "narHash": "sha256-gYTZbNvQ7Gz29SRRzoJWHGzktEI6CqPBoXiPVIXdE9c=",
+        "lastModified": 1728306776,
+        "narHash": "sha256-57QXMMEELaEbE+ZVg0ngSC7UGZoyYP2QmDGcQSJ8BnE=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "2ba025eab61fe026a76bbab3579d1f051dde5275",
+        "rev": "1775c732071d0ee37c1950ce4ecbf2729487ee71",
         "type": "github"
       },
       "original": {
@@ -850,11 +850,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714058656,
-        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
+        "lastModified": 1723808491,
+        "narHash": "sha256-rhis3qNuGmJmYC/okT7Dkc4M8CeUuRCSvW6kC2f3hBc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
+        "rev": "1d07739554fdc4f8481068f1b11d6ab4c1a4167a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`9f45b87b`](https://github.com/Mic92/nix-fast-build/commit/9f45b87b433e8fb19409fb62eab23a9f6dc16419) | `` add machine-readable output format ``       |
| [`8e410259`](https://github.com/Mic92/nix-fast-build/commit/8e410259bf6e0aab4d10457cf91c450f0b89dded) | `` raise Error rather than a die() function `` |
| [`ac08d34e`](https://github.com/Mic92/nix-fast-build/commit/ac08d34e1d2e89cb29955e4c9cef7bb5e711ec80) | `` reformat with treefmt ``                    |
| [`b208b716`](https://github.com/Mic92/nix-fast-build/commit/b208b7169cad9b7574567c0049d3ea1ec88e6a52) | `` modernize treefmt ``                        |
| [`218a9be9`](https://github.com/Mic92/nix-fast-build/commit/218a9be977cb8008001ff9b29a5d1b5968bbea34) | `` update flake inputs ``                      |