### PR TITLE
chore(flake/nixvim-flake): `481d4144` -> `b592ddc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1731547981,
-        "narHash": "sha256-OsirA3w8Sv5i0LP6z52KnWCDYdPwyAIdP8GEfENXv24=",
+        "lastModified": 1731570175,
+        "narHash": "sha256-kzW8TYIIp1llIyGDLGvKIROblqkxs2WwqfwA0ySMnNw=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "481d4144c019efc9361528d3dbeb25aef3aca4a9",
+        "rev": "b592ddc41524f85a11cf33d6f2b768a8601ae90b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                   |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| [`b592ddc4`](https://github.com/alesauce/nixvim-flake/commit/b592ddc41524f85a11cf33d6f2b768a8601ae90b) | `` fix(config/lang/java): Remove on_attach string from config (#359) ``                   |
| [`48725064`](https://github.com/alesauce/nixvim-flake/commit/48725064d48645b2fdf86258bae65008dd9597b7) | `` fix(config/lang/typescript): Fixing renaming warnings in typescript tools and noice `` |
| [`7c66efe7`](https://github.com/alesauce/nixvim-flake/commit/7c66efe79ec0963de9499b0a18f7fbed918d6531) | `` fix(config/lsp/rust-tools): Removing rust-tools from nix config ``                     |