### PR TITLE
chore(flake/nix-index-database): `5c54c33a` -> `04f8a11f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728790083,
-        "narHash": "sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y=",
+        "lastModified": 1729394935,
+        "narHash": "sha256-2ntUG+NJKdfhlrh/tF+jOU0fOesO7lm5ZZVSYitsvH8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5c54c33aa04df5dd4b0984b7eb861d1981009b22",
+        "rev": "04f8a11f247ba00263b060fbcdc95484fd046104",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`04f8a11f`](https://github.com/nix-community/nix-index-database/commit/04f8a11f247ba00263b060fbcdc95484fd046104) | `` update generated.nix to release 2024-10-20-031810 `` |
| [`5d35fda9`](https://github.com/nix-community/nix-index-database/commit/5d35fda9b85565a4f0ba3750d6883c60a3a54000) | `` flake.lock: Update ``                                |