### PR TITLE
chore(flake/home-manager): `1743615b` -> `8f6ca785`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730490306,
-        "narHash": "sha256-AvCVDswOUM9D368HxYD25RsSKp+5o0L0/JHADjLoD38=",
+        "lastModified": 1730633670,
+        "narHash": "sha256-ZFJqIXpvVKvzOVFKWNRDyIyAo+GYdmEPaYi1bZB6uf0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1743615b61c7285976f85b303a36cdf88a556503",
+        "rev": "8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`8f6ca785`](https://github.com/nix-community/home-manager/commit/8f6ca7855d409aeebe2a582c6fd6b6a8d0bf5661) | `` flake.lock: Update ``           |
| [`2c6a9b3c`](https://github.com/nix-community/home-manager/commit/2c6a9b3ccf1bb0930befadfed13195c2168d1287) | `` git: fix maintenance service `` |