### PR TITLE
chore(flake/nix-index-database): `271e5bd7` -> `79b7b8ea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -634,11 +634,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736652904,
-        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
+        "lastModified": 1737861961,
+        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
+        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`79b7b8ea`](https://github.com/nix-community/nix-index-database/commit/79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523) | `` update generated.nix to release 2025-01-26-030915 `` |
| [`a07b10ac`](https://github.com/nix-community/nix-index-database/commit/a07b10ac6326546b93920b6345ee18f41bba6849) | `` flake.lock: Update ``                                |
| [`744d3306`](https://github.com/nix-community/nix-index-database/commit/744d330659e207a1883d2da0141d35e520eb87bd) | `` update generated.nix to release 2025-01-19-031135 `` |
| [`5b1c0594`](https://github.com/nix-community/nix-index-database/commit/5b1c05942acc51e9cb5a4ad214b2292f8401af67) | `` flake.lock: Update ``                                |