### PR TITLE
chore(flake/home-manager): `aecd341d` -> `819f6822`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731880681,
-        "narHash": "sha256-FmYTkIyPBUxSWgA7DPIVTsCCMvSSbs56yOtHpLNSnKg=",
+        "lastModified": 1732884235,
+        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "aecd341dfead1c3ef7a3c15468ecd71e8343b7c6",
+        "rev": "819f682269f4e002884702b87e445c82840c68f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`819f6822`](https://github.com/nix-community/home-manager/commit/819f682269f4e002884702b87e445c82840c68f2) | `` lorri: fix ReadWritePaths for new gcroots behavior `` |
| [`2f7739d0`](https://github.com/nix-community/home-manager/commit/2f7739d01080feb4549524e8f6927669b61c6ee3) | `` kakoune: add colorSchemePackage option ``             |
| [`b7219652`](https://github.com/nix-community/home-manager/commit/b7219652387ce4331ae49ddac8b0286f50e0ed68) | `` mopidy: ignore collisions between extensions ``       |
| [`de7d67b8`](https://github.com/nix-community/home-manager/commit/de7d67b8bae8aa2ac920fa10918c89ce44b66d00) | `` mopidy: make makeWrapper a native build input ``      |
| [`21396857`](https://github.com/nix-community/home-manager/commit/21396857fdceb61239a7ae67b9be4dbfd90c12c1) | `` kdeconnect: upgrade default version ``                |
| [`f83dc9f2`](https://github.com/nix-community/home-manager/commit/f83dc9f25a5915c70b013102e30f3ee2a72ba633) | `` tmux: set `sensibleOnTop = false` as a default ``     |
| [`0941a2e1`](https://github.com/nix-community/home-manager/commit/0941a2e14486ee30e2088afa1d2869f2486dd3b8) | `` flake.lock: Update ``                                 |
| [`a9953635`](https://github.com/nix-community/home-manager/commit/a9953635d7f34e7358d5189751110f87e3ac17da) | `` mopidy: restart service on config changes ``          |
| [`4d8d8c38`](https://github.com/nix-community/home-manager/commit/4d8d8c385e78f5f744e2e2f81f5c56fade6ca4eb) | `` zed-editor: add extraPackages option ``               |
| [`83002f18`](https://github.com/nix-community/home-manager/commit/83002f18468c4471d5f8de8c542ed2422badbf8f) | `` mopidy: restart the systemd service on failure ``     |
| [`98bf8de6`](https://github.com/nix-community/home-manager/commit/98bf8de65dc1ed12c6443b18f6f24d36e9c438d6) | `` volnoti: use cfg.package instead of pkgs ``           |
| [`f9fd45c5`](https://github.com/nix-community/home-manager/commit/f9fd45c512ef02c69557823543bb04051a41fa37) | `` volnoti: add self to maintainers ``                   |
| [`9ae941a4`](https://github.com/nix-community/home-manager/commit/9ae941a4cff40575feb7a64eb6cce70f733b12ed) | `` abook: remove platform linux assertion ``             |
| [`5e2f47c5`](https://github.com/nix-community/home-manager/commit/5e2f47c5a52707d250364401091e88021ba052a1) | `` hypridle: fix service when no config file ``          |
| [`bd58a113`](https://github.com/nix-community/home-manager/commit/bd58a1132e9b7f121f65313bc662ad6c8a05f878) | `` hyprpaper: fix service when no config file ``         |
| [`67cd4814`](https://github.com/nix-community/home-manager/commit/67cd4814a247fd0fe97171acb90659f7e304bcb8) | `` flake.lock: Update ``                                 |
| [`92fef254`](https://github.com/nix-community/home-manager/commit/92fef254a9071fa41a13908281284e6a62b9c92e) | `` podman: install package and create config files ``    |
| [`ba9367b5`](https://github.com/nix-community/home-manager/commit/ba9367b5a98402fb3d2afe7aa58c432c43996720) | `` emacs: add darwin service ``                          |
| [`16fe7818`](https://github.com/nix-community/home-manager/commit/16fe78182e924c9a2b0cffa1f343efea80945ef2) | `` conky: update systemd exec path to config package ``  |
| [`445d721e`](https://github.com/nix-community/home-manager/commit/445d721ecfbd92d83f857f12f1f99f5c8fa79951) | `` home-cursor: add hyprcursor support ``                |
| [`8cf9cb2e`](https://github.com/nix-community/home-manager/commit/8cf9cb2ee78aa129e5b8220135a511a2be254c0c) | `` tests: fix integration test ``                        |
| [`a46e7020`](https://github.com/nix-community/home-manager/commit/a46e702093a5c46e192243edbd977d5749e7f294) | `` espanso: fix test failure ``                          |
| [`d37f154d`](https://github.com/nix-community/home-manager/commit/d37f154dba0d4c015f17a24314e89b77a7ba5ff3) | `` flake.lock: Update ``                                 |
| [`a42fa14b`](https://github.com/nix-community/home-manager/commit/a42fa14b53ceab66274a21da480c9f8e06204173) | `` syncthing: expand declarative configuration ``        |
| [`705cf376`](https://github.com/nix-community/home-manager/commit/705cf3763a6d6074c1b7edb3ff0bb44efa7f091b) | `` Translate using Weblate (Ukrainian) ``                |
| [`094265fc`](https://github.com/nix-community/home-manager/commit/094265fca0e000f8af3c38e4dde0e459f91d59f0) | `` Translate using Weblate (Italian) ``                  |
| [`0bd5e9c7`](https://github.com/nix-community/home-manager/commit/0bd5e9c76c9f2f486f4bec0524e16026547df414) | `` librewolf: hide bookmarks option ``                   |
| [`18462998`](https://github.com/nix-community/home-manager/commit/18462998b126c8e32bc34c56156690052d1b46c2) | `` librewolf: use mkFirefoxModule ``                     |
| [`f3a2ff69`](https://github.com/nix-community/home-manager/commit/f3a2ff69586f3a54b461526e5702b1a2f81e740a) | `` zsh-abbr: update source path (#6084) ``               |
| [`05d3b621`](https://github.com/nix-community/home-manager/commit/05d3b6215afa733fed6f025a59a562f98330acc3) | `` home-manager: prepare 25.05-pre ``                    |
| [`0918bb02`](https://github.com/nix-community/home-manager/commit/0918bb02385a6897e7a0180d23ee4587491eb0d4) | `` ci: make dependabot consider release-24.11 ``         |