### PR TITLE
chore(flake/darwin): `5c74ab86` -> `e30d226a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731153869,
-        "narHash": "sha256-3Ftf9oqOypcEyyrWJ0baVkRpvQqroK/SVBFLvU3nPuc=",
+        "lastModified": 1731424394,
+        "narHash": "sha256-J+POQgWQdjhuF1pEnkVKWPJ+dM62FTepk6TmJdj3O5U=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5c74ab862c8070cbf6400128a1b56abb213656da",
+        "rev": "e30d226a24e4079d068321f935dbf30626f08dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------ |
| [`32df51bf`](https://github.com/LnL7/nix-darwin/commit/32df51bf2b82dab724b845f4ad2d45bc1a0d0b9e) | `` fix(defaults): fixing #1107 ``                      |
| [`d71aa30b`](https://github.com/LnL7/nix-darwin/commit/d71aa30b41bac3b2e38bd4b8f49e12811cd27ec1) | `` feat(defaults): adding support to control center `` |