### PR TITLE
chore(flake/nixvim-flake): `bf22a452` -> `a1aae1d6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -717,11 +717,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1737176735,
-        "narHash": "sha256-dUZJuXnW+h+yaV/hacLNqj9OUj8oUoNTdh4nJipRHzE=",
+        "lastModified": 1737777992,
+        "narHash": "sha256-nsvMr0+Xb3qwcTgNvpC65dsrP31yeXRwAzjnRimEYdc=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "bf22a4525e9fec7119bd5c3624ebbb7ea7cce79b",
+        "rev": "a1aae1d6bed14fc15f72b2dbf63d5223d9adbf4f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`a1aae1d6`](https://github.com/alesauce/nixvim-flake/commit/a1aae1d6bed14fc15f72b2dbf63d5223d9adbf4f) | `` chore(deps): bump DeterminateSystems/magic-nix-cache-action from 8 to 9 (#394) `` |