### PR TITLE
chore(flake/nixvim-flake): `25c01449` -> `dc1702a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1731811895,
-        "narHash": "sha256-cLlNAhfZCqcLSeyGG4f4xvH6VDDDKmqMJN0Do7SD6gk=",
+        "lastModified": 1731832637,
+        "narHash": "sha256-VxbgOL5VWU21iJbiO+K8nDZ9HKvXE6rq6/RRvgmqO3o=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "25c01449eade4e56f74a0073ba53605e3a938d22",
+        "rev": "dc1702a2f58e57679477a062ecd25990f098805c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                         |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`dc1702a2`](https://github.com/alesauce/nixvim-flake/commit/dc1702a2f58e57679477a062ecd25990f098805c) | `` feat(config/lang/java): Add debug and test bundles (#372) `` |