### PR TITLE
chore(flake/darwin): `bd921223` -> `49b807fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736819234,
-        "narHash": "sha256-deQVtIH4UJueELJqluAICUtX7OosD9paTP+5FgbiSwI=",
+        "lastModified": 1738277753,
+        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "bd921223ba7cdac346477d7ea5204d6f4736fcc6",
+        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                          |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
| [`f1cf8c4f`](https://github.com/LnL7/nix-darwin/commit/f1cf8c4f5a853683494cd93acbdecedb61dfc179) | `` checks: fix sw_vers parameter for macOSVersion (`--productVersion`, not `-productVersion`) `` |
| [`cc9c8408`](https://github.com/LnL7/nix-darwin/commit/cc9c8408bb9f29b4afe919eff4ad922d054cf591) | `` Revert "{activation-scripts,activate-system}: purify environment" ``                          |
| [`3509925a`](https://github.com/LnL7/nix-darwin/commit/3509925a8634f08b764922577d169757b94df97b) | `` readme: make `darwin-rebuild` use more explicit ``                                            |
| [`2733527a`](https://github.com/LnL7/nix-darwin/commit/2733527a586bad9939edc829017acdbc99654d9b) | `` {environment,readme}: default configuration path to `/etc/nix-darwin` ``                      |
| [`5bc4677c`](https://github.com/LnL7/nix-darwin/commit/5bc4677c03b61213912de654a9409d225fd9fe07) | `` readme: reduce duplication in installation instructions ``                                    |
| [`4bff4bc8`](https://github.com/LnL7/nix-darwin/commit/4bff4bc8ae105dbc3a56ed5255fbde9495cbf4c1) | `` {activation-scripts,activate-system}: purify environment ``                                   |
| [`ff80eacd`](https://github.com/LnL7/nix-darwin/commit/ff80eacd0f756fa2c410f9128b114eeb0b4e5bc5) | `` activation-scripts: remove `_status` ``                                                       |
| [`0e87d3d3`](https://github.com/LnL7/nix-darwin/commit/0e87d3d3914321ceea5b10a87f48b6ff6179e190) | `` activate-system: don’t `KeepAlive` ``                                                         |
| [`2119dd10`](https://github.com/LnL7/nix-darwin/commit/2119dd10f65e376dd42f32b0f7ec43577f48129a) | `` checks: remove `darwinChanges` ``                                                             |
| [`1e16e2a9`](https://github.com/LnL7/nix-darwin/commit/1e16e2a9c25b5a15040686be6f07d0ce67043260) | `` ci: use the PR head as `<darwin>` for install test ``                                         |
| [`87b61d66`](https://github.com/LnL7/nix-darwin/commit/87b61d666632de823338039e6a10785b15519ae4) | `` eval-config: omit `enableNixpkgsReleaseCheck` from `lib.evalModules` ``                       |
| [`b5b78887`](https://github.com/LnL7/nix-darwin/commit/b5b7888793329a8c70c216cae9db8a0180b3dcda) | `` nix-tools: set `$NIX_PATH` ``                                                                 |
| [`4d0ae698`](https://github.com/LnL7/nix-darwin/commit/4d0ae6980d128baecf7e7f636e4df4a95740d628) | `` nix-tools: overwrite `$PATH` rather than prepending ``                                        |
| [`c3954c51`](https://github.com/LnL7/nix-darwin/commit/c3954c51c4a02a9ed5455252c09b7b1690cb59bf) | `` checks: remove `runLink` ``                                                                   |
| [`3d95b013`](https://github.com/LnL7/nix-darwin/commit/3d95b013516aa3c97e645ad803d1a497097dab90) | `` nix-tools: make `systemPath` more readable ``                                                 |
| [`02232f71`](https://github.com/LnL7/nix-darwin/commit/02232f71c5712d08d6fb9d0dbedec50509cebbba) | `` nix-tools: drop `nixPackage` ``                                                               |
| [`5665d6c0`](https://github.com/LnL7/nix-darwin/commit/5665d6c05ef73b904e3a8bc37c35b7be1d923f4d) | `` darwin-rebuild: pass `${extraBuildFlags[@]}` to `nix-instantiate` ``                          |
| [`94adbd62`](https://github.com/LnL7/nix-darwin/commit/94adbd6259190f49104f2edfe82d8e8c2073be05) | `` darwin-uninstaller: remove `darwin` channel from `root` too ``                                |
| [`e1976612`](https://github.com/LnL7/nix-darwin/commit/e1976612f0054a8143f37e7ef25c4ef4b88b44bd) | `` system: tweak ShellCheck settings ``                                                          |
| [`8abb2e72`](https://github.com/LnL7/nix-darwin/commit/8abb2e7244b998a9d73818baa744044f8882e68b) | `` nix: add hashes for Determinate Systems installer v0.33.0 and v0.34.0 ``                      |
| [`2fe899db`](https://github.com/LnL7/nix-darwin/commit/2fe899db70f8d2e9162e9ff44eef4f734787b5b1) | `` nix: check `/etc/nix/nix.custom.conf` hash ``                                                 |
| [`4075a3c2`](https://github.com/LnL7/nix-darwin/commit/4075a3c23aa7996acc960e61df9f21038136d08a) | `` Add support for additional window tiling options ``                                           |
| [`f959b887`](https://github.com/LnL7/nix-darwin/commit/f959b8878b2a2e27f2df024930e52cb68b0528be) | `` defaults-write: fix activation script conditionalization ``                                   |
| [`ff1d6384`](https://github.com/LnL7/nix-darwin/commit/ff1d6384dfa276ff4ab092fd9f37a66b5234466c) | `` {environment,nix-tools}: correct default `$PATH` ordering to match macOS ``                   |
| [`47174f38`](https://github.com/LnL7/nix-darwin/commit/47174f38689dba3221883db5f908f7e3ef924ef6) | `` doc/manual: use `--replace-fail` ``                                                           |
| [`fe2fc038`](https://github.com/LnL7/nix-darwin/commit/fe2fc038fd2a63f23bc646b0f3ce022b7c9b3129) | `` defaults/universalaccess: remove docs for macOS < 11 ``                                       |
| [`c5b7b604`](https://github.com/LnL7/nix-darwin/commit/c5b7b604caad7924924f762b603a978c33091552) | `` darwin-rebuild: remove code for macOS < 11 ``                                                 |
| [`8f4f3d8d`](https://github.com/LnL7/nix-darwin/commit/8f4f3d8d2d333248f5edf8bb9ef7c7d3274bf06f) | `` darwin-uninstaller: remove code for macOS < 11 ``                                             |
| [`1c21c941`](https://github.com/LnL7/nix-darwin/commit/1c21c9410eefec51cb7613d38250e49322eb0ab5) | `` system: remove unnecessary `sudo` ``                                                          |
| [`b721000d`](https://github.com/LnL7/nix-darwin/commit/b721000dc6990f3a9ac8e5f8c9fcd7431c4396af) | `` system: add missing newline ``                                                                |
| [`ed6c4aab`](https://github.com/LnL7/nix-darwin/commit/ed6c4aabeae2ae8869a647eee04a45372a74ab56) | `` system: remove code for macOS < 11 ``                                                         |
| [`303a8143`](https://github.com/LnL7/nix-darwin/commit/303a8143a43579d12b4996ad3ab0e8380ae8c8b5) | `` checks: check for macOS ≥ 11.3 ``                                                             |