### PR TITLE
chore(flake/nix-index-database): `79b7b8ea` -> `895d81b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737861961,
-        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
+        "lastModified": 1739071773,
+        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
+        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`895d81b6`](https://github.com/nix-community/nix-index-database/commit/895d81b6228bbd50a6ef22f5a58a504ca99763ea) | `` update generated.nix to release 2025-02-09-031200 `` |
| [`3e945f71`](https://github.com/nix-community/nix-index-database/commit/3e945f71fc42396bc15d90be67796ee922d5c162) | `` flake.lock: Update ``                                |
| [`46a8f5fc`](https://github.com/nix-community/nix-index-database/commit/46a8f5fc9552b776bfc5c5c96ea3bede33f68f52) | `` update generated.nix to release 2025-02-02-030235 `` |
| [`9000a22f`](https://github.com/nix-community/nix-index-database/commit/9000a22fbd820eedba37fc29a4b9652bfc3068c2) | `` flake.lock: Update ``                                |