### PR TITLE
chore(flake/nixvim-flake): `076f1bea` -> `2c0a1059`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730837930,
-        "narHash": "sha256-0kZL4m+bKBJUBQse0HanewWO0g8hDdCvBhudzxgehqc=",
+        "lastModified": 1731235328,
+        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f607e07f3ac7e53541120536708e824acccfaa8",
+        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1731155487,
-        "narHash": "sha256-+D57j7BcV5O3XH9za3c3XXVLHr+F+enThAN2EeF6H/M=",
+        "lastModified": 1731281996,
+        "narHash": "sha256-xdNFY/wcs8i9qluVbTAVh5JLlhI/r4JJfXb0yfEj1Ks=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "31364af1990067d5529846a2ebf17a42c5ab22ff",
+        "rev": "57068f532d5d42601fd74e2b531204fe1cd3a8f2",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1731169542,
-        "narHash": "sha256-EJ9ATq4znaUZl8DILbeAEE27r32AW56S1Rfainzut8U=",
+        "lastModified": 1731288718,
+        "narHash": "sha256-+HaFAx0cKuqc7D/BIr0c+u0LQOOtUuC7jgSUbGN3YS4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "076f1bea5b025af476194eecf4f3622bb5d115b2",
+        "rev": "2c0a1059947b4f2b585477d626fc97925a89fa2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                       |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`2c0a1059`](https://github.com/alesauce/nixvim-flake/commit/2c0a1059947b4f2b585477d626fc97925a89fa2a) | `` chore(flake/nixvim): 31364af1 -> 57068f53 ``                               |
| [`83edfcc1`](https://github.com/alesauce/nixvim-flake/commit/83edfcc10886b09c04c54d02cb65276d3eadf674) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 14 to 15 `` |