### PR TITLE
chore(flake/nix-index-database): `f1e477a7` -> `55ab1e1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733629314,
-        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
+        "lastModified": 1735443188,
+        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
+        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                          |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`55ab1e1d`](https://github.com/nix-community/nix-index-database/commit/55ab1e1df5daf2476e6b826b69a82862dcbd7544) | `` update generated.nix to release 2024-12-29-031725 ``          |
| [`6d3f0273`](https://github.com/nix-community/nix-index-database/commit/6d3f02734423ba59679a15f529b95da15d265d0e) | `` flake.lock: Update ``                                         |
| [`7e3246f6`](https://github.com/nix-community/nix-index-database/commit/7e3246f6ad43b44bc1c16d580d7bf6467f971530) | `` update generated.nix to release 2024-12-26-140211 ``          |
| [`e609cc6e`](https://github.com/nix-community/nix-index-database/commit/e609cc6e0f9037b2bb02bd1104afcc1f6f936d33) | `` Revert "update generated.nix to release 2024-12-25-204532" `` |
| [`0a961f69`](https://github.com/nix-community/nix-index-database/commit/0a961f691c4da1e7edc0c23afd6e8d6765499ce0) | `` Omit symlinks to avoid a file collision ``                    |
| [`c8470746`](https://github.com/nix-community/nix-index-database/commit/c8470746a9f4d1ab4c7563db7da995595ed64ca2) | `` update generated.nix to release 2024-12-25-204532 ``          |
| [`f3ea8bd1`](https://github.com/nix-community/nix-index-database/commit/f3ea8bd11b980aefb1324b0d71d7aee09db1c0a8) | `` set small db as default for comma ``                          |
| [`07f7fcb8`](https://github.com/nix-community/nix-index-database/commit/07f7fcb8de6ee50a472a119a02616fb1ed67a25f) | `` update generated.nix to release 2024-12-22-163440 ``          |
| [`2ad40f1b`](https://github.com/nix-community/nix-index-database/commit/2ad40f1b4cf5512681509bb4ff79e87084888f10) | `` expose nix-index-small-database ``                            |
| [`e6926650`](https://github.com/nix-community/nix-index-database/commit/e6926650c0a6fcb7a7e80b963002c5e1403dea0e) | `` expose small db and nix-index package with it ``              |
| [`e2f645c6`](https://github.com/nix-community/nix-index-database/commit/e2f645c6bdd50f7767f3e90f41a59abdde77288f) | `` update generated.nix to release 2024-12-22-115534 ``          |
| [`8abb006e`](https://github.com/nix-community/nix-index-database/commit/8abb006edb7d7e0e442f00c0bf705bc86ca7a88e) | `` generate small index ``                                       |
| [`d583b2d1`](https://github.com/nix-community/nix-index-database/commit/d583b2d142f0428313df099f4a2dcf2a0496aa78) | `` update generated.nix to release 2024-12-22-031612 ``          |
| [`af62b107`](https://github.com/nix-community/nix-index-database/commit/af62b10745e18133fbc6ed164baf4846c75ef5d5) | `` flake.lock: Update ``                                         |
| [`311d6cf3`](https://github.com/nix-community/nix-index-database/commit/311d6cf3ad3f56cb051ffab1f480b2909b3f754d) | `` update generated.nix to release 2024-12-15-032933 ``          |
| [`ad035087`](https://github.com/nix-community/nix-index-database/commit/ad03508704b42d0a0b9acb79978965e2f2373bbe) | `` flake.lock: Update ``                                         |