### PR TITLE
chore(flake/flake-parts): `506278e7` -> `205b12d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -191,11 +191,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1730504689,
-        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -602,14 +602,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1730504152,
-        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
       }
     },
     "nixpkgs-stable": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                              |
| -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`85954c90`](https://github.com/hercules-ci/flake-parts/commit/85954c907b405159f275949ff49632b5808a02d7) | `` Update get-flake to its upstream, flake-compat `` |
| [`39d7a315`](https://github.com/hercules-ci/flake-parts/commit/39d7a31582b2002b2b28402f3c3127ad831253c0) | `` dev/flake.lock: Update ``                         |
| [`0a1d130f`](https://github.com/hercules-ci/flake-parts/commit/0a1d130f5fa6d2ea95ef92c5d1454098b4c957a9) | `` flake.lock: Update ``                             |
| [`5a2b1192`](https://github.com/hercules-ci/flake-parts/commit/5a2b1192edc1d179de0c9da0f404d4882fe0ccd1) | `` flake.nix: Update nixpkgs-lib tree ``             |