### PR TITLE
chore(flake/home-manager): `509dbf8d` -> `3ac39b2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728041527,
-        "narHash": "sha256-03liqiJtk9UP7YQHW4r8MduKCK242FQzud8iWvvlK+o=",
+        "lastModified": 1728306985,
+        "narHash": "sha256-l/KpcWTv2SjxCnqFs5GYhvjeVYd40WQV4/F2+w9btd4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "509dbf8d45606b618e9ec3bbe4e936b7c5bc6c1e",
+        "rev": "3ac39b2a8b7cbfc0f96628d8a84867c885bc988b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`3ac39b2a`](https://github.com/nix-community/home-manager/commit/3ac39b2a8b7cbfc0f96628d8a84867c885bc988b) | `` zathura: Fix the type for config options (#5934) `` |
| [`fcf5e608`](https://github.com/nix-community/home-manager/commit/fcf5e608ac65f64463bc0ccc5ea86f2170f20689) | `` kitty: allow float values in settings (#5925) ``    |
| [`bc623830`](https://github.com/nix-community/home-manager/commit/bc623830e619cef86a2d3750625ffe4e24ea7e64) | `` ci: bump cachix/install-nix-action from 27 to 30 `` |