### PR TITLE
chore(flake/stylix): `f48cab39` -> `965d1cb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -594,11 +594,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1734716067,
-        "narHash": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
+        "lastModified": 1736592044,
+        "narHash": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
+        "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
         "type": "github"
       },
       "original": {
@@ -971,11 +971,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734543842,
-        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735685839,
-        "narHash": "sha256-62xAPSs5VRZoPH7eRanUn5S5vZEd+8vM4bD5I+zxokc=",
+        "lastModified": 1736819234,
+        "narHash": "sha256-deQVtIH4UJueELJqluAICUtX7OosD9paTP+5FgbiSwI=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6a1fdb2a1204c0de038847b601cff5012e162b5e",
+        "rev": "bd921223ba7cdac346477d7ea5204d6f4736fcc6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -640,11 +640,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1736652904,
+        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -207,11 +207,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -671,14 +671,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs-stable": {

--- a/flake.lock
+++ b/flake.lock
@@ -340,11 +340,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -518,11 +518,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734093295,
-        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {
@@ -570,11 +570,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733570843,
-        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
+        "lastModified": 1735478292,
+        "narHash": "sha256-Ys9pSP9ch0SthhpbjnkCSJ9ZLfaNKnt/dcy7swjmS1A=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
+        "rev": "71a3a075e3229a7518d76636bb762aef2bcb73ac",
         "type": "github"
       },
       "original": {
@@ -620,11 +620,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1733069686,
-        "narHash": "sha256-lThMnu0otRxDTso07OU72+RZrUNokXwLKTjzTWGrxUo=",
+        "lastModified": 1734716067,
+        "narHash": "sha256-BCpd50t/3JU4ydiNfJxH3LzQDzyGbBI0CKWaeplnkVg=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "95f5dc09a725a1916fd064f01eb3be9a5f487095",
+        "rev": "ed736c65a8cb58a85369f6ee1c3f4403aa904fcc",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1734223742,
-        "narHash": "sha256-vp3wSbCVU/4y5W+YI6H9PSix3WD7XbcIyesmB7W0ZWo=",
+        "lastModified": 1735656123,
+        "narHash": "sha256-AnTW4OA8vW6CGqNJQZ/jV+i9ei7h7g+htGGdshWmQSo=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "58d2a5ac9cc4ff987e6edb77f2b55d1dec05ce50",
+        "rev": "bc87d91273928c97a47eab0df9b303bb45adc6f4",
         "type": "github"
       },
       "original": {
@@ -755,11 +755,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1734453820,
-        "narHash": "sha256-yVboUQKDp6wR3ZmG3dgGA9MRBkosjKEfpcwgl7YAQyA=",
+        "lastModified": 1736475034,
+        "narHash": "sha256-IhqhbvJnSVH2vQznlEhiHqemsI8i1MC7rNSonPJG4nY=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "0098d24ee95f660c8c46711c06189ca4103cd13c",
+        "rev": "9a4affffb9a45a836b050369944ea8e54f1243e0",
         "type": "github"
       },
       "original": {
@@ -803,11 +803,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1734190932,
-        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
+        "lastModified": 1734797603,
+        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
+        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
         "type": "github"
       },
       "original": {
@@ -993,11 +993,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732894027,
-        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
+        "lastModified": 1734543842,
+        "narHash": "sha256-/QceWozrNg915Db9x/Ie5k67n9wKgGdTFng+Z1Qw0kE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
+        "rev": "76159fc74eeac0599c3618e3601ac2b980a29263",
         "type": "github"
       },
       "original": {
@@ -1015,11 +1015,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
+        "lastModified": 1735135567,
+        "narHash": "sha256-8T3K5amndEavxnludPyfj3Z1IkcFdRpR23q+T0BVeZE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "rev": "9e09d30a644c57257715902efbb3adc56c79cf28",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -124,6 +124,22 @@
         "type": "github"
       }
     },
+    "firefox-gnome-theme": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1734969791,
+        "narHash": "sha256-A9PxLienMYJ/WUvqFie9qXrNC2MeRRYw7TG/q7DRjZg=",
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "rev": "92f4890bd150fc9d97b61b3583680c0524a8cafe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rafaelmardojai",
+        "repo": "firefox-gnome-theme",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -337,6 +353,37 @@
         "type": "github"
       }
     },
+    "git-hooks_3": {
+      "inputs": {
+        "flake-compat": [
+          "stylix",
+          "flake-compat"
+        ],
+        "gitignore": "gitignore_4",
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "stylix",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -386,6 +433,28 @@
         "nixpkgs": [
           "nixvim-flake",
           "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore_4": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -767,8 +836,10 @@
         "base16-fish": "base16-fish",
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
+        "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_2",
+        "git-hooks": "git-hooks_3",
         "gnome-shell": "gnome-shell",
         "home-manager": [
           "home-manager"
@@ -779,14 +850,15 @@
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
-        "tinted-tmux": "tinted-tmux"
+        "tinted-tmux": "tinted-tmux",
+        "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1735664732,
-        "narHash": "sha256-KoXLDDDT/nMBMl6VtoAGxJ58COvT+SWL5aiR+hUPBUo=",
+        "lastModified": 1736882096,
+        "narHash": "sha256-TQFkQ6RN8L/Xto5Ttt6hwJInFI5Nz2uCfXg5ci2q6UA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f48cab39ba162c5eaef3d975aaac467c20db402b",
+        "rev": "965d1cb7c84170200b4f05e68ebd27a88d171e8c",
         "type": "github"
       },
       "original": {
@@ -872,6 +944,22 @@
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
+        "type": "github"
+      }
+    },
+    "tinted-zed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725758778,
+        "narHash": "sha256-8P1b6mJWyYcu36WRlSVbuj575QWIFZALZMTg5ID/sM4=",
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
+        "rev": "122c9e5c0e6f27211361a04fae92df97940eccf9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "base16-zed",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -496,11 +496,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735381016,
-        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
+        "lastModified": 1736785676,
+        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
+        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -303,15 +303,14 @@
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        ]
       },
       "locked": {
-        "lastModified": 1734797603,
-        "narHash": "sha256-ulZN7ps8nBV31SE+dwkDvKIzvN6hroRY8sYOT0w+E28=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f0f0dc4920a903c3e08f5bdb9246bb572fcae498",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -697,22 +696,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
         "devshell": "devshell",
@@ -800,7 +783,7 @@
           "nixvim-flake",
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
         "lastModified": 1734797603,

--- a/flake.lock
+++ b/flake.lock
@@ -654,11 +654,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1736798957,
+        "narHash": "sha256-qwpCtZhSsSNQtK4xYGzMiyEDhkNzOCz/Vfu4oL2ETsQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "9abb87b552b7f55ac8916b6fc9e5cb486656a2f3",
         "type": "github"
       },
       "original": {

--- a/graphical/darwin.nix
+++ b/graphical/darwin.nix
@@ -6,10 +6,6 @@
         greedy = true;
       }
       {
-        name = "alt-tab";
-        greedy = true;
-      }
-      {
         name = "amethyst";
         greedy = true;
       }
@@ -39,10 +35,6 @@
       }
       {
         name = "spotify";
-        greedy = true;
-      }
-      {
-        name = "zen-browser";
         greedy = true;
       }
     ];


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                           |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`965d1cb7`](https://github.com/danth/stylix/commit/965d1cb7c84170200b4f05e68ebd27a88d171e8c) | `` zathura: set background opacity with stylix.opacity.applications (#770) ``     |
| [`934e2bfe`](https://github.com/danth/stylix/commit/934e2bfe7954d6c94f25d45cb12a8b3547825699) | `` vencord: init (#768) ``                                                        |
| [`fb773084`](https://github.com/danth/stylix/commit/fb773084f74b2ddec103a2459847dabd2a65874c) | `` doc: fix two titles not using sentence case (#769) ``                          |
| [`0a20c8d0`](https://github.com/danth/stylix/commit/0a20c8d0ede42be2ab75038f868f6b961d9d827f) | `` ci: standardize output redirection formatting (#756) ``                        |
| [`f1e00319`](https://github.com/danth/stylix/commit/f1e003194cb528bbd4eda50b781d1f703611782d) | `` zed: convert font sizes from pt to px (#766) ``                                |
| [`a8399897`](https://github.com/danth/stylix/commit/a8399897e85510de8698f9a3737d91143af704ef) | `` treewide: remove redundant empty line in testbeds (#760) ``                    |
| [`6d986760`](https://github.com/danth/stylix/commit/6d9867604efd73274bbe40fe974af66e9e3faa04) | `` treewide: reduce indentation level with lib.singleton (#754) ``                |
| [`5c84f02f`](https://github.com/danth/stylix/commit/5c84f02fcfb4fc697f132e90b8b3f9598c809b96) | `` regreet: respect dark mode and unset extraCss for custom styling (#723) ``     |
| [`8be9e8ad`](https://github.com/danth/stylix/commit/8be9e8ad9a238ce11fc3a1a00d4baffa4eb9ed28) | `` ci: update Ubuntu runner to ubuntu-24.04 in Backport workflow ``               |
| [`0db7d025`](https://github.com/danth/stylix/commit/0db7d025edaae15dd603c7c9874212a052ca328f) | `` ci: lock Ubuntu runner to ubuntu-22.04 in Backport workflow ``                 |
| [`1d7b70ed`](https://github.com/danth/stylix/commit/1d7b70ed9ee4c3b24ed6b0c7c64a0ee5fcc4ae10) | `` firefox: add firefoxGnomeTheme.enable option (#702) ``                         |
| [`284c5b03`](https://github.com/danth/stylix/commit/284c5b03578eecbf3c680392ea7d0506834adc6b) | `` ci: run CI on PRs and limit push event to protected branches (#751) ``         |
| [`a6b53aa6`](https://github.com/danth/stylix/commit/a6b53aa677ab9bd9098abbdc47924854c76c3eb1) | `` gnome-text-editor: init (#747) ``                                              |
| [`b47ef3b8`](https://github.com/danth/stylix/commit/b47ef3b8560c3921404d72cec95d84632e355e01) | `` zed: init (#620) ``                                                            |
| [`ad64260a`](https://github.com/danth/stylix/commit/ad64260a75f0331d4d9b0db70f60634283e0aa5d) | `` treewide: add and apply nixfmt pre-commit hook ``                              |
| [`807c8189`](https://github.com/danth/stylix/commit/807c81894e9af60b105476c3dab679e9dc86686f) | `` stylix: add ghc developer shell ``                                             |
| [`708b2147`](https://github.com/danth/stylix/commit/708b2147c095a60994f56714968f00de531f8deb) | `` stylix: add hlint pre-commit hook ``                                           |
| [`439c6cf2`](https://github.com/danth/stylix/commit/439c6cf24e89730d3271baf10e5706df1cdecedf) | `` treewide: add and apply stylish-haskell ``                                     |
| [`4ceede75`](https://github.com/danth/stylix/commit/4ceede75042e362d3270b52d4870702a99915bb0) | `` ci: prevent the Check workflow from running duplicated checks outputs ``       |
| [`d3bdbf0c`](https://github.com/danth/stylix/commit/d3bdbf0c5b4656955be0019e821de6fa65a6bb78) | `` treewide: add and apply yamllint pre-commit hook ``                            |
| [`5ab7d034`](https://github.com/danth/stylix/commit/5ab7d0345a902f5f4c30f9c31ccf42c563ad6463) | `` treewide: add and apply typos pre-commit hook ``                               |
| [`2b85a562`](https://github.com/danth/stylix/commit/2b85a562355c80e1ef2f9070a3a44befdd7c9764) | `` ci: simplify workflows ``                                                      |
| [`fe72c230`](https://github.com/danth/stylix/commit/fe72c2306f517a865c23e9fc92fc72cc408c1ab7) | `` ci: update Ubuntu runner to ubuntu-24.04 ``                                    |
| [`1aa931f6`](https://github.com/danth/stylix/commit/1aa931f6f1eb85b4f8358e7ed3706ed82d3048ca) | `` ci: lock workflow dependencies to increase reproducibility ``                  |
| [`a0838923`](https://github.com/danth/stylix/commit/a0838923e45f63b2b46a132eaa02c45e03e8818a) | `` stylix: add nix-flake-check package ``                                         |
| [`e56d332c`](https://github.com/danth/stylix/commit/e56d332ca367bd021d3c584ac9130064916cd0c7) | `` stylix: add packages to checks output ``                                       |
| [`b3230ef3`](https://github.com/danth/stylix/commit/b3230ef39814b1c3809ffbad20f6361c8b737731) | `` stylix: integrate pre-commit hooks into developer shell ``                     |
| [`0d0af5f4`](https://github.com/danth/stylix/commit/0d0af5f4426104ed82b17d41f8763fcf84b2c0ea) | `` ci: consolidate Build and Lint workflows into single Check workflow ``         |
| [`60855608`](https://github.com/danth/stylix/commit/6085560893ae3620acf8d799dda138b207e6f5ed) | `` stylix: add deadnix and statix pre-commit hooks ``                             |
| [`3c54cb33`](https://github.com/danth/stylix/commit/3c54cb3384116d430e2a83c5d3d3f0dd59eb9ff2) | `` treewide: ignore unused arguments detected by deadnix ``                       |
| [`6ef37ca6`](https://github.com/danth/stylix/commit/6ef37ca6aaf82e59394d0a93acdc932af1739d58) | `` treewide: leverage direnv to automatically enter developer shell ``            |
| [`703f49aa`](https://github.com/danth/stylix/commit/703f49aaca9030b066bb60310d19d7cadfb4b376) | `` treewide: add developer shell ``                                               |
| [`7c8874b3`](https://github.com/danth/stylix/commit/7c8874b311c5ac7429a2384fc116cb9a69aaba84) | `` doc: remove "below" which was moved to a separate page (#727) ``               |
| [`18fd600c`](https://github.com/danth/stylix/commit/18fd600cd2ef008d0c5b23528d9307e97bf1da94) | `` doc: draw attention to release branches (#726) ``                              |
| [`2256b7d7`](https://github.com/danth/stylix/commit/2256b7d74bf2aec90d5c4e9acc7954ccb9cf34cf) | `` micro: init (#716) ``                                                          |
| [`fe25ebfd`](https://github.com/danth/stylix/commit/fe25ebfdc9591601885961183f3edaa9b8babcfb) | `` doc: update copyright year (#715) ``                                           |
| [`e0a41d3a`](https://github.com/danth/stylix/commit/e0a41d3a2562ce1b43cad8560333673d04b111b8) | `` kde: replace systemd unit with AutostartScript for theme application (#708) `` |
| [`0ce2a52d`](https://github.com/danth/stylix/commit/0ce2a52decf36d815065f8cda06586ed59ed3ef7) | `` yazi: add testbed, resolve 0.4.0 breaking changes, and improve names (#719) `` |
| [`6eb0597e`](https://github.com/danth/stylix/commit/6eb0597e345a7f4a16f7d7b14154fc151790b419) | `` ghostty: init (#703) ``                                                        |
| [`90f95c5d`](https://github.com/danth/stylix/commit/90f95c5d8408360fc38cb3a862565bcb08ae6aa8) | `` stylix: point nixpkgs input to more conventional nixos-unstable ref (#712) ``  |
| [`911c07f4`](https://github.com/danth/stylix/commit/911c07f40f816fd2d12a7dd750ca8bc421db9dd2) | `` fctix5: init (#718) ``                                                         |