### PR TITLE
chore(flake/home-manager): `819f6822` -> `66c5d8b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732884235,
-        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
+        "lastModified": 1734093295,
+        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "819f682269f4e002884702b87e445c82840c68f2",
+        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`66c5d8b6`](https://github.com/nix-community/home-manager/commit/66c5d8b62818ec4c1edb3e941f55ef78df8141a8) | `` zed-editor: fix always generating settings.json ``              |
| [`3066cc58`](https://github.com/nix-community/home-manager/commit/3066cc58f552421a2c5414e78407fa5603405b1e) | `` kanshi: dont write config in absence of nix settings (#6198) `` |
| [`e526fd2b`](https://github.com/nix-community/home-manager/commit/e526fd2b1a40e4ca0b5e07e87b8c960281c67412) | `` gnome-shell: fix extensions' default (#6199) ``                 |
| [`15151bb5`](https://github.com/nix-community/home-manager/commit/15151bb5e7d6e352247ecaeeeefc34d0f306b287) | `` gpg: fix hash of test (#6200) ``                                |
| [`6e5b2d9e`](https://github.com/nix-community/home-manager/commit/6e5b2d9e8014b5572e3367937a329e7053458d34) | `` home-manager: support username with special chars (#5609) ``    |
| [`f26aa4b7`](https://github.com/nix-community/home-manager/commit/f26aa4b76fb7606127032d33ac73d7d507d82758) | `` gpg-agent: fix GCR DBus package note ``                         |
| [`c6a5fbfd`](https://github.com/nix-community/home-manager/commit/c6a5fbfd99bccfafbe99a6bb87b351c8fb7de70a) | `` qt: install kio when qt.platformTheme = "kde" ``                |
| [`8772bae5`](https://github.com/nix-community/home-manager/commit/8772bae58c0a1390727aaf13802debfa29757d67) | `` nushell: allow installing plugins ``                            |
| [`e952e949`](https://github.com/nix-community/home-manager/commit/e952e94955dcc6fa2120c1430789fc41363f5237) | `` atuin: Prepare for daemon socket path in 18.4.0 ``              |
| [`77a792a0`](https://github.com/nix-community/home-manager/commit/77a792a0418227e69a2ba26728b47f2b8cf3b6ec) | `` atuin: Do not hard code prefix for daemon socket path ``        |
| [`9ebaa80a`](https://github.com/nix-community/home-manager/commit/9ebaa80a227eaca9c87c53ed515ade013bc2bca9) | `` thunderbird: set the correct SMTP server for aliases (#6177) `` |
| [`f63c15c1`](https://github.com/nix-community/home-manager/commit/f63c15c137f9e446af897c15218c1af9f06d91ad) | `` isync/mbsync: update module for 1.5.0 changes (#5918) ``        |
| [`d00c6f6d`](https://github.com/nix-community/home-manager/commit/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a) | `` nix: simplify tests ``                                          |
| [`63eb786e`](https://github.com/nix-community/home-manager/commit/63eb786e047fbb101041103f86162cd72d105d79) | `` xresources: simplify tests ``                                   |
| [`0b42cc1b`](https://github.com/nix-community/home-manager/commit/0b42cc1b1c7a38f32334f217eadbc7b83b3ef44c) | `` cmus: reduce test closure ``                                    |
| [`953521f7`](https://github.com/nix-community/home-manager/commit/953521f759fd746190ae2d2d052183296425b27b) | `` fcitx5: fix package reference in test ``                        |
| [`65912bc6`](https://github.com/nix-community/home-manager/commit/65912bc6841cf420eb8c0a20e03df7cbbff5963f) | `` imapnotify: provide an option for setting PATH ``               |
| [`0daaded6`](https://github.com/nix-community/home-manager/commit/0daaded612b0e6eaed0a63fc9d0778d8f05940fe) | `` starship: replace `eval` with `source` for fish ``              |
| [`86ee1290`](https://github.com/nix-community/home-manager/commit/86ee1290d76bcd5f7ee6c80f181288a28ab0dca0) | `` starship: add `enableInteractive` option for fish ``            |
| [`1cd17a2f`](https://github.com/nix-community/home-manager/commit/1cd17a2f76f7711b06d5d59f1746cef602974498) | `` mangohud: fix a non-working example ``                          |
| [`3a7fc9cd`](https://github.com/nix-community/home-manager/commit/3a7fc9cd71a844aae9c6b6bb44700cea9539bc13) | `` zsh: make autosuggest strategy accept more options ``           |
| [`ad48eb25`](https://github.com/nix-community/home-manager/commit/ad48eb25cd0b00ce730da00fa1f8e6e6c27b397d) | `` etesync-dav: update default server URL ``                       |
| [`b1c19f1d`](https://github.com/nix-community/home-manager/commit/b1c19f1dcbc2429c16d5e6259dbff4f12dd8a89d) | `` home-cursor: use `profileExtra` instead of `initExtra` ``       |
| [`30f66eaa`](https://github.com/nix-community/home-manager/commit/30f66eaa3209e13f32f98df5a150542baf2d72af) | `` xresources: use `profileExtra` instead of `initExtra` ``        |
| [`6c3a7a0b`](https://github.com/nix-community/home-manager/commit/6c3a7a0b72c19ec994b85c57a1712d177bd809b2) | `` qt: reduce test closure ``                                      |
| [`8f4f57f9`](https://github.com/nix-community/home-manager/commit/8f4f57f9a67367881b1a36f93856ffef8646d428) | `` qt: update tooling for Plasma 6 ``                              |
| [`70803283`](https://github.com/nix-community/home-manager/commit/70803283187c8f775ff561be4117e5b1a11b296e) | `` Translate using Weblate (Finnish) ``                            |
| [`5b5de433`](https://github.com/nix-community/home-manager/commit/5b5de4338fad32dc709c900b4dcbbcd98b20dc4c) | `` kakoune: fix color scheme package XDG file ``                   |
| [`256ec265`](https://github.com/nix-community/home-manager/commit/256ec2653e79363022a6042285dde3935816cea4) | `` flake.lock: Update ``                                           |
| [`dfdf59b2`](https://github.com/nix-community/home-manager/commit/dfdf59b2d539941aea5c26666c9ab809c1dc34df) | `` atuin: make daemon log level configurable ``                    |
| [`f8bc330a`](https://github.com/nix-community/home-manager/commit/f8bc330a13f80e13e70967bca0e674f711218ea2) | `` atuin: capitalize mentions of "atuin" ``                        |
| [`c56aa0f5`](https://github.com/nix-community/home-manager/commit/c56aa0f51d058f41a7ba0c45bd3b6d9d244c0396) | `` atuin: assert version >= 18.2.0 when daemon is enabled ``       |
| [`33c236f1`](https://github.com/nix-community/home-manager/commit/33c236f1d5eb3d1a3df202540794d590c2fe0a2f) | `` atuin: add water-sucks as maintainer ``                         |
| [`092b81b9`](https://github.com/nix-community/home-manager/commit/092b81b95615919b36cbb0e690dda8583b31013e) | `` atuin: configure daemon using systemd and launchd ``            |
| [`bf23fe41`](https://github.com/nix-community/home-manager/commit/bf23fe41082aa0289c209169302afd3397092f22) | `` tmux: add 'focusEvents' ``                                      |
| [`873e39d5`](https://github.com/nix-community/home-manager/commit/873e39d5f4437d2f3ab06881fea8e63e45e1d011) | `` podman-container: fix tests and failing podman 5.3.0 service `` |
| [`d2e2bda6`](https://github.com/nix-community/home-manager/commit/d2e2bda6c050a61d51b8e395ad66b8fa48318e07) | `` nix-your-shell: fix creating required directory ``              |
| [`c1fee8d4`](https://github.com/nix-community/home-manager/commit/c1fee8d4a60b89cae12b288ba9dbc608ff298163) | `` alot: make package used by module configurable ``               |
| [`86327350`](https://github.com/nix-community/home-manager/commit/863273505016a1e88e4ffaec48d1b767104c5652) | `` kubecolor: add module ``                                        |
| [`e71e678d`](https://github.com/nix-community/home-manager/commit/e71e678d18d1a24e01d823ccb72df13f9e82f65b) | `` nix-your-shell: add module ``                                   |
| [`7f78e2d1`](https://github.com/nix-community/home-manager/commit/7f78e2d1c6a9db76444e02a73f0669ebb79f8833) | `` yazi: update keymap config ``                                   |
| [`441fae84`](https://github.com/nix-community/home-manager/commit/441fae847ddfe20f9f9a4c47345691a205bb772c) | `` zsh-abbr: add package option ``                                 |
| [`4964f3c6`](https://github.com/nix-community/home-manager/commit/4964f3c6fc17ae4578e762d3dc86b10fe890860e) | `` home-manager: prepare 24.11 release ``                          |
| [`8eeda281`](https://github.com/nix-community/home-manager/commit/8eeda281e70cbadabb7f0095c5f34e354e85f307) | `` flake.lock: Update ``                                           |