### PR TITLE
chore(flake/stylix): `fb9399b7` -> `04afcfc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1729380793,
-        "narHash": "sha256-TV6NYBUqTHI9t5fqNu4Qyr4BZUD2yGxAn3E+d5/mqaI=",
+        "lastModified": 1729963473,
+        "narHash": "sha256-uGjTjvvlGQfQ0yypVP+at0NizI2nrb6kz4wGAqzRGbY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "fb9399b7e2c855f42dae76a363bab28d4f24aa8d",
+        "rev": "04afcfc0684d9bbb24bb1dc77afda7c1843ec93b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                               |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`04afcfc0`](https://github.com/danth/stylix/commit/04afcfc0684d9bbb24bb1dc77afda7c1843ec93b) | `` gnome: fix GDM theme not applying when Gnome is disabled (#598) `` |