### PR TITLE
chore(flake/nix-index-database): `bdba2469` -> `f4a5ca57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731814505,
-        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
+        "lastModified": 1732519917,
+        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
+        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                       |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`fdc58afc`](https://github.com/nix-community/nix-index-database/commit/fdc58afcc31a59b679b676071b94442b3f83bbec) | `` darwin-module: stop setting unused comma.package option `` |
| [`bedc30c6`](https://github.com/nix-community/nix-index-database/commit/bedc30c64442579943c1c6e7579db263d810884f) | `` add missing include for home-manager ``                    |
| [`0ef970b7`](https://github.com/nix-community/nix-index-database/commit/0ef970b7021e0ee9ab93437d0e28296e86669b03) | `` update generated.nix to release 2024-11-24-032503 ``       |
| [`6a79fb11`](https://github.com/nix-community/nix-index-database/commit/6a79fb11d1dda460b5e869ed44eb388e41042112) | `` flake.lock: Update ``                                      |
| [`af404206`](https://github.com/nix-community/nix-index-database/commit/af404206393ced55798b7fadb1959377cb0a02f6) | `` more defensivly seperate options from configuration ``     |
| [`faa91659`](https://github.com/nix-community/nix-index-database/commit/faa91659deeb2257c41bbc32fa0eb7839a6798c1) | `` README: mention nix-darwin usage ``                        |