### PR TITLE
chore(flake/darwin): `e56d80b2` -> `146629a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730560543,
-        "narHash": "sha256-Ny8bMwoQH2JmLr2/+Zqer1Aizk5nCIXLPGUL1YyFS3I=",
+        "lastModified": 1730589595,
+        "narHash": "sha256-QI//TRTTmkUM0bz+KhdanRcwzlYib6PjMTvhC3dwUWA=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "e56d80b28314643da5a0a27c6371c0682ab8389f",
+        "rev": "146629a54364f6b54e7f3d15c44fea69ed0bf476",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`21809c42`](https://github.com/LnL7/nix-darwin/commit/21809c4261a421eb06b2d7b3ccd18ebadd921f96) | `` Allow configuring the fn key action ``                            |
| [`0dacfdea`](https://github.com/LnL7/nix-darwin/commit/0dacfdea635b664812b8065e6b5449c43bf1a586) | `` Configure the folder that new Finder windows open ``              |
| [`63f4d40e`](https://github.com/LnL7/nix-darwin/commit/63f4d40e551e7b29fbe586967c03eea1e6a70ce4) | `` tmux: remove `programs.tmux.defaultCommand` ``                    |
| [`1588cb2e`](https://github.com/LnL7/nix-darwin/commit/1588cb2e997fb37a4eab78da13808faf49df903f) | `` environment: remove misleading `environment.loginShell` option `` |