### PR TITLE
chore(flake/darwin): `7840909b` -> `2eb47223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729826725,
-        "narHash": "sha256-w3WNlYxqWYsuzm/jgFPyhncduoDNjot28aC8j39TW0U=",
+        "lastModified": 1729982130,
+        "narHash": "sha256-HmLLQbX07rYD0RXPxbf3kJtUo66XvEIX9Y+N5QHQ9aY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "7840909b00fbd5a183008a6eb251ea307fe4a76e",
+        "rev": "2eb472230a5400c81d9008014888b4bff23bcf44",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                    |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`445c6bfc`](https://github.com/LnL7/nix-darwin/commit/445c6bfc65b4f9df882d6bb089d46014204f8523) | `` Add keepalive flag for emacs service `` |