### PR TITLE
chore(flake/home-manager): `66c5d8b6` -> `10e99c43`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734093295,
-        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`10e99c43`](https://github.com/nix-community/home-manager/commit/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2) | `` copyq: add option to disable XWayland ``                  |
| [`b7a7cd5d`](https://github.com/nix-community/home-manager/commit/b7a7cd5dd1a74a9fe86ed4e016f91c78483b527a) | `` pqiv: fix condition for writing pqivrc file ``            |
| [`19398e50`](https://github.com/nix-community/home-manager/commit/19398e505a80db1a1c41207ee89e1b1770c5dcf6) | `` lesspipe: allow configuring package ``                    |
| [`35b98d20`](https://github.com/nix-community/home-manager/commit/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84) | `` treewide: change pacien to euxane ``                      |
| [`afbf007b`](https://github.com/nix-community/home-manager/commit/afbf007bb5e05b7837be5485e221ea50c4fd4f1b) | `` tests: add integration test for nh ``                     |
| [`64272584`](https://github.com/nix-community/home-manager/commit/64272584091a47e3762d1bfb40638fbe58dd756d) | `` tests: change to wait for network.target ``               |
| [`aa8c3d7f`](https://github.com/nix-community/home-manager/commit/aa8c3d7f7d6b61d3273e943d4fb8bddf7a647431) | `` tests: remove stray line ``                               |
| [`f1b1786e`](https://github.com/nix-community/home-manager/commit/f1b1786ea77739dcd181b920d430e30fb1608b8a) | `` swayr: avoid IFD ``                                       |
| [`8264bfe3`](https://github.com/nix-community/home-manager/commit/8264bfe3a064d704c57df91e34b795b6ac7bad9e) | `` mu: add integration tests ``                              |
| [`7349b015`](https://github.com/nix-community/home-manager/commit/7349b01505d18cd60ba0e573e78c234b742056ef) | `` mu: reinitialize when personal addresses change ``        |
| [`8bea1a20`](https://github.com/nix-community/home-manager/commit/8bea1a2005c64a8c9c430d0dddb6b2e5db5f6f12) | `` nixgl: forward override calls to wrapped package ``       |
| [`edb8b00e`](https://github.com/nix-community/home-manager/commit/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4) | `` Translate using Weblate (Czech) ``                        |
| [`1f74238a`](https://github.com/nix-community/home-manager/commit/1f74238a4c8e534a1b6be72cb5153043071ffd17) | `` xresources: allow floating point values ``                |
| [`cb27edb5`](https://github.com/nix-community/home-manager/commit/cb27edb5221d2f2920a03155f8becc502cf60e35) | `` waybar: add systemd restart triggers ``                   |
| [`f47b6c15`](https://github.com/nix-community/home-manager/commit/f47b6c153ad31187a519bd569ccbcb20acb16ce0) | `` cavalier: add module ``                                   |
| [`c903b1f6`](https://github.com/nix-community/home-manager/commit/c903b1f6fbfc2039963806df896f698331b77aa8) | `` flake.lock: Update ``                                     |
| [`51160a09`](https://github.com/nix-community/home-manager/commit/51160a097a850839b7eae7ef08d0d3e7e353dfc3) | `` thunderbird: implement `extensions` for profiles ``       |
| [`f342df3a`](https://github.com/nix-community/home-manager/commit/f342df3ad938f205a913973b832f52c12546aac6) | `` flake.lock: Update ``                                     |
| [`db9a98e1`](https://github.com/nix-community/home-manager/commit/db9a98e178b57a8aff46b3482dfccb3f4d8d4ce3) | `` pay-respects: add module ``                               |
| [`99f54cdf`](https://github.com/nix-community/home-manager/commit/99f54cdfef395bb3de1c7b8dd422412de65b038d) | `` yazi: fix example option for settings ``                  |
| [`1395379a`](https://github.com/nix-community/home-manager/commit/1395379a7a36e40f2a76e7b9936cc52950baa1be) | `` home-manager: improve path handling when building news `` |
| [`832920a6`](https://github.com/nix-community/home-manager/commit/832920a60833533eaabcc93ab729801bf586fa0c) | `` thunderbird: add profileVersion ``                        |
| [`83ecd509`](https://github.com/nix-community/home-manager/commit/83ecd50915a09dca928971139d3a102377a8d242) | `` docs: fix typo in 24.11 release notes ``                  |