### PR TITLE
chore(flake/nix-fast-build): `1775c732` -> `8e7c9d76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1728306776,
-        "narHash": "sha256-57QXMMEELaEbE+ZVg0ngSC7UGZoyYP2QmDGcQSJ8BnE=",
+        "lastModified": 1730278911,
+        "narHash": "sha256-CrbqsC+lEA3w6gLfpqfDMDEKoEta2sl4sbQK6Z/gXak=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "1775c732071d0ee37c1950ce4ecbf2729487ee71",
+        "rev": "8e7c9d76979381441facb8888f21408312cf177a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`f41bcd68`](https://github.com/Mic92/nix-fast-build/commit/f41bcd6843e09934d67146c8749913f52f1cd3f7) | `` add docs ``                  |
| [`6b119b82`](https://github.com/Mic92/nix-fast-build/commit/6b119b82d967b41ea3deb8a99ba4a99080d6a425) | `` only push 'out' ``           |
| [`6101c80e`](https://github.com/Mic92/nix-fast-build/commit/6101c80e4d2b6ffe672aa486f541a81c27111163) | `` add upload to attic cache `` |