### PR TITLE
chore(flake/home-manager): `2f607e07` -> `60bb1109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730837930,
-        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
+        "lastModified": 1731235328,
+        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
+        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`60bb1109`](https://github.com/nix-community/home-manager/commit/60bb110917844d354f3c18e05450606a435d2d10) | `` helix: fix wrapping of extraPackages `` |
| [`73090072`](https://github.com/nix-community/home-manager/commit/73090072715c823dd19478a58ba4f241d27a577f) | `` news: fix typo ``                       |