### PR TITLE
chore(flake/nixvim-flake): `9dfbcda6` -> `f346e3e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1728736326,
-        "narHash": "sha256-JYy050VI7AQyDPHjZ/48rdNFfVvdbR0wPtsRA/4nc7E=",
+        "lastModified": 1728752931,
+        "narHash": "sha256-ZTj+Ahtouc9m9Ea4qfAFAkOR/1cq+6H7BOjO69MjZ78=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "2e1b3b7d43f485866573f70411a4797ce38e27bb",
+        "rev": "48b62ac2e607fb0c5332ba2a2455e9cf3184832a",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1728750464,
-        "narHash": "sha256-xTa07kEv7DEGHE8b+gnrRKPdBLGu8MqGV21Za9sRmZg=",
+        "lastModified": 1728799085,
+        "narHash": "sha256-Er21iM1kVXGumeurCLam/NaiW1+1Av4Iye1+1ZjvjTI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "9dfbcda65110daa05a6e615417be86ac4dc776e0",
+        "rev": "f346e3e5763fc3fecd03d662698b1f066e0f8dd0",
         "type": "github"
       },
       "original": {
@@ -703,11 +703,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728651332,
-        "narHash": "sha256-lm+asqDSTj0m6j1dtEte1/XG+uzZbwxS3tn7JLaBw84=",
+        "lastModified": 1728778939,
+        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "06bb5971c139959d9a951f34e4264d32f5d998e7",
+        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                          |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
| [`f346e3e5`](https://github.com/alesauce/nixvim-flake/commit/f346e3e5763fc3fecd03d662698b1f066e0f8dd0) | `` fix(lang/java): Remove Lua-string based config and files enclosure attrset `` |
| [`775a98df`](https://github.com/alesauce/nixvim-flake/commit/775a98df42f9dacb0245e9b94973139392339bb4) | `` feat(lang/java): Adding copyright header autocommand for new java files ``    |
| [`6d1709ea`](https://github.com/alesauce/nixvim-flake/commit/6d1709eaa1de9d78304a90ed12467274b3a8ae4a) | `` feat(lang/kotlin): Init Kotlin language configuration ``                      |
| [`53125bb3`](https://github.com/alesauce/nixvim-flake/commit/53125bb3e1694286793a5860aba62859a607e103) | `` chore(flake/pre-commit-hooks): 06bb5971 -> ff68f917 ``                        |
| [`314fadda`](https://github.com/alesauce/nixvim-flake/commit/314faddae8a0fda2a80d982af32ee974b813cacc) | `` chore(flake/nixvim): 2e1b3b7d -> 48b62ac2 ``                                  |