### PR TITLE
chore(flake/nix-index-database): `f4a5ca57` -> `f1e477a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732519917,
-        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
+        "lastModified": 1733629314,
+        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
+        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`f1e477a7`](https://github.com/nix-community/nix-index-database/commit/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8) | `` update generated.nix to release 2024-12-08-032901 `` |
| [`871d3049`](https://github.com/nix-community/nix-index-database/commit/871d304912084543002cd90a32d5ccc3f88b30f5) | `` flake.lock: Update ``                                |
| [`6e0b7f81`](https://github.com/nix-community/nix-index-database/commit/6e0b7f81367069589a480b91603a10bcf71f3103) | `` update generated.nix to release 2024-12-01-033612 `` |
| [`fc9c0def`](https://github.com/nix-community/nix-index-database/commit/fc9c0def2633a44750f1f1cd9f03ab6c5ad5c7bb) | `` flake.lock: Update ``                                |