### PR TITLE
chore(flake/darwin): `3224bb2f` -> `5c74ab86`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731140526,
-        "narHash": "sha256-lPCTS5Jvypptq//q86G1BoggCXSWEMwDw1C1ky8P2vs=",
+        "lastModified": 1731153869,
+        "narHash": "sha256-3Ftf9oqOypcEyyrWJ0baVkRpvQqroK/SVBFLvU3nPuc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "3224bb2f7c998448e4eb9b5df93195af2e268a30",
+        "rev": "5c74ab862c8070cbf6400128a1b56abb213656da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`5a1ae6a6`](https://github.com/LnL7/nix-darwin/commit/5a1ae6a6e41362fb52a682fd3d5f19585131d5de) | `` readme: add prerequisites section ``                                        |
| [`050b7db4`](https://github.com/LnL7/nix-darwin/commit/050b7db4451bbca9798d09661f098cb0033779b5) | `` installer: don't tell users to source bashrc ``                             |
| [`2fe3de58`](https://github.com/LnL7/nix-darwin/commit/2fe3de580e02a3d867134d6632525cf93ffaf0cb) | `` readme: fix badge ``                                                        |
| [`ae09d7ba`](https://github.com/LnL7/nix-darwin/commit/ae09d7ba528760f9c9b4f92d905d35c46d50ddca) | `` readme: remove outdated instructions for manually managing `/etc/bashrc` `` |
| [`534ca069`](https://github.com/LnL7/nix-darwin/commit/534ca06930039a616934b6d9dd8316e8df799622) | `` docs: use `nix-darwin` instead of `Darwin` ``                               |
| [`29358906`](https://github.com/LnL7/nix-darwin/commit/293589065dd0f6bbfd6f83fcdc4f2d74543337c9) | `` ci: fix manual not being regenerated when non-Nix files are updated ``      |
| [`a89c8519`](https://github.com/LnL7/nix-darwin/commit/a89c85192354229d9fc0adfe11f3f89620eb9487) | `` ci: don't override nixpkgs when building the manual ``                      |
| [`2ff55ab1`](https://github.com/LnL7/nix-darwin/commit/2ff55ab1c5c238181c3b6f1bd78156e7d77812bb) | `` manual: get revision information when called from flake ``                  |
| [`a82d72d2`](https://github.com/LnL7/nix-darwin/commit/a82d72d25f67dff02afbd6fb72cd16e2ec040a68) | `` flake: expose docs on Linux as well ``                                      |