### PR TITLE
chore(flake/darwin): `6ab87b7c` -> `a35b08d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732603785,
-        "narHash": "sha256-AEjWTJwOmSnVYsSJCojKgoguGfFfwel6z/6ud6UFMU8=",
+        "lastModified": 1733570843,
+        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6ab87b7c84d4ee873e937108c4ff80c015a40c7a",
+        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                     |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`8752b6ae`](https://github.com/LnL7/nix-darwin/commit/8752b6ae3c0d6b44ca4ef28e50503f8efcec0096) | `` github-runner: add instructions for triggering a runner registration ``  |
| [`22cde06f`](https://github.com/LnL7/nix-darwin/commit/22cde06f497b97cbab4186292f9fd82487bbfecc) | `` github-runner: fix service not starting ``                               |
| [`06e1d770`](https://github.com/LnL7/nix-darwin/commit/06e1d770687a832a13aa23f37cdebeadc3af89b8) | `` github-runner: use `lib.getExe{,'}` ``                                   |
| [`d8255f09`](https://github.com/LnL7/nix-darwin/commit/d8255f09da39e603e710149dc87a5f3eaa4ff049) | `` github-runner: remove `with lib;` ``                                     |
| [`55d46b89`](https://github.com/LnL7/nix-darwin/commit/55d46b8997e16e52d8a05232f4444124e04ba686) | `` test(aerospace): assert config values ``                                 |
| [`9a595560`](https://github.com/LnL7/nix-darwin/commit/9a5955601847c728ffb98e70b89a359390b24d28) | `` fix(aerospace): allow startup commands ``                                |
| [`0f9576ce`](https://github.com/LnL7/nix-darwin/commit/0f9576cedc9b23ec8b01302daae919bc6018c3ca) | `` nix: fix Lix version detection in auto-optimise-store assertion ``       |
| [`567bae1e`](https://github.com/LnL7/nix-darwin/commit/567bae1e17fdd10eccc9d5c6ec20e3d98d498de7) | `` defaults: expose-group-by-app -> expose-group-apps ``                    |
| [`09e5dfb6`](https://github.com/LnL7/nix-darwin/commit/09e5dfb67ee27355d78d35a4f4ab747c230cb9b8) | `` defaults: add `EnableTiledWindowMargins` option ``                       |
| [`70957ab0`](https://github.com/LnL7/nix-darwin/commit/70957ab0c6a37fe72d21e1a2c273189a05c3670c) | `` linux-builder: default `maxJobs` to amount of cores for Linux builder `` |