### PR TITLE
chore(flake/darwin): `0e3f3f01` -> `98e7dba8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730779758,
-        "narHash": "sha256-5WI9AnsBwhLzVRnQm3Qn9oAbROnuLDQTpaXeyZCK8qw=",
+        "lastModified": 1730878299,
+        "narHash": "sha256-0VIz/3PKaylSIoRdOE07kkT1tMXgqaybXrfIS2Xz+so=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0e3f3f017c14467085f15d42343a3aaaacd89bcb",
+        "rev": "98e7dba87238e4fa4eac609dc44f07dab40661c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                         |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| [`48e5c8de`](https://github.com/LnL7/nix-darwin/commit/48e5c8de1a4575441b46cb174afebfa02732c0ff) | `` Update modules/programs/zsh/default.nix ``                                  |
| [`897fc37c`](https://github.com/LnL7/nix-darwin/commit/897fc37c47d2592c475f8732f3f1a4fbc9f18f9e) | `` Update default.nix ``                                                        |
| [`44c88484`](https://github.com/LnL7/nix-darwin/commit/44c88484c4c386f3eae8a5398e9b22a78d606e43) | `` add warning for enabling syntax highlighting and fast syntax highlighting `` |
| [`2839ef54`](https://github.com/LnL7/nix-darwin/commit/2839ef54aaaa0ca797659a1db45876260b93b1eb) | `` Add support for zsh-fast-syntax-highlighting ``                              |