### PR TITLE
chore(flake/stylix): `b00c9f46` -> `e86de61b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -807,15 +807,16 @@
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
+        "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1738278499,
-        "narHash": "sha256-q1SUyXSQ9znHTME53/vPLe+Ga3V1wW3X3gWfa8JsBUM=",
+        "lastModified": 1739375014,
+        "narHash": "sha256-0fNbvZ1Dod4rDIfwGnC7CzJ3wRFSF1v5AvNCmNkVgXo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b00c9f46ae6c27074d24d2db390f0ac5ebcc329f",
+        "rev": "e86de61bb8f5f2b6459d0be3e3291ad16db4b777",
         "type": "github"
       },
       "original": {
@@ -885,6 +886,22 @@
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
         "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "type": "github"
+      }
+    },
+    "tinted-schemes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1737565458,
+        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
+        "owner": "tinted-theming",
+        "repo": "schemes",
+        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "schemes",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`e86de61b`](https://github.com/danth/stylix/commit/e86de61bb8f5f2b6459d0be3e3291ad16db4b777) | `` gnome: fix Home Manager activation (#860) ``                             |
| [`d8289c3f`](https://github.com/danth/stylix/commit/d8289c3f0e5995863921ea207392c122f5d59f6d) | `` ci: disable IFD (#855) ``                                                |
| [`4af2686c`](https://github.com/danth/stylix/commit/4af2686c1c62176d0ce28c4d55e813ae5ed52b6f) | `` nixcord: use new template format (#852) ``                               |
| [`7f0154c3`](https://github.com/danth/stylix/commit/7f0154c371a847d23eace73f6daaa814d2d42261) | `` neovim: fix SignColumn transparency (#628) ``                            |
| [`65eae5aa`](https://github.com/danth/stylix/commit/65eae5aaa2169ed4f6a066b4da698cb0e07b2719) | `` kde: fix KDE apps ignoring colorscheme (#850) ``                         |
| [`eb5f8175`](https://github.com/danth/stylix/commit/eb5f81756731a3eefa42b1caf494ba5a9c8aedb4) | `` {vencord,vesktop}: support fonts without IFD (#846) ``                   |
| [`2c1d493c`](https://github.com/danth/stylix/commit/2c1d493c5f5af6caec9f02a5c3d88d84ee2f10b8) | `` qt: respect stylix.enable (#847) ``                                      |
| [`e72aa84d`](https://github.com/danth/stylix/commit/e72aa84da1c6982c11620a4154ded8c603f33f46) | `` {vencord,vesktop}: revert attempt to support fonts (#844) ``             |
| [`7818098f`](https://github.com/danth/stylix/commit/7818098f4df4ee73667036c65909cf311d36968b) | `` treewide: remove trailing whitespaces and add trailing newline (#841) `` |
| [`be606eaa`](https://github.com/danth/stylix/commit/be606eaa87dfcf22c98f80453b42ec40dcbcdf36) | `` {vencord,vesktop}: fonts (#840) ``                                       |
| [`ff8ce4f3`](https://github.com/danth/stylix/commit/ff8ce4f3d2ad4d09291fa079c12a523d9b1c6aa6) | `` kde: make wallpaper optional and nondestructive (#823) ``                |
| [`708770fc`](https://github.com/danth/stylix/commit/708770fcb045b6efb4c419ff7be9760d010699bc) | `` wayfire: init (#765) ``                                                  |
| [`b3ef236d`](https://github.com/danth/stylix/commit/b3ef236d22572618828f9e7019362cc89d877bd0) | `` glance: init (#827) ``                                                   |
| [`87791e06`](https://github.com/danth/stylix/commit/87791e0665bd345127b7f35aca6e9195e74ef39c) | `` halloy: init (#825) ``                                                   |
| [`d513f59d`](https://github.com/danth/stylix/commit/d513f59da5856978c363d2f82103f708f4a6024d) | `` stylix: update and simplify flake-compat instructions (#816) ``          |
| [`bae5cbb8`](https://github.com/danth/stylix/commit/bae5cbb8fb36bd74c5303df4f9727e640a15b10b) | `` doc: expand description of font units (#819) ``                          |
| [`596d6644`](https://github.com/danth/stylix/commit/596d6644077d6d25ff713e93b55efc867979959d) | `` kde: correct quotes in stylix-activate-kde to prevent failure (#832) ``  |
| [`8be2aed2`](https://github.com/danth/stylix/commit/8be2aed2950ed7a0e0dcc270d74f28b6600c1e59) | `` qt: fix qt6ct directory name (#830) ``                                   |
| [`b7f50a56`](https://github.com/danth/stylix/commit/b7f50a56c3ccda1e6020e62b77a9f9ea80d6a656) | `` qt: add flexible theming with sensible defaults (#780) ``                |