### PR TITLE
chore(flake/nixvim-flake): `79b275cc` -> `60f7ce96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1720386169,
-        "narHash": "sha256-NGKVY4PjzwAa4upkGtAMz1npHGoRzWotlSnVlqI40mo=",
+        "lastModified": 1730741070,
+        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "194846768975b7ad2c4988bdb82572c00222c0d7",
+        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1730795322,
-        "narHash": "sha256-ORYBVlZLsyu0KS3zKIbm1RG4b5kNVoM9HKVX/Na943I=",
+        "lastModified": 1730824162,
+        "narHash": "sha256-Q71XAj6wi7+eh83j6VTLZJPfCYyqorBIIox+EK61wLA=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "79b275ccde9c75af7cb79b42f3948bb47656412a",
+        "rev": "60f7ce96d949d89cacda2b2e01a2c17c544250a2",
         "type": "github"
       },
       "original": {
@@ -734,11 +734,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730302582,
-        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
+        "lastModified": 1730814269,
+        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
+        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`60f7ce96`](https://github.com/alesauce/nixvim-flake/commit/60f7ce96d949d89cacda2b2e01a2c17c544250a2) | `` chore(flake/pre-commit-hooks): af8a16fe -> d70155fd `` |