### PR TITLE
chore(flake/darwin): `64d9d1ae` -> `d99f9ae9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729579044,
-        "narHash": "sha256-0kEUVl5s8LHbK4/xEePflsdYVwG+RRFSIofSvITYmIU=",
+        "lastModified": 1729694034,
+        "narHash": "sha256-nGBcMeL6iB20z8Gz/H6roGa/WRmKAmipY0/iXCq4DCo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "64d9d1ae25215c274c37e3e4016977a6779cf0d3",
+        "rev": "d99f9ae9fdfbcc36b81d264678bf58004464892e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`8c02940d`](https://github.com/LnL7/nix-darwin/commit/8c02940d702170feea7947f768aa807c11b65a41) | `` users: ensure Full Disk Access is granted before trying to delete users `` |
| [`9ee30f25`](https://github.com/LnL7/nix-darwin/commit/9ee30f253432d3a059411d28aa05638a92ea8c71) | `` darwin-rebuild: add comments explaining the custom `sudo` logic ``         |
| [`0a686597`](https://github.com/LnL7/nix-darwin/commit/0a686597faa81831e027505b149dd77b2524ab18) | `` users: don't allow `name` to be empty ``                                   |
| [`11c777c7`](https://github.com/LnL7/nix-darwin/commit/11c777c7198f4cfcd55fe81646e503c58ceb9f4a) | `` users: change default `description` to `null` ``                           |
| [`ac7932f9`](https://github.com/LnL7/nix-darwin/commit/ac7932f9de36b8126abcb9d4966d5d95fcadd807) | `` users: use `lib.escapeShellArg` for group description ``                   |
| [`ea7e178a`](https://github.com/LnL7/nix-darwin/commit/ea7e178ad4113c2134c5b734e3198ebbc591af0b) | `` users: use `lib.escapeShellArg` for `createhomedir` ``                     |
| [`8451125c`](https://github.com/LnL7/nix-darwin/commit/8451125cf8eab07056da090a4616ce46a1952ff9) | `` users: use `lib.escapeShellArg` for `dscl` paths ``                        |
| [`7a3ec645`](https://github.com/LnL7/nix-darwin/commit/7a3ec6459c4394767ebcc136c0da0bb0c73d76ed) | `` networking: use `lib.escapeShellArgs` instead of custom version ``         |
| [`7bb6366f`](https://github.com/LnL7/nix-darwin/commit/7bb6366f40dd4ef6efe3223e6dffb3dd7f8dea66) | `` users: use `lib.escapeShellArgs` instead of custom version ``              |
| [`26f7e45f`](https://github.com/LnL7/nix-darwin/commit/26f7e45fb117171c9e8b27a34cfccb91ef50f068) | `` users: use `lib.escapeShellArgs` for `sysadminctl -addUser` ``             |
| [`cb2e5fa6`](https://github.com/LnL7/nix-darwin/commit/cb2e5fa6c5d99c581f9669e66e61ac1585ab56ad) | `` users: use `lib.escapeShellArg` for `sysadminctl -deleteUser` ``           |
| [`9a6b12b9`](https://github.com/LnL7/nix-darwin/commit/9a6b12b9ef35cf4ac4970f94791b3dd734c0da96) | `` users: use `lib.escapeShellArg` for `id -u` ``                             |
| [`5b873c48`](https://github.com/LnL7/nix-darwin/commit/5b873c48ace1ee08186d88288cf4f565202c0f28) | `` users: set `default` for `users.users.<user>.name` ``                      |
| [`2788e4fa`](https://github.com/LnL7/nix-darwin/commit/2788e4fa981566e34fa40938705cd7f595f05e74) | `` Use `sysadminctl` instead of `dscl` ``                                     |