### PR TITLE
chore(flake/darwin): `146629a5` -> `4652874d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730589595,
-        "narHash": "sha256-QI//TRTTmkUM0bz+KhdanRcwzlYib6PjMTvhC3dwUWA=",
+        "lastModified": 1730600078,
+        "narHash": "sha256-BoyFmE59HDF3uybBySsWVoyjNuHvz3Wv8row/mSb958=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "146629a54364f6b54e7f3d15c44fea69ed0bf476",
+        "rev": "4652874d014b82cb746173ffc64f6a70044daa7e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                               |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`53b9de4d`](https://github.com/LnL7/nix-darwin/commit/53b9de4d6ca51c38299f265630b811fed6d4fd05) | `` ci: remove tests to ensure submodules work ``      |
| [`1d8c91b4`](https://github.com/LnL7/nix-darwin/commit/1d8c91b40e82853e76a0a308cfc5ddc5a72667d3) | `` darwin-rebuild: do not resolve flake path ``       |
| [`406cb56d`](https://github.com/LnL7/nix-darwin/commit/406cb56d06247487386667162131703f7d6cc68f) | `` Back out "Add support for submodules in flakes" `` |