### PR TITLE
chore(flake/darwin): `98e7dba8` -> `158198a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730878299,
-        "narHash": "sha256-0VIz/3PKaylSIoRdOE07kkT1tMXgqaybXrfIS2Xz+so=",
+        "lastModified": 1730963783,
+        "narHash": "sha256-I5l9aMkCQi0CHCrE4tol+31z74ZfnYDaeGoK1Bi9Qrk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "98e7dba87238e4fa4eac609dc44f07dab40661c4",
+        "rev": "158198a6e3690facf15718b24571789c0756d43a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`79608947`](https://github.com/LnL7/nix-darwin/commit/79608947e27163a2e74b1bec0812ce7a942cbdb8) | `` buildkit-agents: don't use `mkdir -p -m` ``                               |
| [`3b738c76`](https://github.com/LnL7/nix-darwin/commit/3b738c765de1bb4ecc4993fa092b27dd46d495ed) | `` github-runner: replace `mkdir -p -m` with `umask` ``                      |
| [`cf130aa9`](https://github.com/LnL7/nix-darwin/commit/cf130aa9579fc1708ff4a265d2108eefa535e9b2) | `` users: don't generate `ensurePerms` when no users to manage ``            |
| [`32814a6e`](https://github.com/LnL7/nix-darwin/commit/32814a6eb1de3b564ff43e5b6453637b1eb25721) | `` users: replace runtime check to prevent deleting `root` with assertion `` |
| [`fd510a71`](https://github.com/LnL7/nix-darwin/commit/fd510a7122d49cc1cbd72b9e70b1ae6b3c76c990) | `` system: replace `for f in $(ls ...)` with `for f in .../*` ``             |
| [`04199680`](https://github.com/LnL7/nix-darwin/commit/041996803af5497fb000e3f79621fa5bb6995057) | `` treewide: fix shellcheck warnings and errors ``                           |
| [`9afef995`](https://github.com/LnL7/nix-darwin/commit/9afef9950f28780ff24908496c36f27826a601cf) | `` checks: move manual `/run` instructions to activation ``                  |
| [`3ea11449`](https://github.com/LnL7/nix-darwin/commit/3ea11449387edeac72fbd7791d106af7553be6e2) | `` system: run `shellcheck` on `activate` and `activate-user` scripts ``     |
| [`2af06b08`](https://github.com/LnL7/nix-darwin/commit/2af06b086283be3ab3824a86f35f6301c95b372b) | `` examples: clean up ``                                                     |
| [`223a920a`](https://github.com/LnL7/nix-darwin/commit/223a920ab457160a245a588f4191f2b6782b3957) | `` ci: upgrade `actions/checkout` ``                                         |
| [`37b591bd`](https://github.com/LnL7/nix-darwin/commit/37b591bd8b3ca9641a8aff165f30927755b5dc20) | `` ci: remove unused workflows ``                                            |
| [`e0f243d1`](https://github.com/LnL7/nix-darwin/commit/e0f243d17e5c6281b2541c79b52be0270be9a360) | `` ci: run nix flake check ``                                                |
| [`68637ee7`](https://github.com/LnL7/nix-darwin/commit/68637ee7dbdb194755697930c36272ad115af4a6) | `` flake: expose `jobs` from `release.nix` as a flattened attrset ``         |
| [`c13549d7`](https://github.com/LnL7/nix-darwin/commit/c13549d7a632fc107bc8802463806fc2002c9c54) | `` examples: drop `ofborg` example ``                                        |
| [`56915346`](https://github.com/LnL7/nix-darwin/commit/569153467be5f438e4f932a09bfba79adcecf856) | `` ofborg: automatically add `ofborg` to `known{Users,Groups}` ``            |
| [`dd48cbd7`](https://github.com/LnL7/nix-darwin/commit/dd48cbd7766baba246f0b2e2bd42baf67e0005d6) | `` examples: fix evaluation ``                                               |
| [`56ac6182`](https://github.com/LnL7/nix-darwin/commit/56ac6182d3fcb449db620fac0658eedd56aa1597) | `` release: remove unnecessary use of `release-lib` ``                       |
| [`c904f6cd`](https://github.com/LnL7/nix-darwin/commit/c904f6cdcb02c85181cf478496b0b9a78308133a) | `` release: rename `release` to `release-lib` to match NixOS ``              |
| [`8a03b185`](https://github.com/LnL7/nix-darwin/commit/8a03b1850b3adf005da3f35e696e801d700740ec) | `` release: remove package jobs ``                                           |
| [`e11dd028`](https://github.com/LnL7/nix-darwin/commit/e11dd028d38bd09ec4a1119742d735512775c8a6) | `` release: remove `unstable` job ``                                         |
| [`1a8c6cac`](https://github.com/LnL7/nix-darwin/commit/1a8c6cac8c7a9537fcf928714ca3778f4c59c2fd) | `` release: fix tests not running on `aarch64-darwin` ``                     |