### PR TITLE
chore(flake/stylix): `33a2eff1` -> `fb9399b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -751,11 +751,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1728900372,
-        "narHash": "sha256-hmG/u7qZEm7CTh1XPDi+pg4Oi0nNrv7sL8PgZDRe6wg=",
+        "lastModified": 1729380793,
+        "narHash": "sha256-TV6NYBUqTHI9t5fqNu4Qyr4BZUD2yGxAn3E+d5/mqaI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "33a2eff15181e557bb6dd9d2073b90f7d218975d",
+        "rev": "fb9399b7e2c855f42dae76a363bab28d4f24aa8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                               |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`fb9399b7`](https://github.com/danth/stylix/commit/fb9399b7e2c855f42dae76a363bab28d4f24aa8d) | `` wob: init (#594) ``                                |
| [`17f6d6e5`](https://github.com/danth/stylix/commit/17f6d6e5aaf3c9eb393a07aeb34d374d7130081e) | `` nixvim: add stylix.targets.nixvim.plugin option `` |
| [`14df1e64`](https://github.com/danth/stylix/commit/14df1e648889db48b43edba9813abc59587bdd48) | `` neovim: add stylix.targets.neovim.plugin option `` |