### PR TITLE
chore(flake/nixvim-flake): `d7c9638b` -> `8b5b2355`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1729602958,
-        "narHash": "sha256-eKGQKlj1oShfR6uqE1RjB4CgQ3DBrMS4VPrGPDKq1J4=",
+        "lastModified": 1729699620,
+        "narHash": "sha256-f6S8JX5w9bPLMbaqR5dM5koybZntdSFfKyfq/LQU7rs=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b076f006c6b0cc6644a651bd21d4449cc3e7e56d",
+        "rev": "029eafd70d6e28919a9ec01a94a46b51c4ccff40",
         "type": "github"
       },
       "original": {
@@ -656,11 +656,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1729629226,
-        "narHash": "sha256-TLozqZQaMDragLA8PDs3OLFv4gljwKG36wt/LWHCIXA=",
+        "lastModified": 1729701010,
+        "narHash": "sha256-VApv2XzzwPh2hKk1dMsm2bBQ0EhfcGVUbPPtIMwWET0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "d7c9638b5ef9903ca13c81b4a54dbe720956c9f8",
+        "rev": "8b5b2355ee93c0321f859039ca44ed9a33a2ea90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`8b5b2355`](https://github.com/alesauce/nixvim-flake/commit/8b5b2355ee93c0321f859039ca44ed9a33a2ea90) | `` chore(flake/nixvim): b076f006 -> 029eafd7 `` |