### PR TITLE
chore(flake/home-manager): `93435d27` -> `e8341405`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729894599,
-        "narHash": "sha256-nL9nzNE5/re/P+zOv7NX6bRm5e+DeS1HIufQUJ01w20=",
+        "lastModified": 1730016908,
+        "narHash": "sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93435d27d250fa986bfec6b2ff263161ff8288cb",
+        "rev": "e83414058edd339148dc142a8437edb9450574c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e8341405`](https://github.com/nix-community/home-manager/commit/e83414058edd339148dc142a8437edb9450574c8) | `` flake.lock: Update ``                                  |
| [`05d9bee4`](https://github.com/nix-community/home-manager/commit/05d9bee4a5155758aec3c3807c0e342b9f253522) | `` git-credential-oauth: fix use of mkIf and add tests `` |