### PR TITLE
chore(flake/home-manager): `1d0862ee` -> `1bd5616e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1731786860,
+        "narHash": "sha256-130gQ5k8kZlxjBEeLpE+SvWFgSOFgQFeZlqIik7KgtQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "1bd5616e33c0c54d7a5b37db94160635a9b27aeb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`1bd5616e`](https://github.com/nix-community/home-manager/commit/1bd5616e33c0c54d7a5b37db94160635a9b27aeb) | `` lib/file-type: Make `force` option visible (#6003) ``                                                           |
| [`c7c25176`](https://github.com/nix-community/home-manager/commit/c7c251761235282acfc681accf8d3deea6681cc0) | `` {gtk, dunst}: replace `pkgs.gnome.adwaita-icon-theme` with `pkgs.adwaita-icon-theme` in the examples (#5712) `` |
| [`d154a557`](https://github.com/nix-community/home-manager/commit/d154a557da07645aaea3b3375317c234cf2eed82) | `` aerc: add support of account gpg config (#5298) ``                                                              |
| [`192f123e`](https://github.com/nix-community/home-manager/commit/192f123e4b5a4605c30566409ccacffc416e45c4) | `` nixos: add `key` to shared module to allow disabling it (#6017) ``                                              |
| [`400e3c01`](https://github.com/nix-community/home-manager/commit/400e3c0152793ece616081870f979a2081a04f63) | `` nixos: always run home-manager on NixOS activation (#5780) ``                                                   |