### PR TITLE
chore(flake/git-hooks): `06bb5971` -> `ff68f917`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728651332,
-        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
+        "lastModified": 1728778939,
+        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
+        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                     |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`e76201cb`](https://github.com/cachix/git-hooks.nix/commit/e76201cb5eb84bc613ef4276f7d0095978233a06) | `` hooks: fix rome and nixfmt migrations `` |
| [`eb74e0be`](https://github.com/cachix/git-hooks.nix/commit/eb74e0be24a11a1531b5b8659535580554d30b28) | `` typo ``                                  |
| [`c93e347b`](https://github.com/cachix/git-hooks.nix/commit/c93e347b6ffdd98709a949faeb5480a8ccf11da0) | `` feat(run.nix): expose more ``            |