### PR TITLE
chore(flake/nixvim-flake): `31e64546` -> `ae23699d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1729438888,
-        "narHash": "sha256-TGTDOX2/5OIoSzlcRReVn4BbbfL6Ami/eassiPPGqNA=",
+        "lastModified": 1729532160,
+        "narHash": "sha256-Nxpp4vrnMw9R43iWTfsId8vadk7vQk33duanvIQ3V9w=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "47b563d4e1410bff6a9481b3dd8b01b1e5ed70d2",
+        "rev": "0562e519ec0e69125c5edc917d41bccb54a534fd",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1729474901,
-        "narHash": "sha256-whP9hFkC7hr0UfBy9xB5hZxWEJ459aiSVk9X3e46eOY=",
+        "lastModified": 1729561214,
+        "narHash": "sha256-9tvy8ywrHgdQE5c2fok0ySRYuLWZhCxsfGCTAZgFk2g=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "31e64546abdda617b4a15ce0a2edc62869784bb5",
+        "rev": "ae23699da2e4860489bb95a69880c239cf20b654",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`ae23699d`](https://github.com/alesauce/nixvim-flake/commit/ae23699da2e4860489bb95a69880c239cf20b654) | `` chore(flake/nixvim): 47b563d4 -> 0562e519 `` |