### PR TITLE
chore(flake/nixpkgs): `5633bcff` -> `7ffd9ae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -586,11 +586,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1730531603,
+        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`7ffd9ae6`](https://github.com/NixOS/nixpkgs/commit/7ffd9ae656aec493492b44d0ddfb28e79a1ea25d) | `` Revert "bundler: 2.5.16 -> 2.5.21" (#353045) ``                                  |
| [`3e6843e8`](https://github.com/NixOS/nixpkgs/commit/3e6843e8d5a20fbf76e8c939c7c6f29977d87f8b) | `` terraform-providers.google-beta: 6.7.0 -> 6.9.0 ``                               |
| [`a50de591`](https://github.com/NixOS/nixpkgs/commit/a50de591409d9e85449118ce4a704b61281e2b8a) | `` oraclejdk_*: mark insecure and not updated ``                                    |
| [`37ee6ba6`](https://github.com/NixOS/nixpkgs/commit/37ee6ba681f133e76532b51320032896831b5d9f) | `` Revert "NixOS `apply` script" ``                                                 |
| [`a4bd8993`](https://github.com/NixOS/nixpkgs/commit/a4bd8993b30ca13ed4b1085a70ad4b9fceed8bad) | `` python312Packages.meteoswiss-async: relax aiohttp ``                             |
| [`da8c5488`](https://github.com/NixOS/nixpkgs/commit/da8c5488d1e3c15816d5e75bc8a76f010526de29) | `` python3Packages.strawberry-graphql: remove poetry patch and missing test path `` |
| [`913fb634`](https://github.com/NixOS/nixpkgs/commit/913fb6348478695104c458b7a6deb74a87a46fae) | `` {mpc_cli,mpc-cli}: red-alias ``                                                  |
| [`93207b76`](https://github.com/NixOS/nixpkgs/commit/93207b762985558888c0fe334b043a6f01d13d51) | `` bumblebee-status: update plugins ``                                              |
| [`77ec23d6`](https://github.com/NixOS/nixpkgs/commit/77ec23d6aff5b78c52364725f455e8916d57d456) | `` nixos/tests/mpd: update and format ``                                            |
| [`178ea7bb`](https://github.com/NixOS/nixpkgs/commit/178ea7bbd53839046cc3dffe400c7fd8cc1064fd) | `` nixos/triggerhappy: update and format ``                                         |
| [`bcd149f7`](https://github.com/NixOS/nixpkgs/commit/bcd149f7a57a9871cd5b9762e8262f912ee0e700) | `` clerk: migrate to by-name ``                                                     |
| [`b1b11769`](https://github.com/NixOS/nixpkgs/commit/b1b1176946e8ea915b3c4d1b469b52d92e48b7bb) | `` clerk: update and format ``                                                      |
| [`ca1ecc03`](https://github.com/NixOS/nixpkgs/commit/ca1ecc03a2fc1d6c0852a4f6cdb71f23e02fa28e) | `` mpc: 0.34 -> 0.35 ``                                                             |
| [`36ecd860`](https://github.com/NixOS/nixpkgs/commit/36ecd8606f33cfb8bd88c86d924a2e0949914a87) | `` mpc: refactor ``                                                                 |
| [`791efe72`](https://github.com/NixOS/nixpkgs/commit/791efe72af651b8940efd43c60e0e0cbfb7480da) | `` mpc: migrate to by-name ``                                                       |
| [`b44fbe5e`](https://github.com/NixOS/nixpkgs/commit/b44fbe5ed4ca82247c07302015327b26be12266e) | `` mpc-cli: hide inputs ``                                                          |
| [`8aa6466c`](https://github.com/NixOS/nixpkgs/commit/8aa6466c2a4b5f1e6031abfe6714b326d391f788) | `` linux-kernels: fix typo ``                                                       |
| [`0029a89c`](https://github.com/NixOS/nixpkgs/commit/0029a89ce9cbe49b5e3ef9bdcc4dcaa2e26a1d0d) | `` vscode-extensions.github.copilot-chat: 0.22.2024100702 -> 0.23.2024102903 ``     |
| [`cc721631`](https://github.com/NixOS/nixpkgs/commit/cc7216313aa50ad184b2a69930fb274e524c1f7c) | `` vscode-extensions.github.copilot: 1.236.0 -> 1.243.1191 ``                       |
| [`c0ebcd4e`](https://github.com/NixOS/nixpkgs/commit/c0ebcd4ee6cc0ec3c2e8bdc450ed0c871bdf505a) | `` python311Packages.graspologic: relax beartype and hyppo ``                       |
| [`fd5b39ad`](https://github.com/NixOS/nixpkgs/commit/fd5b39ad6e9ea714c41897e707b100b67137c1fa) | `` gitkraken: fix invalid darwin hash ``                                            |
| [`500bc3e9`](https://github.com/NixOS/nixpkgs/commit/500bc3e96986c0393405eeb0a088bab748cf1abd) | `` python312Packages.sqlalchemy-mixins: add aiosqlite ``                            |
| [`60263374`](https://github.com/NixOS/nixpkgs/commit/60263374cda31d7b929c36e5c6e0f28d281976fd) | `` csvtk: install shell completions ``                                              |
| [`5d1c122d`](https://github.com/NixOS/nixpkgs/commit/5d1c122dc9d2673ad5cad7849e97717428c9973c) | `` python312Packages.hyppo: 0.5.0 -> 0.5.1 ``                                       |
| [`33926c66`](https://github.com/NixOS/nixpkgs/commit/33926c661bc12750da0d909921ee72d0374cd6b9) | `` python312Packages.neo4j: 5.25.0 -> 5.26.0 ``                                     |
| [`b7324929`](https://github.com/NixOS/nixpkgs/commit/b732492974e0d9b9301c79bcb02cf2550d18a59e) | `` python312Packages.cvss: 3.2 -> 3.3 ``                                            |
| [`59053abd`](https://github.com/NixOS/nixpkgs/commit/59053abdf68730d6a0cd7fed3d8db3602e58e625) | `` python312Packages.manimpango: stop pname misuse ``                               |
| [`74b5aa68`](https://github.com/NixOS/nixpkgs/commit/74b5aa68dc7428d0f82da368343fa69b5cbbe57e) | `` python312Packages.manimpango: add pytest-cov-stub to nativeCheckInputs ``        |
| [`fd1d12a7`](https://github.com/NixOS/nixpkgs/commit/fd1d12a791cdba5e8893f8734acad897ee596c56) | `` python312Packages.manimpango: switch to pypaBuildHook ``                         |
| [`f960d753`](https://github.com/NixOS/nixpkgs/commit/f960d7534c0a92a532fb5a483d49c200c4bb39cd) | `` python312Packages.manimpango: 0.5.0 -> 0.6.0 ``                                  |
| [`78ebb34b`](https://github.com/NixOS/nixpkgs/commit/78ebb34bc8368518f2e1440f8205800d082e6be4) | `` virtualboxKvm: fix for 7.0.22 ``                                                 |
| [`100a0fa0`](https://github.com/NixOS/nixpkgs/commit/100a0fa0af68b1146bda1c94e7ff0c9ef577488b) | `` dbeaver: allow custom java -Xmx value ``                                         |
| [`4552cd2c`](https://github.com/NixOS/nixpkgs/commit/4552cd2cfaf9114ce1bedde44426e852d02f6d68) | `` xlsxgrep: drop ``                                                                |
| [`e70bc936`](https://github.com/NixOS/nixpkgs/commit/e70bc9367ee06c609323e73e7fe537f4e7a5f586) | `` virtualbox: build BIOS from alternate sources ``                                 |
| [`7111740c`](https://github.com/NixOS/nixpkgs/commit/7111740cfa60b34dd7272a877bd3c995842a49ce) | `` Revert "virtualbox: do not use open-watcom-bin" ``                               |
| [`3d9f0777`](https://github.com/NixOS/nixpkgs/commit/3d9f077746109e73cba3ce60f37ba37930697e0e) | `` chrony: switch to apple-sdk_11 ``                                                |
| [`0b0ff2ff`](https://github.com/NixOS/nixpkgs/commit/0b0ff2ffd1cebe152e1842821606c019a8be5e23) | `` python312Packages.hstspreload: 2024.10.1 -> 2024.11.1 ``                         |
| [`586a9433`](https://github.com/NixOS/nixpkgs/commit/586a9433b74ac1ff11c4de044ed10c37cfd3c504) | `` ente-auth: fix icon path ``                                                      |
| [`6a2f29a3`](https://github.com/NixOS/nixpkgs/commit/6a2f29a3829c7f68073618a6d69584101d770b03) | `` python312Packages.gradio: relax aiofiles and markupfiles ``                      |
| [`e4f302de`](https://github.com/NixOS/nixpkgs/commit/e4f302deb8cf324905ba93e650f2f4ef24b33606) | `` zed-editor: 0.159.6 -> 0.159.7 ``                                                |
| [`ccb0d0ef`](https://github.com/NixOS/nixpkgs/commit/ccb0d0efa0f265a92fb18b9236e23d29e19c783b) | `` kanidm: remove trailing slash ``                                                 |
| [`393342ad`](https://github.com/NixOS/nixpkgs/commit/393342adfe7b27b922c35914a92f3a3f95522b77) | `` dependabot-cli: add infinisil as maintainer ``                                   |
| [`3345d7d0`](https://github.com/NixOS/nixpkgs/commit/3345d7d01021af7de84a83f2ba9ff65fdc9cbd18) | `` dependabot-cli: Create dependabot-pinned wrapper with pinned docker images ``    |
| [`43ba6edb`](https://github.com/NixOS/nixpkgs/commit/43ba6edbb793e6c0ed2ed49f589ed02cd5ed0220) | `` terraform-docs: 0.18.0 -> 0.19.0 (#352524) ``                                    |
| [`88cbef5e`](https://github.com/NixOS/nixpkgs/commit/88cbef5e67c45866386da166a5cbdc1ee7e0cb85) | `` vimPlugins.nvim-scissors: init at 2024-10-30 ``                                  |
| [`771d9030`](https://github.com/NixOS/nixpkgs/commit/771d9030faf5f61213b30f04528d46517def345f) | `` pinnwand: 1.5.0 -> 1.6.0 ``                                                      |
| [`e40b101a`](https://github.com/NixOS/nixpkgs/commit/e40b101a239f1b9da92ccaf7c397af62b7be9f21) | `` warp-terminal: 0.2024.10.23.14.49.stable_00 -> 0.2024.10.29.08.02.stable_02 ``   |
| [`35387b65`](https://github.com/NixOS/nixpkgs/commit/35387b655dd8ab3a2dd494835b23ab312d00b43d) | `` csvtk: 0.30.0 -> 0.31.0 ``                                                       |
| [`cab0f213`](https://github.com/NixOS/nixpkgs/commit/cab0f213d682d3ac7c0456056140be9cd06f054b) | `` keycloak: 26.0.4 -> 26.0.5 ``                                                    |
| [`e9378c41`](https://github.com/NixOS/nixpkgs/commit/e9378c411dac7d6384ec22667d12393acbddfbfa) | `` keycloak: 26.0.2 -> 26.0.4 ``                                                    |
| [`d04833bf`](https://github.com/NixOS/nixpkgs/commit/d04833bf5c6e3ed3737134a401df846db3ca0ce3) | `` python312Packages.scikit-misc: 0.4.0 -> 0.5.1 ``                                 |