### PR TITLE
chore(flake/git-hooks): `af8a16fe` -> `d70155fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {
@@ -614,11 +614,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                  |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`26f0d52b`](https://github.com/cachix/git-hooks.nix/commit/26f0d52b005bce294591c120585d6993c62cb8cb) | `` chore(deps): lock file maintenance `` |
| [`04db8c18`](https://github.com/cachix/git-hooks.nix/commit/04db8c18ca4667986514ef81dc93d88998e9438d) | `` fix: poetry option is not defined ``  |
| [`92495abe`](https://github.com/cachix/git-hooks.nix/commit/92495abe55afe79f1f7b23a0b304d8dc3fa29740) | `` fix: poetry option is not defined ``  |