### PR TITLE
chore(flake/home-manager): `342a1d68` -> `2b13611e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728598744,
-        "narHash": "sha256-sSfvyO5xH3HObHHmh6lp/hcvo7tMjFKd/HXpxyrRnoE=",
+        "lastModified": 1728685293,
+        "narHash": "sha256-1WowL96pksT/XCi+ZXHgqiQ9NiU5oxWuNIQYWqOoEYc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "342a1d682386d3a1d74f9555cb327f2f311dda6e",
+        "rev": "2b13611eaed8326789f76f70d21d06fbb14e3e47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`2b13611e`](https://github.com/nix-community/home-manager/commit/2b13611eaed8326789f76f70d21d06fbb14e3e47) | `` floorp: add module ``                            |
| [`65ae9c14`](https://github.com/nix-community/home-manager/commit/65ae9c147349829d3df0222151f53f79821c5134) | `` git: add module for `git maintenance` (#5772) `` |
| [`58283095`](https://github.com/nix-community/home-manager/commit/582830954264080aae93f751c3cdc58df600d2d1) | `` vifm: add module ``                              |