### PR TITLE
chore(flake/darwin): `49b807fa` -> `678b2264`

### DIFF
--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,10 +43,7 @@
   };
 
   services = {
-    nix-daemon = {
-      enable = true;
-      logFile = "/var/log/nix-daemon.log";
-    };
+    nix-daemon.logfile = "/var/log/nix-daemon.log";
   };
 
   system = {

--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,10 +43,7 @@
   };
 
   services = {
-    nix-daemon = {
-      enable = true;
-      logFile = "/var/log/nix-daemon.log";
-    };
+    nix-daemon.logFile = "/var/log/nix-daemon.log";
   };
 
   system = {

--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,7 +43,10 @@
   };
 
   services = {
-    nix-daemon.logfile = "/var/log/nix-daemon.log";
+    nix-daemon = {
+      enable = true;
+      logFile = "/var/log/nix-daemon.log";
+    };
   };
 
   system = {

--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737861961,
-        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
+        "lastModified": 1739071773,
+        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
+        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -208,11 +208,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -661,14 +661,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "nixvim": {

--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738277753,
-        "narHash": "sha256-iyFcCOk0mmDiv4ut9mBEuMxMZIym3++0qN1rQBg8FW0=",
+        "lastModified": 1739548217,
+        "narHash": "sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "49b807fa7c37568d7fbe2aeaafb9255c185412f9",
+        "rev": "678b22642abde2ee77ae2218ab41d802f010e5b0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -807,15 +807,16 @@
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738278499,
-        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
+        "lastModified": 1739375014,
+        "narHash": "sha256-0fNbvZ1Dod4rDIfwGnC7CzJ3wRFSF1v5AvNCmNkVgXo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
+        "rev": "e86de61bb8f5f2b6459d0be3e3291ad16db4b777",
         "type": "github"
       },
       "original": {
@@ -885,6 +886,22 @@
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
         "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737565458,
+        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1738648605,
-        "narHash": "sha256-/XCACYEb7A/h0w+0HvarL+yr/F/pV6gSBKqs5jfamBY=",
+        "lastModified": 1738874334,
+        "narHash": "sha256-kc8kVqPtqbpyVbExHVDVuqVzBwdxBPpSFNdE0F24EAI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "0d9edd6fb1e4ff45cd4a580b1f31d4ee8e24ce93",
+        "rev": "251b8011399efa0a57dc1ff03cf2924ffc9b844c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -645,11 +645,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
| [`5926058a`](https://github.com/LnL7/nix-darwin/commit/5926058aecd67ec1bf5030b5a419c260876ea9ba) | `` nix: place `extra-`prefixed settings after their non-prefixed variants ``           |
| [`731910af`](https://github.com/LnL7/nix-darwin/commit/731910af010086c4dbe23eb6ae79d81bcec703aa) | `` {activation-scripts,activate-system}: check `gcroots` before linking ``             |
| [`cd445c54`](https://github.com/LnL7/nix-darwin/commit/cd445c546561d5ca4e9124cb4668ce80939ac0c9) | `` nix: catch reads of unmanaged defaults ``                                           |
| [`d677e3e8`](https://github.com/LnL7/nix-darwin/commit/d677e3e844e21789c6f39a90aacadf6dc777ca42) | `` nix-tools: only pass `config.nix.nixPath` through if `nix.enable` ``                |
| [`42e16f31`](https://github.com/LnL7/nix-darwin/commit/42e16f31c6faf29a51a2aa15aeff64934bf5d157) | `` cachix-agent: check for `nix.enable` ``                                             |
| [`e3bde158`](https://github.com/LnL7/nix-darwin/commit/e3bde1588bc6b4cf774197228330139338a4a12c) | `` github-runner: check for `nix.enable` ``                                            |
| [`f4e2805e`](https://github.com/LnL7/nix-darwin/commit/f4e2805e19f84420538590ff4e91b1bfa2e79784) | `` ofborg: check for `nix.enable` ``                                                   |
| [`aba0c60e`](https://github.com/LnL7/nix-darwin/commit/aba0c60ebab549f69ece1622d99ffc5e6ad81af3) | `` lorri: check for `nix.enable` ``                                                    |
| [`57c93ffe`](https://github.com/LnL7/nix-darwin/commit/57c93ffe6cbb627e5c9d10ceae7b31e68ba945ac) | `` hercules-ci-agent: check for `nix.enable` ``                                        |
| [`147ed950`](https://github.com/LnL7/nix-darwin/commit/147ed950e382ef45d083f060b4529df817077069) | `` nixpkgs-flake: check for `nix.enable` ``                                            |
| [`7cca8f95`](https://github.com/LnL7/nix-darwin/commit/7cca8f95f7761bff239066306148714e560cbc2e) | `` linux-builder: check for `nix.enable` ``                                            |
| [`0176a508`](https://github.com/LnL7/nix-darwin/commit/0176a5082ba8450e1480204a824ed188cdc81600) | `` nix-optimise: check for `nix.enable` ``                                             |
| [`fc9367a9`](https://github.com/LnL7/nix-darwin/commit/fc9367a9ec8ce3527291fc3bfc1b12c0260bc676) | `` nix-gc: check for `nix.enable` ``                                                   |
| [`c31b6e8a`](https://github.com/LnL7/nix-darwin/commit/c31b6e8a0305fee46238387a3462ec060e377500) | `` homebrew: use `mas` from Nixpkgs ``                                                 |
| [`a2e44a84`](https://github.com/LnL7/nix-darwin/commit/a2e44a84be1c6b951d1764a1d44fff37d8fc59f5) | `` changelog: document changes to Nix installation management ``                       |
| [`00a8cb30`](https://github.com/LnL7/nix-darwin/commit/00a8cb30fa7d52681f3445de672db95479b83d8c) | `` readme: update information about Determinate ``                                     |
| [`03877755`](https://github.com/LnL7/nix-darwin/commit/03877755e9f67e584381ecde74ed2c030639aa0c) | `` checks: add check for Determinate ``                                                |
| [`fb2bc03f`](https://github.com/LnL7/nix-darwin/commit/fb2bc03f922d406621928a80b28225340cb2b070) | `` activation-scripts: add unmanaged system Nix to activation path ``                  |
| [`8a94b5b9`](https://github.com/LnL7/nix-darwin/commit/8a94b5b99bfa6aec7846bec63eba93d05f8f44d8) | `` nix-daemon: remove `services.nix-daemon.enable` ``                                  |
| [`adc989f7`](https://github.com/LnL7/nix-darwin/commit/adc989f7ec9efd8bb4e1b6b48c15f4c0f41be018) | `` nix: remove `nix.configureBuildUsers` ``                                            |
| [`c796587d`](https://github.com/LnL7/nix-darwin/commit/c796587d2ef4ab06f84c4f740931f579f719b6f5) | `` nix: remove `nix.useDaemon` ``                                                      |
| [`e182d8df`](https://github.com/LnL7/nix-darwin/commit/e182d8dff6bd3b0913ae6531c6abae3ed1e38364) | `` nix: add `nix.enable` option to disable Nix management ``                           |
| [`d634e28f`](https://github.com/LnL7/nix-darwin/commit/d634e28f67b5e1fc82b3ea107fbd9b3a3abf3a7b) | `` users: use `launchctl managername` to determine session type ``                     |
| [`0824c138`](https://github.com/LnL7/nix-darwin/commit/0824c13801d18722a5dd7827f575f5c42e80ad43) | `` checks: fix macOS version check exit code ``                                        |
| [`da331139`](https://github.com/LnL7/nix-darwin/commit/da3311397a1a2ba1a02f026cce1700a3556279cc) | `` Revert "nixpkgs: make config.nixpkgs.{buildPlatform,hostPlatform} write only" ``    |
| [`3f6f5124`](https://github.com/LnL7/nix-darwin/commit/3f6f512406d852afa0e54118b2002896da66fd3e) | `` users: fix typo ``                                                                  |
| [`9b9c9a57`](https://github.com/LnL7/nix-darwin/commit/9b9c9a57b626d72c4def5c2ddb7253bccb19c75d) | `` nix: don’t set `$NIX_REMOTE` ``                                                     |
| [`8f227c40`](https://github.com/LnL7/nix-darwin/commit/8f227c405e0d42dfdbfce9849c689152c083a48b) | `` nix: fix typo in assertion conditional ``                                           |
| [`1f7ed1c7`](https://github.com/LnL7/nix-darwin/commit/1f7ed1c7fe20d9b9d410c4f385a7d13ae1f4349e) | `` checks: remove `nixChannels` check ``                                               |
| [`7c72c013`](https://github.com/LnL7/nix-darwin/commit/7c72c013b160627540b8b465a05ba258f47a16d8) | `` nixpkgs: make config.nixpkgs.{buildPlatform,hostPlatform} write only ``             |
| [`5084b332`](https://github.com/LnL7/nix-darwin/commit/5084b33265f1c14551af63e61ec8bb75fec3ccbc) | `` git-blame-ignore-revs: add `nixpkgs` module formatting commit ``                    |
| [`dc1c716d`](https://github.com/LnL7/nix-darwin/commit/dc1c716ded39758062ed7e6bc410ad274119de9f) | `` nixpkgs: format with `nixfmt` ``                                                    |
| [`80eddf2b`](https://github.com/LnL7/nix-darwin/commit/80eddf2bf743620faab78d06846d9478fb21aa3b) | `` nixpkgs: show definition files in `config` assertion ``                             |
| [`e84e84a2`](https://github.com/LnL7/nix-darwin/commit/e84e84a2566a1b431686c9c5ed45b01e1fdcf831) | `` nixpkgs: fix `config` assertion text ``                                             |
| [`bd1d4676`](https://github.com/LnL7/nix-darwin/commit/bd1d46766afb73b87b0e07172ca6a00a036d03da) | `` nixpkgs: remove `with lib;` ``                                                      |
| [`320bf025`](https://github.com/LnL7/nix-darwin/commit/320bf025d22ae9c50a410bef27596b945be65889) | `` nixpkgs: link to Nixpkgs manual for global configuration options ``                 |
| [`6b81859e`](https://github.com/LnL7/nix-darwin/commit/6b81859ed0e35f052043384c7febb853176bc500) | `` nixpkgs: fix determination for cross-compiled nix-darwin system ``                  |
| [`2df9e481`](https://github.com/LnL7/nix-darwin/commit/2df9e4811008fca085d15f67b51cd7bc497a17bb) | `` nixpkgs: use less confusing example systems ``                                      |
| [`3cd3a79f`](https://github.com/LnL7/nix-darwin/commit/3cd3a79f9ba7f6c3421f4f7fd557b4c8666e7183) | `` nixpkgs: Rewrite overlays option docs ``                                            |
| [`962eb3f1`](https://github.com/LnL7/nix-darwin/commit/962eb3f1c0c2d5e4ac92eb8bfc91333d3b1cb0e7) | `` nixpkgs: assert that nixpkgs.config is not set when pkgs is passed in externally `` |
| [`5b0cffee`](https://github.com/LnL7/nix-darwin/commit/5b0cffeec2973101432f7a6ce5644e73ca661618) | `` nixpkgs: fix undefined variable in assertion ``                                     |