### PR TITLE
chore(flake/darwin): `5d891207` -> `0e3f3f01`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730765507,
-        "narHash": "sha256-u2KaQonCkHQbQvYrfZz7OJuyOrFelbfh5gS9L43c1WY=",
+        "lastModified": 1730779758,
+        "narHash": "sha256-5WI9AnsBwhLzVRnQm3Qn9oAbROnuLDQTpaXeyZCK8qw=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5d891207854e792a33b5984e9bee56c8b57ef010",
+        "rev": "0e3f3f017c14467085f15d42343a3aaaacd89bcb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                             |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`84d14d40`](https://github.com/LnL7/nix-darwin/commit/84d14d404325380ec180f580332e8e85df232d06) | `` prometheus-node-exporter: fix log permissions `` |
| [`6ff3a49c`](https://github.com/LnL7/nix-darwin/commit/6ff3a49ceb1c98e96452542a6feadacc477eedff) | `` time: shellcheck fix ``                          |