### PR TITLE
chore(flake/nixvim-flake): `8ed9ca88` -> `8c5cbc58`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1729093974,
-        "narHash": "sha256-gQ0Zb0YN5+wqzq5v8vh0ssWZgyYzoiiT7La6WWOFiXM=",
+        "lastModified": 1729196897,
+        "narHash": "sha256-xftdQl0kxWJZNWCDSl0pU2E7zCmGjhD/N9ZWgPXK0A0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "717e7060fafa2c3822a64e3f5bbfd4895577fdbf",
+        "rev": "3c7b6ae5d1524c691a1b65f7290facd0dc296e40",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1729128722,
-        "narHash": "sha256-Hpg2N3wuh/y8HEAUndihA0NbfG5X3ZXivhv62shLvhg=",
+        "lastModified": 1729215590,
+        "narHash": "sha256-pgRbYPRvqusmPqQpwmwxwFatjJMT+ItmM03zzzQ99N4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8ed9ca88507a73c1fc2a0ae276a8d456e19bd045",
+        "rev": "8c5cbc58c4012cadff3bbec930918ad7ca34462a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`8c5cbc58`](https://github.com/alesauce/nixvim-flake/commit/8c5cbc58c4012cadff3bbec930918ad7ca34462a) | `` chore(flake/nixvim): 717e7060 -> 3c7b6ae5 `` |