### PR TITLE
chore(flake/nix-index-database): `5fce10c8` -> `5c54c33a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728263287,
-        "narHash": "sha256-GJDtsxz2/zw6g/Nrp4XVWBS5IaZ7ZUkuvxPOBEDe7pg=",
+        "lastModified": 1728790083,
+        "narHash": "sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5fce10c871bab6d7d5ac9e5e7efbb3a2783f5259",
+        "rev": "5c54c33aa04df5dd4b0984b7eb861d1981009b22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5c54c33a`](https://github.com/nix-community/nix-index-database/commit/5c54c33aa04df5dd4b0984b7eb861d1981009b22) | `` update generated.nix to release 2024-10-13-031548 `` |
| [`b8e0bc25`](https://github.com/nix-community/nix-index-database/commit/b8e0bc25593a748acef3121c7bedc20c483baf46) | `` flake.lock: Update ``                                |