### PR TITLE
chore(flake/nixvim-flake): `b1b2e6dc` -> `b9753b11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -231,11 +231,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731535640,
-        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {
@@ -501,11 +501,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731454423,
-        "narHash": "sha256-TtwvgFxUa0wyptLhQbKaixgNW1UXf3+TDqfX3Kp63oM=",
+        "lastModified": 1731642829,
+        "narHash": "sha256-vG+O2RZRzYZ8BUMNNJ+BLSj6PUoGW7taDQbp6QNJ3Xo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6c71c49e2448e51ad830ed211024e6d0edc50116",
+        "rev": "f86f158efd4bab8dce3e207e4621f1df3a760b7a",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1731707185,
-        "narHash": "sha256-IfA3x0eL4Be/7hvdvGSnT8fgiXz7GL3PtjGw3BH68gM=",
+        "lastModified": 1731760432,
+        "narHash": "sha256-tLOq1smR8yJ7Td4vKKEL251fp94XAibFmqRt3yWJxdI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "be455f7f2714ce3479ae5bb662a03bd450f45793",
+        "rev": "5c6dd20aeb7fa868836cfb20ac2ec546cc3c977a",
         "type": "github"
       },
       "original": {
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1731721422,
-        "narHash": "sha256-b//a7C8wL5iG+Q5BxLfEn5UB3e3Lksw+8sP1lg9BHDU=",
+        "lastModified": 1731790833,
+        "narHash": "sha256-8zWUrxL7qO4IbriW/CJJb4EtbbqYzqJliCItCs8yE18=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "b1b2e6dc37c877c700324790ec1c0539cf1a8fed",
+        "rev": "b9753b11cf2526d4df82d2ed93b8c7096fb87dba",
         "type": "github"
       },
       "original": {
@@ -710,11 +710,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731347683,
-        "narHash": "sha256-BcSWCEUBShuB32LPif+EG0XGXyUi2jyjCSpGE1rbOws=",
+        "lastModified": 1731582522,
+        "narHash": "sha256-1w6aM4bG5cl2E4jHLPnMKkrUO4tY1jUX1NI6/RwJN7Y=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "135d202e032be70c93b6d7d53592ef4799d6efde",
+        "rev": "13300b2297c51368e0892c3ebe220f688014fe15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`b9753b11`](https://github.com/alesauce/nixvim-flake/commit/b9753b11cf2526d4df82d2ed93b8c7096fb87dba) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 15 to 16 (#363) `` |
| [`bf2bb06d`](https://github.com/alesauce/nixvim-flake/commit/bf2bb06dd137ba5cdcdfd7b1e8ce8e676ac9190c) | `` fix(config/lang/java): Fix root dir concatenation (#369) ``                       |
| [`e4356675`](https://github.com/alesauce/nixvim-flake/commit/e43566758851d531361f054828a5c6d79738b777) | `` feat(config/core): Enabling byte compiling for lua plugins ``                     |
| [`eca9f6af`](https://github.com/alesauce/nixvim-flake/commit/eca9f6afe195ee648652e11a996b9ddc63d8a573) | `` feat(config/lang/java): Adding completion capabilities to jdtls setup ``          |
| [`931027f0`](https://github.com/alesauce/nixvim-flake/commit/931027f0912072e1db52ed3c7a5b39e79caf1776) | `` feat(config/lsp/cmp): Adding git and tmux cmp sources ``                          |
| [`ab49f2ca`](https://github.com/alesauce/nixvim-flake/commit/ab49f2ca180dc5dc0d58cb3d9980a963e86933a4) | `` chore(flake/nixvim): be455f7f -> 5c6dd20a ``                                      |