### PR TITLE
chore(flake/home-manager): `fc52a210` -> `a8159195`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736785676,
-        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
+        "lastModified": 1738275749,
+        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`a8159195`](https://github.com/nix-community/home-manager/commit/a8159195bfaef3c64df75d3b1e6a68d49d392be9) | `` flake-module: fix naming ``                                                                             |
| [`234613d7`](https://github.com/nix-community/home-manager/commit/234613d77c939ff2e2c0f2c476a56d80930e5b8b) | `` neovim: remove with lib ``                                                                              |
| [`86b0f304`](https://github.com/nix-community/home-manager/commit/86b0f3049c3a5f3e8ec13a54a323ed3e2587ed93) | `` hyprland: add null package tests ``                                                                     |
| [`fee01c93`](https://github.com/nix-community/home-manager/commit/fee01c9351638a67ec8605a43f2e535c1c66266f) | `` hyprland: fix null package conditions ``                                                                |
| [`e3baf274`](https://github.com/nix-community/home-manager/commit/e3baf274f47678df6289c7482353cb6d38b7be5d) | `` bat: remove with lib ``                                                                                 |
| [`c90cd85b`](https://github.com/nix-community/home-manager/commit/c90cd85b04ff3348978b05ba73ffc8e1b74b9fce) | `` kitty: remove with lib ``                                                                               |
| [`2d731a33`](https://github.com/nix-community/home-manager/commit/2d731a33b193209cb88b874e508ea912765f7d99) | `` wezterm: remove with lib ``                                                                             |
| [`20fd9686`](https://github.com/nix-community/home-manager/commit/20fd9686b85dc64657a176466e23d0f3a5e1f760) | `` btop: remove with lib; ``                                                                               |
| [`bf2a029b`](https://github.com/nix-community/home-manager/commit/bf2a029bcde2e223db10a0a3fb9a94dc9e833d75) | `` yazi: add khaneliman maintainer ``                                                                      |
| [`d62027e4`](https://github.com/nix-community/home-manager/commit/d62027e44d8ff7adc3306482d3c3b195f21f0004) | `` ripgrep: add khaneliman maintainer ``                                                                   |
| [`9cb98f31`](https://github.com/nix-community/home-manager/commit/9cb98f3140c02e59d70262a0d0b8e8275ff3b6be) | `` lazygit: add khaneliman maintainer ``                                                                   |
| [`cb985acc`](https://github.com/nix-community/home-manager/commit/cb985acc3ca1cc7d44de0f165b89098f9752f737) | `` git: add khaneliman maintainer ``                                                                       |
| [`90b7acd9`](https://github.com/nix-community/home-manager/commit/90b7acd9880ff1809807f5c78af869d4dd5969b5) | `` fzf: add khaneliman maintainer ``                                                                       |
| [`a77b2c18`](https://github.com/nix-community/home-manager/commit/a77b2c186a0ab3d50abc547a18842340d8a84d10) | `` fastfetch: add khaneliman maintainer ``                                                                 |
| [`5a3f7c6d`](https://github.com/nix-community/home-manager/commit/5a3f7c6d078557ada97938a41adb05c27f52325e) | `` direnv: add khaneliman maintainer ``                                                                    |
| [`6a988979`](https://github.com/nix-community/home-manager/commit/6a988979464c3ca13d146ab16bb6996ad86d9b37) | `` nix-index: add khaneliman maintainer ``                                                                 |
| [`c72b699e`](https://github.com/nix-community/home-manager/commit/c72b699ec6d16f449a34b980d6d4898f231ada6b) | `` btop: add khaneliman maintainer ``                                                                      |
| [`34e28fc6`](https://github.com/nix-community/home-manager/commit/34e28fc6ddeab63f4c9aa1262b24e8bd1197d613) | `` bat: add khaneliman maintainer ``                                                                       |
| [`05c64fa7`](https://github.com/nix-community/home-manager/commit/05c64fa76b2dfbf4a3f5fbca916bcc7f434739d7) | `` ghostty: add khaneliman maintainer ``                                                                   |
| [`178f8265`](https://github.com/nix-community/home-manager/commit/178f8265cbbe72415dcc3759debebf15f308f0bc) | `` kitty: add khaneliman maintainer ``                                                                     |
| [`ebdbb381`](https://github.com/nix-community/home-manager/commit/ebdbb381034f4af008aed45cd3bdf873b1443792) | `` wezterm: add khaneliman maintainer ``                                                                   |
| [`06bc3541`](https://github.com/nix-community/home-manager/commit/06bc354189e5a7d94b691779f9cb3ac00bab8bce) | `` neovim: add khaneliman maintainer ``                                                                    |
| [`c3031a0e`](https://github.com/nix-community/home-manager/commit/c3031a0e8c988fdf2880c98ce5fbab7ee637e8ad) | `` waybar: add khaneliman maintainer ``                                                                    |
| [`9a97ac43`](https://github.com/nix-community/home-manager/commit/9a97ac435e3da2a2abf465a0ddd22ce022418495) | `` swaync: add khaneliman maintainer ``                                                                    |
| [`9ee99be0`](https://github.com/nix-community/home-manager/commit/9ee99be0c03f30cf3351917402216d256181c4c1) | `` cliphist: add khaneliman maintainer ``                                                                  |
| [`a5e196d6`](https://github.com/nix-community/home-manager/commit/a5e196d61f6e564f7fdeeb4a92cef92e1785d3f5) | `` flake-module: add flake-parts module (#5229) ``                                                         |
| [`7a457746`](https://github.com/nix-community/home-manager/commit/7a457746847c9cb3a1e46e5bc86b205fbadf5da8) | `` aerospace: enable option desc fix (#6375) ``                                                            |
| [`c621c26c`](https://github.com/nix-community/home-manager/commit/c621c26c4c1ea6e0a9a01c3ca33ef62da5ee155d) | `` aerospace: cleanup ``                                                                                   |
| [`d963ed33`](https://github.com/nix-community/home-manager/commit/d963ed335b890a70ed53eecf14cdb21528eda9b8) | `` linux-wallpaperengine: add module ``                                                                    |
| [`41f3dbd7`](https://github.com/nix-community/home-manager/commit/41f3dbd795fd89017232c1a6a90dc9d760334ef8) | `` linux-wallpaperengine: add ckgxrg as maintainer ``                                                      |
| [`86a0d627`](https://github.com/nix-community/home-manager/commit/86a0d627cae02e8cc5d29eeb03de97f8c652a4bb) | `` home-manger: fix runtime closure (#5174) ``                                                             |
| [`9ce5d0b8`](https://github.com/nix-community/home-manager/commit/9ce5d0b888a054945121394297ad34173d135547) | `` xdg-autostart: add module (#5251) ``                                                                    |
| [`7636b248`](https://github.com/nix-community/home-manager/commit/7636b248675e00d887ec0e6932c316d87f36dbf3) | `` hyprland: make package nullable (#5742) ``                                                              |
| [`ba3338ab`](https://github.com/nix-community/home-manager/commit/ba3338ab990e4348a4e57fc4fdac758524cf7029) | `` waybar: allow setting layer to overlay (#5729) ``                                                       |
| [`697ba131`](https://github.com/nix-community/home-manager/commit/697ba1319fdc58c94dc94cd7908df554dc48d970) | `` waybar: allow setting systemd.target to null (#6241) ``                                                 |
| [`6fbbfb92`](https://github.com/nix-community/home-manager/commit/6fbbfb92409bf999fd80b78c7f7bc145d2d36f39) | `` Revert "thunderbird: add native host support (#6292)" (#6371) ``                                        |
| [`79eff1f6`](https://github.com/nix-community/home-manager/commit/79eff1f6b95c059ed0f9dfae9fd16689c1dda5ca) | `` zsh: added HIST_SAVE_NO_DUPS and HIST_FIND_NO_DUPS options to zsh for history configuration. (#6227) `` |
| [`6aa38ffd`](https://github.com/nix-community/home-manager/commit/6aa38ffdf77fb4250f5d832fd5a09eb99226fba7) | `` atuin: set socket path for darwin (#6248) ``                                                            |
| [`608b26d1`](https://github.com/nix-community/home-manager/commit/608b26d16ee69384580b1b14ac947d81d0240beb) | `` thunderbird: add native host support (#6292) ``                                                         |
| [`d5e5c0d0`](https://github.com/nix-community/home-manager/commit/d5e5c0d051d8d4f293d8c7550c167597427e058b) | `` aerospace: add module (#6279) ``                                                                        |
| [`d71828a7`](https://github.com/nix-community/home-manager/commit/d71828a7dd0dc53cf3994e8737c84b4180cc6dfa) | `` ghostty: allow darwin users to manager their config (#6300) ``                                          |
| [`c4650fb9`](https://github.com/nix-community/home-manager/commit/c4650fb9c0c4c8f7e1a43e6d72378246a4b50f3b) | `` cliphist: support multiple systemdTargets properly (#5669) ``                                           |
| [`5dc1c2e4`](https://github.com/nix-community/home-manager/commit/5dc1c2e40410f7dabef3ba8bf4fdb3145eae3ceb) | `` hyprland: add xdg.portal configuration (#5707) ``                                                       |
| [`0ee8bfdd`](https://github.com/nix-community/home-manager/commit/0ee8bfdd04de611a93cf57dda01686b613cc587d) | `` firefox: add preConfig ``                                                                               |
| [`bd530df4`](https://github.com/nix-community/home-manager/commit/bd530df4e284310fee0fada3562de908009e1236) | `` firefox: avoid unnecessarily overriding package ``                                                      |
| [`82455a84`](https://github.com/nix-community/home-manager/commit/82455a84e32af01c66e326e5a188795f324975a1) | `` nushell: allow multi-word aliases ``                                                                    |
| [`709aaab1`](https://github.com/nix-community/home-manager/commit/709aaab1a5c35a8d1f1e7546efa226e09f3316fb) | `` nushell: set env in config.nu file ``                                                                   |
| [`46c83c07`](https://github.com/nix-community/home-manager/commit/46c83c07b9a97a8f7633dd162dd9a3bbe511195b) | `` nushell: add settings option ``                                                                         |
| [`a1df6c4c`](https://github.com/nix-community/home-manager/commit/a1df6c4c76a839661207105daa519e3de3b5fe15) | `` nushell: slight refactor ``                                                                             |
| [`1b4f2a48`](https://github.com/nix-community/home-manager/commit/1b4f2a48168b3d90e11365552d1e7e601a4be6b6) | `` zed-editor: add installRemoteServer option ``                                                           |
| [`0a64a209`](https://github.com/nix-community/home-manager/commit/0a64a209aa3c0e5ae528b9f25c3c5e9bb735dbb3) | `` flake.lock: Update ``                                                                                   |
| [`e1ae908b`](https://github.com/nix-community/home-manager/commit/e1ae908bcc30af792b0bb0a52e53b03d2577255e) | `` flake.lock: Update ``                                                                                   |
| [`daf04c59`](https://github.com/nix-community/home-manager/commit/daf04c5950b676f47a794300657f1d3d14c1a120) | `` ollama: add darwin support ``                                                                           |
| [`1b9fe46e`](https://github.com/nix-community/home-manager/commit/1b9fe46e9fc3575eeb63ef42d73144e397593904) | `` home-manager: move tests into new test flake ``                                                         |
| [`b93e17c7`](https://github.com/nix-community/home-manager/commit/b93e17c73cca670460d0604c00ba0571eb5d4cad) | `` neovim: fix flaky test ``                                                                               |
| [`15f7f9bc`](https://github.com/nix-community/home-manager/commit/15f7f9bc4e7aedcdd26e2f20fc4b46220ead584d) | `` himalaya: fix tests ``                                                                                  |
| [`e9068fac`](https://github.com/nix-community/home-manager/commit/e9068facd7bcfb99405d0e5e3b938f5e5ddc38e0) | `` himalaya: adjust package for released v1.0.0 ``                                                         |
| [`2ae3dd46`](https://github.com/nix-community/home-manager/commit/2ae3dd460f60822434959a92e8e19c9f9b7efce2) | `` himalaya: add xdg desktop entry ``                                                                      |
| [`5f5a9d5c`](https://github.com/nix-community/home-manager/commit/5f5a9d5cd23e6ff7f877ec66b498bb02585a72b0) | `` himalaya: make use of lib.getExe ``                                                                     |
| [`44ee9bc8`](https://github.com/nix-community/home-manager/commit/44ee9bc826770df1ab83c7e93f77fdaddd37523a) | `` himalaya: improve service ``                                                                            |
| [`a0428685`](https://github.com/nix-community/home-manager/commit/a0428685572b134f6594e7d7f5db5e1febbab2d7) | `` nh: remove PATH assignment in nh-clean systemd unit ``                                                  |
| [`a2362a64`](https://github.com/nix-community/home-manager/commit/a2362a64964c406ba3b289a474fbde573f4b7fc9) | `` nh: check osConfig for null before accessing ``                                                         |
| [`7b9ece1b`](https://github.com/nix-community/home-manager/commit/7b9ece1bf3c8780cde9b975b28c2d9ccd7e9cdb9) | `` tealdeer: update docs link ``                                                                           |
| [`0db5c8bf`](https://github.com/nix-community/home-manager/commit/0db5c8bfcce78583ebbde0b2abbc95ad93445f7c) | `` ghostty: add keybinds to settings example ``                                                            |
| [`01d01729`](https://github.com/nix-community/home-manager/commit/01d0172933845daaf3392f6b8c3953995e912f6e) | `` wezterm: update expected test result ``                                                                 |
| [`b17008a7`](https://github.com/nix-community/home-manager/commit/b17008a795066bd3b4da86d7614a3be0efb0092e) | `` swayr: update expected test result ``                                                                   |
| [`4806e9c0`](https://github.com/nix-community/home-manager/commit/4806e9c021e8f1d78b0bb7bc4ecc75d27a31a4bb) | `` flake.lock: Update ``                                                                                   |
| [`1757aca1`](https://github.com/nix-community/home-manager/commit/1757aca1640bebd7495f2784844f21a8dd712f8d) | `` go: stub systemd dependency in test ``                                                                  |
| [`cefb1889`](https://github.com/nix-community/home-manager/commit/cefb1889b96ddd1dac3dd4734e894f4cadab7802) | `` Translate using Weblate (Czech) ``                                                                      |
| [`4481a16d`](https://github.com/nix-community/home-manager/commit/4481a16d1ac5bff4a77c608cefe08c9b9efe840d) | `` yazi: improve fish integration ``                                                                       |
| [`96dee79b`](https://github.com/nix-community/home-manager/commit/96dee79b178d295b716052feca3ee46abc085abe) | `` lsd: remove with lib; ``                                                                                |
| [`bb14224f`](https://github.com/nix-community/home-manager/commit/bb14224f51ae4caed12a7b26f245d042c8cf8553) | `` mu: allow option to set muhome ``                                                                       |
| [`0b8df9ee`](https://github.com/nix-community/home-manager/commit/0b8df9eeb66941ef32e5761ecf4cddff91e5c020) | `` lsd: add support for icons.yaml ``                                                                      |
| [`9786661d`](https://github.com/nix-community/home-manager/commit/9786661d57c476021c8a0c3e53bf9fa2b4f3328b) | `` fcitx5: allow to set fcitx5-with-addons (#5770) ``                                                      |
| [`f8ef4541`](https://github.com/nix-community/home-manager/commit/f8ef4541bb8a54a8b52f19b52912119e689529b3) | `` nixpkgs: lib.isFunction replaces builtins.isFunction in check for overlayType (#6338) ``                |
| [`97d7946b`](https://github.com/nix-community/home-manager/commit/97d7946b5e107dd03cc82f21165251d4e0159655) | `` {hypridle, hyrpaper}: remove with lib; (#6318) ``                                                       |
| [`1c75a4c1`](https://github.com/nix-community/home-manager/commit/1c75a4c151dfe417c73ae3f87a6eba0b009c438c) | `` syncthing: have tray wait for bar to load (#6290) ``                                                    |
| [`1e364297`](https://github.com/nix-community/home-manager/commit/1e36429705f9af2d00a517ba46a4f21ef8a8194f) | `` sbt: allow irregular plugins to be configured ``                                                        |
| [`495de1e1`](https://github.com/nix-community/home-manager/commit/495de1e197e7e113ad8877dad4c29a66482a093c) | `` Translate using Weblate (Danish) ``                                                                     |
| [`a0046af1`](https://github.com/nix-community/home-manager/commit/a0046af169ce7b1da503974e1b22c48ef4d71887) | `` Translations update from Hosted Weblate ``                                                              |
| [`12851ae7`](https://github.com/nix-community/home-manager/commit/12851ae7467bad8ef422b20806ab4d6d81e12d29) | `` thunderbird: Enable tests for Darwin (#6324) ``                                                         |
| [`0dfec9de`](https://github.com/nix-community/home-manager/commit/0dfec9deb275854a56c97c356c40ef72e3a2e632) | `` hyprlock: remove with lib; ``                                                                           |
| [`a1f180af`](https://github.com/nix-community/home-manager/commit/a1f180af1710c2b4a2b9e1a8f6d8871840497393) | `` hyprlock: add bezier to importantPrefixes ``                                                            |