### PR TITLE
chore(flake/darwin): `678b2264` -> `5d6e0851`

### DIFF
--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -47,7 +47,7 @@
   };
 
   system = {
-    stateVersion = 5;
+    stateVersion = 4;
     defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -857,11 +857,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740644467,
-        "narHash": "sha256-i2ArXwncE2OmneLBllo5OlpLB2UsXU5JX+T+7or5OX4=",
+        "lastModified": 1740769934,
+        "narHash": "sha256-iyxUwII/NQNClT77VqQiDpaXJz1r0Z8tNVxgY64mLak=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7c09d206680e6fe6771e1ac9a83515313feaf95",
+        "rev": "de4ee5899042801b62f988687acd454d4d411075",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739548217,
-        "narHash": "sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ=",
+        "lastModified": 1740755725,
+        "narHash": "sha256-amZbqP84H/ApugaT+TADXTB3NbjkVHI9Vac1saIk0kE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "678b22642abde2ee77ae2218ab41d802f010e5b0",
+        "rev": "5d6e0851b60508cffd66b4a6982440a40720338d",
         "type": "github"
       },
       "original": {

--- a/graphical/darwin.nix
+++ b/graphical/darwin.nix
@@ -44,7 +44,7 @@
     ];
   };
 
-  security.pam.enableSudoTouchIdAuth = true;
+  security.pam.services.sudo_local.touchIdAuth = true;
 
   system = {
     defaults = {

--- a/users/alesauce/core/default.nix
+++ b/users/alesauce/core/default.nix
@@ -26,7 +26,7 @@
 
   home = {
     username = "alesauce";
-    stateVersion = "25.05";
+    stateVersion = "23.11";
     packages = with pkgs; [
       alejandra
       eza


### PR DESCRIPTION
| Commit                                                                                           | Message                                                         |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`7386d887`](https://github.com/LnL7/nix-darwin/commit/7386d8878ec409f672f64df24e4d00da04bfc8ce) | `` services/dnscrypt-proxy: init ``                             |
| [`b1db30ce`](https://github.com/LnL7/nix-darwin/commit/b1db30ce36f25eb07a7d4832cc2d29b1697c00f1) | `` networking: Restore the original /etc/hosts on activation `` |
| [`1d9f6224`](https://github.com/LnL7/nix-darwin/commit/1d9f622484f00df0a8c00b13f427e4175760cf3c) | `` Revert "Add networking.hosts and .hostFiles from nixos " ``  |
| [`727119f8`](https://github.com/LnL7/nix-darwin/commit/727119f8c7420879e83ffc310b8c1f4fa2800c11) | `` pam: add `pam_watchid` support ``                            |
| [`11ea44f3`](https://github.com/LnL7/nix-darwin/commit/11ea44f3e20737004f7c0f1d27354b9d7a79c2f5) | `` pam: add `pam_reattach` support ``                           |
| [`47f26307`](https://github.com/LnL7/nix-darwin/commit/47f263077ee53de95a1c35eb6892665d77ce6165) | `` pam: switch to using `sudo_local` file ``                    |
| [`bde9fa6f`](https://github.com/LnL7/nix-darwin/commit/bde9fa6f64211dc8bc9717fb37463e65de238b08) | `` add networking.hosts and .hostFiles from nixos ``            |
| [`c9c2d40f`](https://github.com/LnL7/nix-darwin/commit/c9c2d40f7172747823dc9c5ab16b9bb541cf3c0d) | `` pam: remove `with lib;` ``                                   |
| [`e21d0798`](https://github.com/LnL7/nix-darwin/commit/e21d07988b30adbd5b77d16f9fa40b7d5fc00a09) | `` dock: refactor persistent-apps option ``                     |
| [`02ba211e`](https://github.com/LnL7/nix-darwin/commit/02ba211ea19fb4e5a5da2e24a6ebbed526f5231d) | `` dock: allow setting tile-types ``                            |