### PR TITLE
chore(flake/git-hooks): `c2b3567b` -> `f0f0dc49`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                                |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`3e3ebb27`](https://github.com/cachix/git-hooks.nix/commit/3e3ebb2765e48344a3ab700fc25c125181eb8bcb) | `` chore(cabal2nix): stick to camelCase ``                                             |
| [`03c878f8`](https://github.com/cachix/git-hooks.nix/commit/03c878f82e08d28345604895e84188e249b9ce21) | `` fix: biome write deprecation ``                                                     |
| [`96209c15`](https://github.com/cachix/git-hooks.nix/commit/96209c15446f3fa6985306fbb9034635cf69c1fc) | `` Throw a pretty error if the hooks cannot be sorted ``                               |
| [`4d562428`](https://github.com/cachix/git-hooks.nix/commit/4d562428f8bfebae5504f6189acef68833a6450d) | `` Simplify internal `before`/`after` code ``                                          |
| [`3e7d7910`](https://github.com/cachix/git-hooks.nix/commit/3e7d791061be477b20a9d4e1f57872a51a392a57) | `` bugfix: remove before/after options from config json file ``                        |
| [`2c69d710`](https://github.com/cachix/git-hooks.nix/commit/2c69d710c20b8856e18d01fd4f6d265175167eec) | `` chore: add a default priority to `cabal2nix` which ensures it runs after `hpack` `` |
| [`8a8d2b81`](https://github.com/cachix/git-hooks.nix/commit/8a8d2b81f465bb693c676a285f1ba93b4d3a8931) | `` make sure that clang-tools is in the same version across all platforms ``           |
| [`be16516d`](https://github.com/cachix/git-hooks.nix/commit/be16516ddd761e03509849c2d037925f826740cc) | `` feat: add an option to cabal2nix hook for specifying output filename. ``            |