### PR TITLE
chore(flake/darwin): `6a1fdb2a` -> `bd921223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735685839,
-        "narHash": "sha256-62xAPSs5VRZoPH7eRanUn5S5vZEd+8vM4bD5I+zxokc=",
+        "lastModified": 1736819234,
+        "narHash": "sha256-deQVtIH4UJueELJqluAICUtX7OosD9paTP+5FgbiSwI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6a1fdb2a1204c0de038847b601cff5012e162b5e",
+        "rev": "bd921223ba7cdac346477d7ea5204d6f4736fcc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                            |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
| [`e33d37c4`](https://github.com/LnL7/nix-darwin/commit/e33d37c41f8040631f0cc16b032a1cf214aeeb4e) | `` {readme,examples/flake}: update for release branches ``                                         |
| [`d5aeb4e5`](https://github.com/LnL7/nix-darwin/commit/d5aeb4e5b17c4e17b4eb515e088d6ea6babd14d8) | `` checks: recommend `sudo nix-channel` ``                                                         |
| [`efba3517`](https://github.com/LnL7/nix-darwin/commit/efba3517fcd8f034e01dfda1c94a865d11aaf69f) | `` eval-config: implement release branch checks ``                                                 |
| [`c7b33c13`](https://github.com/LnL7/nix-darwin/commit/c7b33c131fcbb83eb2f47e07de5a8dee587e5d4b) | `` ci: only test one version ``                                                                    |
| [`8a3ea966`](https://github.com/LnL7/nix-darwin/commit/8a3ea966bcb14655b231308e9d52195715c71692) | `` version: implement nix-darwin release versions ``                                               |
| [`be4c1b89`](https://github.com/LnL7/nix-darwin/commit/be4c1b897accbdfc3429e99b5bd5234c5663776e) | `` openssh: init module ``                                                                         |
| [`0ef91bc1`](https://github.com/LnL7/nix-darwin/commit/0ef91bc148dc1873cdc21d8efbe3c65f91db311a) | `` flake: pin Nixpkgs explicitly ``                                                                |
| [`9e856ad0`](https://github.com/LnL7/nix-darwin/commit/9e856ad0c1a677d1585e53a634c4abe487601c51) | `` nix: merge `nix.settings.trusted-users` by default ``                                           |
| [`6ee6262d`](https://github.com/LnL7/nix-darwin/commit/6ee6262d2468cf053f39cb53ea6272af337f2cf7) | `` Add --ignore-dependencies option for casks ``                                                   |
| [`89be82cb`](https://github.com/LnL7/nix-darwin/commit/89be82cb2b19b6371a786af6eb9effc79babb70f) | `` power: quote in string triggered shellcheck SC2016 ``                                           |
| [`492a7200`](https://github.com/LnL7/nix-darwin/commit/492a72007ae2e7bd5895458fcd72ac2c8c9a0dc4) | `` power: echo to print in error messages ``                                                       |
| [`62d8f5f2`](https://github.com/LnL7/nix-darwin/commit/62d8f5f289341497ea0fa21814e734cbea69a0a1) | `` power: move the check for restartPowerfailure support to checks.nix ``                          |
| [`016b1608`](https://github.com/LnL7/nix-darwin/commit/016b1608eec6c54cfaece96b63ec9d1a6cd4672b) | `` power: restartAfterPowerFailure option is carried out in activation script only if supported `` |