### PR TITLE
chore(flake/stylix): `d13ffb38` -> `f48cab39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -406,16 +406,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1713702291,
-        "narHash": "sha256-zYP1ehjtcV8fo+c+JFfkAqktZ384Y+y779fzmR9lQAU=",
+        "lastModified": 1732369855,
+        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "0d0aadf013f78a7f7f1dc984d0d812971864b934",
+        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "46.1",
+        "ref": "47.2",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -782,11 +782,11 @@
         "tinted-tmux": "tinted-tmux"
       },
       "locked": {
-        "lastModified": 1732993760,
-        "narHash": "sha256-t1J6wgzGjvvGNfdd0ei8HnZf9sTw+SpvCNAX0i6Qgwc=",
+        "lastModified": 1735664732,
+        "narHash": "sha256-KoXLDDDT/nMBMl6VtoAGxJ58COvT+SWL5aiR+hUPBUo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "d13ffb381c83b6139b9d67feff7addf18f8408fe",
+        "rev": "f48cab39ba162c5eaef3d975aaac467c20db402b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                      |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`f48cab39`](https://github.com/danth/stylix/commit/f48cab39ba162c5eaef3d975aaac467c20db402b) | `` doc: document imageScalingMode options (#709) ``                          |
| [`a4ed4168`](https://github.com/danth/stylix/commit/a4ed4168fb83289374f24cb8a039c6983637a076) | `` foot: update desktop file name in testbed (#707) ``                       |
| [`963e77a3`](https://github.com/danth/stylix/commit/963e77a3a4fc2be670d5a9a6cbeb249b8a43808a) | `` gtk: add support for theming Flatpak applications (#693) ``               |
| [`079feceb`](https://github.com/danth/stylix/commit/079fecebad5f616561726359c89cedd811c8a722) | `` firefox: leverage Home Manager's mkFirefoxModule pattern (#695) ``        |
| [`a70154ec`](https://github.com/danth/stylix/commit/a70154ec03034cfd1a88868dc0259456fc618435) | `` doc: resolve 'magick convert' deprecation warning (#697) ``               |
| [`aec7be45`](https://github.com/danth/stylix/commit/aec7be45cf896c52c38ee99b7e1a21f4c6d4ccd4) | `` xresources: convert font size to a string ``                              |
| [`be3a33d5`](https://github.com/danth/stylix/commit/be3a33d58999e92b98152aedcc59238f1c299f87) | `` cava: add rainbow theme option (#638) ``                                  |
| [`75f38f9e`](https://github.com/danth/stylix/commit/75f38f9edffba44cf2f18f4df89850f9c3cb1ddb) | `` stylix: use floats for font sizes ``                                      |
| [`4f489c63`](https://github.com/danth/stylix/commit/4f489c63932f014be856475154bf342f8a40f5ff) | `` vscode: don't round font sizes (#691) ``                                  |
| [`a2d66f25`](https://github.com/danth/stylix/commit/a2d66f25478103ac9b4adc6d6713794f7005221e) | `` treewide: extend stylix.imageScalingMode support ``                       |
| [`a9e37799`](https://github.com/danth/stylix/commit/a9e3779949925ef22f5a215c5f49cf520dea30b1) | `` librewolf: init (#679) ``                                                 |
| [`ccee6332`](https://github.com/danth/stylix/commit/ccee633284cde8a9f825004e00dd84a31b10e6c6) | `` ci: prevent unexpected flake.nix and flake.lock inconsistencies (#674) `` |
| [`bc25f3d6`](https://github.com/danth/stylix/commit/bc25f3d69d3bb54548b772d7c2771e65cc37dc10) | `` emacs: set font for all frames, not just for new ones (#656) ``           |
| [`dd6605be`](https://github.com/danth/stylix/commit/dd6605be798b52bf588dadfda4431acf4145c1ed) | `` doc: encourage adding testbeds for new modules (#673) ``                  |
| [`81148743`](https://github.com/danth/stylix/commit/81148743b9de7a5764c29f64bb9f388d0cea030e) | `` doc: remove documentation about legacy commit conventions (#672) ``       |
| [`5a69e8c6`](https://github.com/danth/stylix/commit/5a69e8c65787a962cb3b7ebd855942029a8cba5a) | `` ci: fix typo in target branch placeholder ``                              |
| [`b08769f6`](https://github.com/danth/stylix/commit/b08769f64e6f82a619abb44420539c93aaa2882a) | `` ci: implement automated backports (#664) ``                               |
| [`23d9debf`](https://github.com/danth/stylix/commit/23d9debfdc43c996a1b0de94ebee0e2cde5ad79a) | `` vscode: extensive fonts ``                                                |
| [`c6547e2b`](https://github.com/danth/stylix/commit/c6547e2b2685db495c70b1f54dc08b6ed31b9a7b) | `` hyprland: remove with statement ``                                        |
| [`5282744c`](https://github.com/danth/stylix/commit/5282744c3439eac8db271ad1c6f3692ca04d4776) | `` hyprland: reduce local variable scopes ``                                 |
| [`638f30a6`](https://github.com/danth/stylix/commit/638f30a67e938495adfc992aa025b4b00bf3f4ee) | `` hyprland: inline single-use variable ``                                   |
| [`47f1504b`](https://github.com/danth/stylix/commit/47f1504b454bbb76a0bc58f9fa63f6e62ad58682) | `` hyprland: structurally separate unconditional and conditional settings `` |
| [`16e4ca7f`](https://github.com/danth/stylix/commit/16e4ca7fa71a5d7bd30c1654d753703dd2ce7b2c) | `` hyprland: add hyprpaper.enable option ``                                  |
| [`eb918dbf`](https://github.com/danth/stylix/commit/eb918dbffa24c4dae497f3ce3173660f948d5237) | `` doc: standardize license formatting (#661) ``                             |
| [`32882de1`](https://github.com/danth/stylix/commit/32882de122465d5ac9d4cf0b08b969c879334bc7) | `` doc: update copyright and include contributors (#659) ``                  |
| [`ffba1f1b`](https://github.com/danth/stylix/commit/ffba1f1bab63ea49541f812c72a4fcf305461d67) | `` gnome: update to GNOME 47.2 (#658) ``                                     |
| [`111c75d7`](https://github.com/danth/stylix/commit/111c75d73439fe4bea2cdfbeb60aeeb6ea770220) | `` sway: handle cursor names containing spaces (#654) ``                     |
| [`74ee1ed5`](https://github.com/danth/stylix/commit/74ee1ed5057e44edbcc36aa189a91d31eda60485) | `` kubecolor: init (#657) ``                                                 |
| [`defb43d4`](https://github.com/danth/stylix/commit/defb43d450dfc472682e64749334bd6f9ade91a5) | `` zathura: add testbed ``                                                   |
| [`6741c2ef`](https://github.com/danth/stylix/commit/6741c2ef6cb881acaf6904c6dc1a6a5cd181994f) | `` wezterm: add testbed ``                                                   |
| [`efb0e6f5`](https://github.com/danth/stylix/commit/efb0e6f59d0b8df5539acb239cd757402ba845b9) | `` vesktop: add testbed ``                                                   |
| [`491f7b3c`](https://github.com/danth/stylix/commit/491f7b3c93fe37403f033d1efd67ea350732b7e2) | `` qutebrowser: add testbed ``                                               |
| [`0c162ff5`](https://github.com/danth/stylix/commit/0c162ff5a8474b419ffe5a9509f377b7980eb478) | `` kitty: add testbed ``                                                     |
| [`7fcf77f1`](https://github.com/danth/stylix/commit/7fcf77f1a9b4c849d6c7f742d7c93dd48554dab4) | `` gedit: add testbed ``                                                     |
| [`7cd8165f`](https://github.com/danth/stylix/commit/7cd8165fc1ced74a63ff216f1adefdae826d2e2c) | `` foot: add testbed ``                                                      |
| [`06218e77`](https://github.com/danth/stylix/commit/06218e77d01569881ec53f1ba5103b6b5e2ceada) | `` emacs: add testbed ``                                                     |
| [`8eb2da8d`](https://github.com/danth/stylix/commit/8eb2da8d502d66e4660049254fec82e3e3e14c19) | `` chromium: add testbed ``                                                  |
| [`2ce89d28`](https://github.com/danth/stylix/commit/2ce89d2821fbb6ef269cad5fdc7c1939e6a0e2b1) | `` alacritty: add testbed ``                                                 |
| [`146d92a2`](https://github.com/danth/stylix/commit/146d92a210743ca0dcdc43a1010ae11a0249a90d) | `` vscode: add testbed ``                                                    |
| [`6c67f751`](https://github.com/danth/stylix/commit/6c67f75101679ce3c7d415995e090c61944e3bed) | `` firefox: add testbed ``                                                   |
| [`195e3240`](https://github.com/danth/stylix/commit/195e32407441033407a6ea7ef531133c8e2bedb0) | `` stylix: add template for application testbeds ``                          |