### PR TITLE
chore(flake/darwin): `a35b08d0` -> `6a1fdb2a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733570843,
-        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
+        "lastModified": 1735685839,
+        "narHash": "sha256-62xAPSs5VRZoPH7eRanUn5S5vZEd+8vM4bD5I+zxokc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
+        "rev": "6a1fdb2a1204c0de038847b601cff5012e162b5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                                 |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
| [`0680f9e9`](https://github.com/LnL7/nix-darwin/commit/0680f9e9e1a2861e1513a4ffe5b483130ce736c7) | `` ci, readme: update stable nixpkgs to 24.11 ``                                                        |
| [`aefd56bb`](https://github.com/LnL7/nix-darwin/commit/aefd56bb562b26ae799e261b1ead27682bf0d8ff) | `` aerospace: add workspace-to-monitor-force-assignment option and fix on-window-detected type #1208 `` |
| [`b8e184eb`](https://github.com/LnL7/nix-darwin/commit/b8e184ebf271367cf1c93d942e71ae51d2a248cb) | `` refactor: use enum as option type ``                                                                 |
| [`19bc0d6c`](https://github.com/LnL7/nix-darwin/commit/19bc0d6cbeacb20c5ca865d06c274152c42ffd22) | `` tests: add screencapture.target test case ``                                                         |
| [`25fb5271`](https://github.com/LnL7/nix-darwin/commit/25fb52710582c19ad811d1ac9a2fe9d8920c0a66) | `` feat: add screencapture.target option ``                                                             |
| [`daf9d9fe`](https://github.com/LnL7/nix-darwin/commit/daf9d9fe5d5a7a5ef25aa446582f8c656aab2b9b) | `` fix(zsh): correct the path of zsh-fast-syntax-highlighting ``                                        |
| [`2165857a`](https://github.com/LnL7/nix-darwin/commit/2165857a24668cc3cb09c052eb0d518a1dfa6d3f) | `` fish: add package option ``                                                                          |
| [`2c86af2e`](https://github.com/LnL7/nix-darwin/commit/2c86af2e996ac6abbf9e1711f36c28d33b328df6) | `` programs.ssh: add extraConfig option ``                                                              |