### PR TITLE
chore(flake/darwin): `4652874d` -> `189d2d42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730600078,
-        "narHash": "sha256-BoyFmE59HDF3uybBySsWVoyjNuHvz3Wv8row/mSb958=",
+        "lastModified": 1730698801,
+        "narHash": "sha256-sq68bCmk4tCXSt5CoRNimfigIZSLJSpNi/gjFtNLjRE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "4652874d014b82cb746173ffc64f6a70044daa7e",
+        "rev": "189d2d422c773fa065cc9c72e6806f007ebb9be0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`6c8d45fb`](https://github.com/LnL7/nix-darwin/commit/6c8d45fb20c40a8ccc73130d026d487b887a3de4) | `` module: add prometheus-node-exporter service `` |