### PR TITLE
chore(flake/git-hooks): `1211305a` -> `06bb5971`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728092656,
-        "narHash": "sha256-eMeCTJZ5xBeQ0f9Os7K8DThNVSo9gy4umZLDfF5q6OM=",
+        "lastModified": 1728651332,
+        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "1211305a5b237771e13fcca0c51e60ad47326a9a",
+        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`6a3d0eb6`](https://github.com/cachix/git-hooks.nix/commit/6a3d0eb6b64920b33683111bce68d1f4a9ef51dd) | `` statix: skip adding `--ignore` if empty ``   |
| [`1fe5afc7`](https://github.com/cachix/git-hooks.nix/commit/1fe5afc78489820f5586a9c90f91358a169604a7) | `` statix: fix broken list option `--ignore` `` |
| [`6ce0397f`](https://github.com/cachix/git-hooks.nix/commit/6ce0397f4bd8af17e83639f7c561a64799fd81ae) | `` feat(rustfmt): add settings ``               |
| [`7ee593e0`](https://github.com/cachix/git-hooks.nix/commit/7ee593e0d1dda9d0038f63db58360b7f891f5123) | `` feat(statix): add settings ``                |