### PR TITLE
chore(flake/home-manager): `a8159195` -> `6d3163ae`

### DIFF
--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,10 +43,7 @@
   };
 
   services = {
-    nix-daemon = {
-      enable = true;
-      logFile = "/var/log/nix-daemon.log";
-    };
+    nix-daemon.logfile = "/var/log/nix-daemon.log";
   };
 
   system = {

--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,10 +43,7 @@
   };
 
   services = {
-    nix-daemon = {
-      enable = true;
-      logFile = "/var/log/nix-daemon.log";
-    };
+    nix-daemon.logFile = "/var/log/nix-daemon.log";
   };
 
   system = {

--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -43,7 +43,10 @@
   };
 
   services = {
-    nix-daemon.logfile = "/var/log/nix-daemon.log";
+    nix-daemon = {
+      enable = true;
+      logFile = "/var/log/nix-daemon.log";
+    };
   };
 
   system = {

--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737861961,
-        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
+        "lastModified": 1739071773,
+        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
+        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -486,11 +486,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739571712,
-        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
+        "lastModified": 1740679976,
+        "narHash": "sha256-6U/zvgtcGJqpOTKsIgf+mRO7/djwV07ImU/t0nZBix8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
+        "rev": "343646e092696d94b6f22b6875ae685756fd4cf0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -208,11 +208,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1736143030,
-        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "lastModified": 1738453229,
+        "narHash": "sha256-7H9XgNiGLKN1G1CgRh0vUL4AheZSYzPm+zmZ7vxbJdo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "rev": "32ea77a06711b758da0ad9bd6a844c5740a87abd",
         "type": "github"
       },
       "original": {
@@ -661,14 +661,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1735774519,
-        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "lastModified": 1738452942,
+        "narHash": "sha256-vJzFZGaCpnmo7I6i416HaBLpC+hvcURh/BQwROcGIp8=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
     "nixvim": {

--- a/flake.lock
+++ b/flake.lock
@@ -807,15 +807,16 @@
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738278499,
-        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
+        "lastModified": 1739375014,
+        "narHash": "sha256-0fNbvZ1Dod4rDIfwGnC7CzJ3wRFSF1v5AvNCmNkVgXo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
+        "rev": "e86de61bb8f5f2b6459d0be3e3291ad16db4b777",
         "type": "github"
       },
       "original": {
@@ -885,6 +886,22 @@
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
         "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737565458,
+        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -713,11 +713,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1738648605,
-        "narHash": "sha256-/XCACYEb7A/h0w+0HvarL+yr/F/pV6gSBKqs5jfamBY=",
+        "lastModified": 1738874334,
+        "narHash": "sha256-kc8kVqPtqbpyVbExHVDVuqVzBwdxBPpSFNdE0F24EAI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "0d9edd6fb1e4ff45cd4a580b1f31d4ee8e24ce93",
+        "rev": "251b8011399efa0a57dc1ff03cf2924ffc9b844c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -645,11 +645,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738142207,
-        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -486,11 +486,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738275749,
-        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
+        "lastModified": 1739571712,
+        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
+        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
| [`6d3163ae`](https://github.com/nix-community/home-manager/commit/6d3163aea47fdb1fe19744e91306a2ea4f602292) | `` git: change stateVersion check for compatiblity (#6453) ``                                                     |
| [`67b9f9de`](https://github.com/nix-community/home-manager/commit/67b9f9de22c78bd1d2cf45583bfb18470d1d3ef8) | `` vscode: add windsurf directories (#6427) ``                                                                    |
| [`582d3cd4`](https://github.com/nix-community/home-manager/commit/582d3cd42df7d2c7565d77119106336ea46e33df) | `` yubikey-agent: init service module (#6446) ``                                                                  |
| [`9daae9a6`](https://github.com/nix-community/home-manager/commit/9daae9a67af7b4d341e2c806fa274a9c0925d7cf) | `` nixos/common: forward `nix.enable` from the OS configuration (#6383) ``                                        |
| [`7da01bc4`](https://github.com/nix-community/home-manager/commit/7da01bc47ad48d696c96fcfd63d10063855d5486) | `` git: support alternate signing methods (#5516) ``                                                              |
| [`5031c6d2`](https://github.com/nix-community/home-manager/commit/5031c6d2978109336637977c165f82aa49fa16a7) | `` syncthing: remove with lib ``                                                                                  |
| [`20fac9bb`](https://github.com/nix-community/home-manager/commit/20fac9bbdf22d697ad68faabb7f95d4deba4f712) | `` syncthing: use package options ``                                                                              |
| [`22b418c1`](https://github.com/nix-community/home-manager/commit/22b418c13fb0be43f4bc5c185f323a3237028594) | `` bash: Make HISTFILESIZE and HISTSIZE nullable (#6443) ``                                                       |
| [`a70d7889`](https://github.com/nix-community/home-manager/commit/a70d788923061a00a488f60a01768ca4c6a8b727) | `` aerospace: fix workspace assignment config (#6442) ``                                                          |
| [`c9d343cf`](https://github.com/nix-community/home-manager/commit/c9d343cfa0565671cc7e8d5aefebaf61cc840abd) | `` docs(zellij): `programs.zellij.settings` are serialized as `kdl` and not `yaml` from version 0.32.0 (#6010) `` |
| [`15b59d41`](https://github.com/nix-community/home-manager/commit/15b59d4191b993ebdfcb1f61b834fced217882ba) | `` eww: fix eww source creation ``                                                                                |
| [`d303453b`](https://github.com/nix-community/home-manager/commit/d303453b134cff1dec350ae2e50fec34d06bee73) | `` eww: add null configDir test ``                                                                                |
| [`1f6fa878`](https://github.com/nix-community/home-manager/commit/1f6fa878080fd1b59b21b43695fd523ea4cae8d6) | `` eww: added tests ``                                                                                            |
| [`f8729b11`](https://github.com/nix-community/home-manager/commit/f8729b11ee49a40fc21b6ec6578a16e9a5261414) | `` eww: fix confDir config using missing attribute "types.isNull" ``                                              |
| [`83bd3a26`](https://github.com/nix-community/home-manager/commit/83bd3a26ac0526ae04fa74df46738bb44b89dcdd) | `` email: add migadu.com flavor ``                                                                                |
| [`f0a31d38`](https://github.com/nix-community/home-manager/commit/f0a31d38e6de48970ce1fe93e6ea343e20a9c80a) | `` neomutt: fix default for 'map' in macros/binds (#6429) ``                                                      |
| [`8f351726`](https://github.com/nix-community/home-manager/commit/8f351726c5841d86854e7fa6003ea472352f5208) | `` git-worktree-switcher: use lib.hm.shell.mkShellIntegrationOption ``                                            |
| [`9c8169b4`](https://github.com/nix-community/home-manager/commit/9c8169b4466391999b1ad5ea86be4e79d560af52) | `` git-worktree-switcher: init module ``                                                                          |
| [`59fe145f`](https://github.com/nix-community/home-manager/commit/59fe145f0bb7cfde99f148140a47a54deb8cc23f) | `` eww: make configDir optional (#6282) ``                                                                        |
| [`ba4a1a11`](https://github.com/nix-community/home-manager/commit/ba4a1a110204c27805d1a1b5c8b24b3a0da4d063) | `` ludusavi: create Ludusavi module (#5626) ``                                                                    |
| [`e5854b98`](https://github.com/nix-community/home-manager/commit/e5854b98cd759b91c83ba5caa5ff32f274f1dc78) | `` flake-module: change type from lazyAttrsOf raw to lazyAttrsOf deferredModule (#6408) ``                        |
| [`5795f792`](https://github.com/nix-community/home-manager/commit/5795f792abf38e4f2701b4f7454deeb8e2575ae4) | `` yazi: organization tweak ``                                                                                    |
| [`b34b5668`](https://github.com/nix-community/home-manager/commit/b34b56689dcc75294e14e8c95db4e054a4e9573f) | `` yazi: remove with lib ``                                                                                       |
| [`c0d06189`](https://github.com/nix-community/home-manager/commit/c0d06189f27f9cd0f97c13a0e75c4fd12c7e9d61) | `` kitty: assert can't enable shell integrations when mode is null ``                                             |
| [`fc3cd1e4`](https://github.com/nix-community/home-manager/commit/fc3cd1e40870cb40692d1272468fa5e187d07591) | `` kitty: allow not setting shell_integration ``                                                                  |
| [`a3c9e881`](https://github.com/nix-community/home-manager/commit/a3c9e88177f0dc4a2662b5324572425f59129f11) | `` nushell: temporarily disable test ``                                                                           |
| [`0f9e9230`](https://github.com/nix-community/home-manager/commit/0f9e92302a6bd86087e8b6f1a539d1d1f0ccbe62) | `` neovim: re-enable test ``                                                                                      |
| [`cf2ea71e`](https://github.com/nix-community/home-manager/commit/cf2ea71e6877dddd9b94812fcb21a19f21f3d351) | `` flake.lock: Update ``                                                                                          |
| [`b0bd29bb`](https://github.com/nix-community/home-manager/commit/b0bd29bb4b8df265b13bbb4a6639afa74faaa831) | `` tldr-update: init (#6401) ``                                                                                   |
| [`5af1b9a0`](https://github.com/nix-community/home-manager/commit/5af1b9a0f193ab6138b89a8e0af8763c21bbf491) | `` treewide: standardize shell integration options ``                                                             |
| [`bf9a1a06`](https://github.com/nix-community/home-manager/commit/bf9a1a068919ccdfa7d130873936c5fd4c826e85) | `` Translate using Weblate (Swedish) ``                                                                           |
| [`90a4374b`](https://github.com/nix-community/home-manager/commit/90a4374b174edb88a2e36889ee39ce45a186c7f6) | `` Translate using Weblate (Portuguese) ``                                                                        |
| [`947eef9e`](https://github.com/nix-community/home-manager/commit/947eef9e99c42346cf0aac2bebe1cd94924c173b) | `` neovim: disable neovim-coc-config test ``                                                                      |
| [`43379927`](https://github.com/nix-community/home-manager/commit/433799271274c9f2ab520a49527ebfe2992dcfbd) | `` wayland: create tray.target if xsession is not enabled (#6332) ``                                              |
| [`f99c704f`](https://github.com/nix-community/home-manager/commit/f99c704fe3a4cf8d72b2d568ec80bc38be1a9407) | `` bash: Make sure HISTFILE's directory exists ``                                                                 |
| [`15bd6736`](https://github.com/nix-community/home-manager/commit/15bd673658c189491cd896f06b3dd8f09bb0dfe4) | `` firefox: remove old unused test file (#6403) ``                                                                |
| [`30ea6fed`](https://github.com/nix-community/home-manager/commit/30ea6fed4e4b41693cebc2263373dd810de4de49) | `` firefox: fix referencing name in profile-specific docs ``                                                      |
| [`f20b7a8a`](https://github.com/nix-community/home-manager/commit/f20b7a8ab527a2482f13754dc00b2deaddc34599) | `` firefox: fix referencing firefox fork name in profile-specific docs (#6407) ``                                 |
| [`3b6fde96`](https://github.com/nix-community/home-manager/commit/3b6fde96d8b41a4a21cbacba8de7debf7ea78021) | `` Translate using Weblate (Russian) ``                                                                           |
| [`987f622c`](https://github.com/nix-community/home-manager/commit/987f622cc4368626d8b041ea495edf0d243714ba) | `` Add translation using Weblate (Bulgarian) ``                                                                   |
| [`39602525`](https://github.com/nix-community/home-manager/commit/396025251ae173da389133ed3aa7a3f18d333ea3) | `` Translate using Weblate (Bulgarian) ``                                                                         |
| [`d092f0a4`](https://github.com/nix-community/home-manager/commit/d092f0a4c07fea79f14886da83c9ee7249c6a84f) | `` Translate using Weblate (Spanish) ``                                                                           |
| [`59971126`](https://github.com/nix-community/home-manager/commit/5997112695f3b02d3992764760fc6ddfef51fba3) | `` flake.lock: Update ``                                                                                          |
| [`f2d32e46`](https://github.com/nix-community/home-manager/commit/f2d32e46fac9d51da6912948ae1156044c71774b) | `` broot: use hjson-go ``                                                                                         |
| [`7a3f0b3b`](https://github.com/nix-community/home-manager/commit/7a3f0b3b8df1b913890f5fad04d34f2af91da858) | `` tests: rework derivation stubbing ``                                                                           |
| [`c5c2cbc8`](https://github.com/nix-community/home-manager/commit/c5c2cbc866fecc75175259bcda02c4c0e00c00ee) | `` ci: tweak test command slightly ``                                                                             |
| [`24bb01ea`](https://github.com/nix-community/home-manager/commit/24bb01ea170a6705c6700be3fa7438b394523ea4) | `` tests: avoid unnecessary test script interpolation ``                                                          |
| [`1e47f710`](https://github.com/nix-community/home-manager/commit/1e47f7101fedd857e561782d00d4cb1f6b69e7df) | `` gpg-agent: no-allow-external-cache option (#6387) ``                                                           |
| [`78576b81`](https://github.com/nix-community/home-manager/commit/78576b817fdd88a75c6adf512e9ba20551662cef) | `` home-manager: add lib support for non-flake users (#5429) ``                                                   |
| [`7abcf59a`](https://github.com/nix-community/home-manager/commit/7abcf59a365430b36f84eaa452a466b11e469e33) | `` mpv: support includes directives (#6391) ``                                                                    |
| [`066ba0c5`](https://github.com/nix-community/home-manager/commit/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe) | `` flake-module: rename `homeModules` to `homeManagerModules` (#6392) ``                                          |
| [`18fa9f32`](https://github.com/nix-community/home-manager/commit/18fa9f323d8adbb0b7b8b98a8488db308210ed93) | `` yazi: add main.lua support to plugins (#6394) ``                                                               |
| [`dae6d346`](https://github.com/nix-community/home-manager/commit/dae6d3460c8bab3ac9f38a86affe45b32818e764) | `` git: add default value null to programs.git.signing.key (#6032) ``                                             |
| [`8544cd09`](https://github.com/nix-community/home-manager/commit/8544cd092047a7e92d0dce011108a563de7fc0f2) | `` lapce: add module (#5752) ``                                                                                   |
| [`055c6705`](https://github.com/nix-community/home-manager/commit/055c67056d87577a39af4144ad5eadb093cfb97d) | `` fcitx5: add waylandFrontend option to not set env vars (#5431) ``                                              |
| [`801ddd86`](https://github.com/nix-community/home-manager/commit/801ddd8693481866c2cfb1efd44ddbae778ea572) | `` hyprland: use package stubs ``                                                                                 |
| [`9afd0220`](https://github.com/nix-community/home-manager/commit/9afd02201332756d4bbad273202ecc96049c53b2) | `` wayfire-stubs: add stubs for wayfire tests ``                                                                  |
| [`c4f28f28`](https://github.com/nix-community/home-manager/commit/c4f28f282f54fc15a60a3b258ecce77a44327958) | `` spectrwm-stubs: add stubs for spectrwm tests ``                                                                |
| [`e17bdf31`](https://github.com/nix-community/home-manager/commit/e17bdf3191ad5f94c4037117f5635c8b1138c730) | `` herbstluftwm-stubs: add stubs for herbstluftwm tests ``                                                        |
| [`c4f4b1e2`](https://github.com/nix-community/home-manager/commit/c4f4b1e2fa335844aaa98d65066a5a434fa9ce22) | `` bspwm-stubs: add stubs for bspwm tests ``                                                                      |
| [`02dc2e82`](https://github.com/nix-community/home-manager/commit/02dc2e827f7c677cad1a4cbfcb7ad01728424351) | `` river-stubs: add stubs for river tests ``                                                                      |
| [`e0a2df31`](https://github.com/nix-community/home-manager/commit/e0a2df319302e975a6c8f7fc940315f425b337e8) | `` i3-stubs: add more stubs ``                                                                                    |
| [`64455251`](https://github.com/nix-community/home-manager/commit/644552519e74bde9c21ea7ec473d5eee67915d25) | `` sway-stubs: add more stubs ``                                                                                  |