### PR TITLE
chore(flake/darwin): `fd0e3ed3` -> `a60ac02f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728769175,
-        "narHash": "sha256-KtE4F2wTzIpE6fI9diD5dDkUgGAt7IG80TnFqkCD8Ws=",
+        "lastModified": 1728901530,
+        "narHash": "sha256-I9Qd0LnAsEGHtKE9+uVR0iDFmsijWSy7GT0g3jihG4Q=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "fd0e3ed30b75ddf7f3d94829d80a078b413b6244",
+        "rev": "a60ac02f9466f85f092e576fd8364dfc4406b5a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                               |
| ------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`6347a9dc`](https://github.com/LnL7/nix-darwin/commit/6347a9dcd1e43b9a5d43b837cfa4ca0073c2eb0e) | `` skhd: add `skhd` to `PATH` ``      |
| [`d32e6de0`](https://github.com/LnL7/nix-darwin/commit/d32e6de094e87ba8eeef0be8c5696f7b14365af2) | `` defaults: don't output Dock PID `` |