### PR TITLE
chore(flake/nixvim-flake): `ea138947` -> `b256d5ce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1731356813,
-        "narHash": "sha256-w0TJwJwZd9so/chWYFFEtOQdnXTCvmNXIHs1FWJDlMM=",
+        "lastModified": 1731452383,
+        "narHash": "sha256-Qht3yghgs5rVaYwGtv3i77b8ILlZPPQEZoi6pU8T1TE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "c892aa20732f982d4cc2b3ef2e2276a2a9a4d45b",
+        "rev": "7dc65b2d9873b6bbb6ef90234b3db6546e4ed9af",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1731400235,
-        "narHash": "sha256-BhTc5O1ezQ7QoH+jP+uAlQ/rPtULauwE4/Lq2xoPtLQ=",
+        "lastModified": 1731461584,
+        "narHash": "sha256-1fdq6yfysHA9vI8rtH+162VkF+WR4NiKVZwsfkPqhvk=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "ea138947018ff48cc91bfb8f220d0ea73c7efbb6",
+        "rev": "b256d5ce72750ef5ec5d2d3ada2bd150f5e9eb97",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`b256d5ce`](https://github.com/alesauce/nixvim-flake/commit/b256d5ce72750ef5ec5d2d3ada2bd150f5e9eb97) | `` chore(flake/nixvim): c892aa20 -> 7dc65b2d `` |