### PR TITLE
chore(flake/nix-index-database): `55ab1e1d` -> `271e5bd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1736652904,
+        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`271e5bd7`](https://github.com/nix-community/nix-index-database/commit/271e5bd7c57e1f001693799518b10a02d1123b12) | `` update generated.nix to release 2025-01-12-031855 `` |
| [`eb593fb1`](https://github.com/nix-community/nix-index-database/commit/eb593fb1ddcbafe3d4280f0c301222f2223d18a8) | `` flake.lock: Update ``                                |
| [`a2200b49`](https://github.com/nix-community/nix-index-database/commit/a2200b499efa01ca8646173e94cdfcc93188f2b8) | `` Add default.nix ``                                   |
| [`816a6ae8`](https://github.com/nix-community/nix-index-database/commit/816a6ae88774ba7e74314830546c29e134e0dffb) | `` update generated.nix to release 2025-01-05-031613 `` |
| [`ff2883e9`](https://github.com/nix-community/nix-index-database/commit/ff2883e99aa3ab84e1cea129c0aad4f4b6dd1fec) | `` flake.lock: Update ``                                |