### PR TITLE
chore(flake/nix-index-database): `cc2ddbf2` -> `896019f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730604744,
-        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
+        "lastModified": 1731209121,
+        "narHash": "sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
+        "rev": "896019f04b22ce5db4c0ee4f89978694f44345c3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`896019f0`](https://github.com/nix-community/nix-index-database/commit/896019f04b22ce5db4c0ee4f89978694f44345c3) | `` update generated.nix to release 2024-11-10-031357 `` |
| [`ddbdec98`](https://github.com/nix-community/nix-index-database/commit/ddbdec986ea89b1febebce875ff6660d38cf82da) | `` flake.lock: Update ``                                |