### PR TITLE
chore(flake/stylix): `965d1cb7` -> `b00c9f46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "base16-helix": {
       "flake": false,
       "locked": {
-        "lastModified": 1725860795,
-        "narHash": "sha256-Z2o8VBPW3I+KKTSfe25kskz0EUj7MpUh8u355Z1nVsU=",
+        "lastModified": 1736852337,
+        "narHash": "sha256-esD42YdgLlEh7koBrSqcT7p2fsMctPAcGl/+2sYJa2o=",
         "owner": "tinted-theming",
         "repo": "base16-helix",
-        "rev": "7f795bf75d38e0eea9fed287264067ca187b88a9",
+        "rev": "03860521c40b0b9c04818f2218d9cc9efc21e7a5",
         "type": "github"
       },
       "original": {
@@ -69,16 +69,17 @@
     "base16-vim": {
       "flake": false,
       "locked": {
-        "lastModified": 1731949548,
-        "narHash": "sha256-XIDexXM66sSh5j/x70e054BnUsviibUShW7XhbDGhYo=",
+        "lastModified": 1732806396,
+        "narHash": "sha256-e0bpPySdJf0F68Ndanwm+KWHgQiZ0s7liLhvJSWDNsA=",
         "owner": "tinted-theming",
         "repo": "base16-vim",
-        "rev": "61165b1632409bd55e530f3dbdd4477f011cadc6",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "base16-vim",
+        "rev": "577fe8125d74ff456cf942c733a85d769afe58b7",
         "type": "github"
       }
     },
@@ -127,11 +128,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1734969791,
-        "narHash": "sha256-A9PxLienMYJ/WUvqFie9qXrNC2MeRRYw7TG/q7DRjZg=",
+        "lastModified": 1736899990,
+        "narHash": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "92f4890bd150fc9d97b61b3583680c0524a8cafe",
+        "rev": "91ca1f82d717b02ceb03a3f423cbe8082ebbb26d",
         "type": "github"
       },
       "original": {
@@ -189,11 +190,11 @@
     "flake-compat_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
         "type": "github"
       },
       "original": {
@@ -357,19 +358,14 @@
         "nixpkgs": [
           "stylix",
           "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "stylix",
-          "git-hooks",
-          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1735882644,
+        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
         "type": "github"
       },
       "original": {
@@ -815,11 +811,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1736882096,
-        "narHash": "sha256-TQFkQ6RN8L/Xto5Ttt6hwJInFI5Nz2uCfXg5ci2q6UA=",
+        "lastModified": 1738278499,
+        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "965d1cb7c84170200b4f05e68ebd27a88d171e8c",
+        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
         "type": "github"
       },
       "original": {
@@ -895,11 +891,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1729501581,
-        "narHash": "sha256-1ohEFMC23elnl39kxWnjzH1l2DFWWx4DhFNNYDTYt54=",
+        "lastModified": 1735737224,
+        "narHash": "sha256-FO2hRBkZsjlIRqzNHCPc/52yxg11kHGA8MEtSun9RwE=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "f0e7f7974a6441033eb0a172a0342e96722b4f14",
+        "rev": "aead506a9930c717ebf81cc83a2126e9ca08fa64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                      |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b00c9f46`](https://github.com/danth/stylix/commit/b00c9f46ae6c27074d24d2db390f0ac5ebcc329f) | `` nixcord: theme Vencord and Vesktop instead of just Vencord ``             |
| [`d9df2b42`](https://github.com/danth/stylix/commit/d9df2b4200ba53a0944c3d2c6d242095e523d3d9) | `` kde: add decorations option and polish code (#772) ``                     |
| [`55418e8f`](https://github.com/danth/stylix/commit/55418e8fc8d4696af619176a22cefcfac56ad2ef) | `` stylix: downgrade and lock base16-vim input (#811) ``                     |
| [`e646a134`](https://github.com/danth/stylix/commit/e646a134db5f4dcaf4fff4e8232229ae5f468cef) | `` waybar: fix typo (#810) ``                                                |
| [`e81bd0cf`](https://github.com/danth/stylix/commit/e81bd0cffadaffecd18b65301628cc4b9b0dbea3) | `` waybar: add addCss option (#804) ``                                       |
| [`6103431c`](https://github.com/danth/stylix/commit/6103431cd2f9d4352e5493a4063cf57e307d355c) | `` doc: Update tricks per tinted-theming schema changes (#792) ``            |
| [`d5f02b54`](https://github.com/danth/stylix/commit/d5f02b541064763ada8b917834d55142af07b55c) | `` ghostty: be consistent with other terminals (#806) ``                     |
| [`d6951d0b`](https://github.com/danth/stylix/commit/d6951d0b2ffe74e4779a180e9b6a0e17627756e1) | `` vesktop: change theme location on nix-darwin (#784) ``                    |
| [`7c1c3259`](https://github.com/danth/stylix/commit/7c1c3259283f2da9c3d15c9096e7b8864f82bd4c) | `` ci: remove Magic Nix Cache (#745) ``                                      |
| [`5e8be752`](https://github.com/danth/stylix/commit/5e8be7521e8f7cc927c92f24f8753e64ec050cdf) | `` treewide: simplify and standardize message convention (#796) ``           |
| [`58b54b66`](https://github.com/danth/stylix/commit/58b54b664b7c67929cd0b5e6221cecbed3eab233) | `` doc: elaborate pre-commit hook usage in development environment (#793) `` |
| [`e594886e`](https://github.com/danth/stylix/commit/e594886eb0951a0a0c28ffa333a9df6fb13857a1) | `` nixcord: init (#767) ``                                                   |
| [`36c39ff0`](https://github.com/danth/stylix/commit/36c39ff014a8abbc682a073b2c5ba6cea77cf41e) | `` gnome: fix foreground color of transparent panels (#788) ``               |
| [`268daf22`](https://github.com/danth/stylix/commit/268daf22a1f93a00b7efc74c367d6711ca7f18e1) | `` eog: init (#781) ``                                                       |
| [`6b69fd47`](https://github.com/danth/stylix/commit/6b69fd47fa86a3258b73168524cd196132549162) | `` firefox: support floorp browser (#785) ``                                 |
| [`76b1f6eb`](https://github.com/danth/stylix/commit/76b1f6eb1d401e91571f7691abd6b0a976eb34cd) | `` stylix: add jq to runtimeInputs (#782) ``                                 |
| [`51ad2cec`](https://github.com/danth/stylix/commit/51ad2cec11e773a949bdbec88bed2524f098f49a) | `` cavalier: init (#758) ``                                                  |
| [`e00ed7e7`](https://github.com/danth/stylix/commit/e00ed7e7f4b828f8b12c5056a6167890e59854ce) | `` wpaperd: fix image scaling modes (#710) ``                                |
| [`a88c4d26`](https://github.com/danth/stylix/commit/a88c4d264a4379b7fe5a9e75ed51bea96f8dd407) | `` stylix: update all flake inputs (#774) ``                                 |
| [`def1e485`](https://github.com/danth/stylix/commit/def1e485d5481f5e7df5465a22d8cf6c3d433ede) | `` stylix: make nix-flake-check package execution location-independent ``    |
| [`0365d80e`](https://github.com/danth/stylix/commit/0365d80e2d3348bb8ad60dd0ef07474592387265) | `` stylix: decrease verbosity level of nix-flake-check package ``            |
| [`0969c2e7`](https://github.com/danth/stylix/commit/0969c2e792c942dc95d98381fa389340bbff10bb) | `` stylix: colorize and prefix nix-flake-check output ``                     |
| [`e88850f9`](https://github.com/danth/stylix/commit/e88850f9c27bd61a0452921e9c30210ee1a1ef06) | `` stylix: add progress bar to nix-flake-check package ``                    |