### PR TITLE
chore(flake/stylix): `04afcfc0` -> `762c07ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -782,11 +782,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1729963473,
-        "narHash": "sha256-uGjTjvvlGQfQ0yypVP+at0NizI2nrb6kz4wGAqzRGbY=",
+        "lastModified": 1730924223,
+        "narHash": "sha256-tGvmW0qih+dCAH9L4BEMYMiHcBoJVZtESbC9WH0EEuw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "04afcfc0684d9bbb24bb1dc77afda7c1843ec93b",
+        "rev": "762c07ee10b381bc8e085be5b6c2ec43139f13b0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`762c07ee`](https://github.com/danth/stylix/commit/762c07ee10b381bc8e085be5b6c2ec43139f13b0) | `` hyprland: adapt breaking changes (#605) `` |