### PR TITLE
chore(flake/nix-fast-build): `f51f479d` -> `95f5dc09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1732540608,
-        "narHash": "sha256-y1Q87PRcztZ2C1J/xGHk0VxY/T9wB6YL1nLtRbMYW5g=",
+        "lastModified": 1733069686,
+        "narHash": "sha256-lThMnu0otRxDTso07OU72+RZrUNokXwLKTjzTWGrxUo=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "f51f479d001317204f1a47302db36473dc12fc8f",
+        "rev": "95f5dc09a725a1916fd064f01eb3be9a5f487095",
         "type": "github"
       },
       "original": {
@@ -883,11 +883,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723808491,
-        "narHash": "sha256-rhis3qNuGmJmYC/okT7Dkc4M8CeUuRCSvW6kC2f3hBc=",
+        "lastModified": 1732894027,
+        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1d07739554fdc4f8481068f1b11d6ab4c1a4167a",
+        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`95f5dc09`](https://github.com/Mic92/nix-fast-build/commit/95f5dc09a725a1916fd064f01eb3be9a5f487095) | `` nixfmt: disable on riscv64 `` |
| [`4cd5ea09`](https://github.com/Mic92/nix-fast-build/commit/4cd5ea094fc56122c28e5da1800a8f7ec6a7b52b) | `` reformat test.yml ``          |
| [`5390a457`](https://github.com/Mic92/nix-fast-build/commit/5390a45760c0d48da0692f6b6231836886c4d40f) | `` flake.lock: Update ``         |
| [`0188252d`](https://github.com/Mic92/nix-fast-build/commit/0188252d0883d23b621e39daf340c6bc74ea95ee) | `` add buildbot to mergify ``    |
| [`86f2973d`](https://github.com/Mic92/nix-fast-build/commit/86f2973d0e0f28d1bc2e92ebbad90993d61e784f) | `` add dependabot ``             |
| [`f24c6c44`](https://github.com/Mic92/nix-fast-build/commit/f24c6c44e11f4f8a20fe4e756079ffdb4005c744) | `` update flake lock ``          |