### PR TITLE
chore(flake/home-manager): `9c1a1c7d` -> `122f7054`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729171802,
-        "narHash": "sha256-Eip3uI+XeyAfBoQXpkm/F7eG3M7AgvzSyhyJdzxVt74=",
+        "lastModified": 1729321331,
+        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9c1a1c7df49a9b28539ccb509b36d0b81e41391c",
+        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`122f7054`](https://github.com/nix-community/home-manager/commit/122f70545b29ccb922e655b08acfe05bfb44ec68) | `` firefox: change container.json version to 5 ``         |
| [`802b3cb2`](https://github.com/nix-community/home-manager/commit/802b3cb2d45ad66619ea8ad19b280baa460556d2) | `` espanso: use `launcher` command on Linux ``            |
| [`09a0c0c0`](https://github.com/nix-community/home-manager/commit/09a0c0c02953318bf94425738c7061ffdc4cba75) | `` cmus: add module ``                                    |
| [`346973b3`](https://github.com/nix-community/home-manager/commit/346973b338365240090eded0de62f7edce4ce3d1) | `` tests/firefox: add shared path test ``                 |
| [`2ffb68e2`](https://github.com/nix-community/home-manager/commit/2ffb68e20981d78bfcc73b2271f2dfa003df182c) | `` thunderbird: conditional search file ``                |
| [`d4a3186d`](https://github.com/nix-community/home-manager/commit/d4a3186de0eeb37d1e43ed65791b0af677e440a1) | `` firefox: conditional search file ``                    |
| [`cb93ab1c`](https://github.com/nix-community/home-manager/commit/cb93ab1c990c5719ec199e8c397e688de06cb46d) | `` direnv: remove nushell hack ``                         |
| [`1834304b`](https://github.com/nix-community/home-manager/commit/1834304bc3849bfec635cab408e6090d536a549f) | `` direnv: simplify, work around nushell/nushell#14112 `` |
| [`e78cbb20`](https://github.com/nix-community/home-manager/commit/e78cbb20276f09c1802e62d2f77fc93ec32da268) | `` zed-editor: add module ``                              |