### PR TITLE
chore(flake/nixvim-flake): `3d23e83e` -> `3acdd541`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1728428263,
-        "narHash": "sha256-TG/ojDMLuLJI4nEo0waZawgAq4r30n7xJ8klEKpFcd0=",
+        "lastModified": 1728485062,
+        "narHash": "sha256-+2e9hAM2GVDF3gywdQI/OA7s4f0Z9rvFuiVxePI41QM=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eda14029813906b1ef355823de237d86fea59908",
+        "rev": "61ec39764fbe1e4f21cf801ea7b9209d527c8135",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1728437449,
-        "narHash": "sha256-ast/5p/3hqQjQa06A+zHJJocsfSvJU8pw+Hpkx3OB1Y=",
+        "lastModified": 1728491330,
+        "narHash": "sha256-4Z3gemkFBGz9uwodl0ysAUWx1jbqmfNCcaVE3So5jd8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "3d23e83ecd817247a67c70fbf54fd807761320dd",
+        "rev": "3acdd541d9ea14a5628ffe76bbaa2f6a6fc01c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`3acdd541`](https://github.com/alesauce/nixvim-flake/commit/3acdd541d9ea14a5628ffe76bbaa2f6a6fc01c1f) | `` chore(flake/nixvim): eda14029 -> 61ec3976 `` |