### PR TITLE
chore(flake/home-manager): `122f7054` -> `1e27f213`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729321331,
-        "narHash": "sha256-KVyQq+ez/oB30/WbdNgVD8g/bda34z8NiU187QKQb74=",
+        "lastModified": 1729459288,
+        "narHash": "sha256-gBOVJv+q6Mx8jGvwX7cE6J8+sZmi1uxpRVsO7WxvVuQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "122f70545b29ccb922e655b08acfe05bfb44ec68",
+        "rev": "1e27f213d77fc842603628bcf2df6681d7d08f7e",
         "type": "github"
       },
       "original": {

--- a/users/alesauce/dev/amzn.nix
+++ b/users/alesauce/dev/amzn.nix
@@ -5,10 +5,7 @@
 }: {
   home = {
     packages = with pkgs;
-      [
-        unison
-      ]
-      ++ lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
+      lib.filter (lib.meta.availableOn stdenv.hostPlatform) [
         unison-fsmonitor
       ];
     sessionPath = [


### PR DESCRIPTION
| Commit                                                                                                      | Message                                        |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`1e27f213`](https://github.com/nix-community/home-manager/commit/1e27f213d77fc842603628bcf2df6681d7d08f7e) | `` flake.lock: Update ``                       |
| [`fe563023`](https://github.com/nix-community/home-manager/commit/fe56302339bb28e3471632379d733547caec8103) | `` zoxide: fix fzf bash-completion conflict `` |
| [`892a6443`](https://github.com/nix-community/home-manager/commit/892a6443b7676207490c83d181367ba3abcb1f23) | `` nh: add module ``                           |