### PR TITLE
chore(flake/stylix): `e86de61b` -> `e7c09d20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -128,11 +128,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1736899990,
-        "narHash": "sha256-S79Hqn2EtSxU4kp99t8tRschSifWD4p/51++0xNWUxw=",
+        "lastModified": 1739223196,
+        "narHash": "sha256-vAxN2f3rvl5q62gQQjZGVSvF93nAsOxntuFz+e/655w=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "91ca1f82d717b02ceb03a3f423cbe8082ebbb26d",
+        "rev": "a89108e6272426f4eddd93ba17d0ea101c34fb21",
         "type": "github"
       },
       "original": {
@@ -188,7 +188,6 @@
       }
     },
     "flake-compat_4": {
-      "flake": false,
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -235,6 +234,28 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "stylix",
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -361,11 +382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -726,6 +747,29 @@
         "type": "github"
       }
     },
+    "nur": {
+      "inputs": {
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": [
+          "stylix",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_4"
+      },
+      "locked": {
+        "lastModified": 1740408283,
+        "narHash": "sha256-2xECnhgF3MU9YjmvOkrRp8wRFo2OjjewgCtlfckhL5s=",
+        "owner": "nix-community",
+        "repo": "NUR",
+        "rev": "496a4a11162bdffb9a7b258942de138873f019f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NUR",
+        "type": "github"
+      }
+    },
     "nuschtosSearch": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -804,6 +848,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nur": "nur",
         "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
@@ -812,11 +857,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1739375014,
-        "narHash": "sha256-0fNbvZ1Dod4rDIfwGnC7CzJ3wRFSF1v5AvNCmNkVgXo=",
+        "lastModified": 1740644467,
+        "narHash": "sha256-i2ArXwncE2OmneLBllo5OlpLB2UsXU5JX+T+7or5OX4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e86de61bb8f5f2b6459d0be3e3291ad16db4b777",
+        "rev": "e7c09d206680e6fe6771e1ac9a83515313feaf95",
         "type": "github"
       },
       "original": {
@@ -892,11 +937,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1737565458,
-        "narHash": "sha256-y+9cvOA6BLKT0WfebDsyUpUa/YxKow9hTjBp6HpQv68=",
+        "lastModified": 1740351358,
+        "narHash": "sha256-Hdk850xgAd3DL8KX0AbyU7tC834d3Lej1jOo3duWiOA=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "ae31625ba47aeaa4bf6a98cf11a8d4886f9463d9",
+        "rev": "a1bc2bd89e693e7e3f5764cfe8114e2ae150e184",
         "type": "github"
       },
       "original": {
@@ -908,11 +953,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1735737224,
-        "narHash": "sha256-FO2hRBkZsjlIRqzNHCPc/52yxg11kHGA8MEtSun9RwE=",
+        "lastModified": 1740272597,
+        "narHash": "sha256-/etfUV3HzAaLW3RSJVwUaW8ULbMn3v6wbTlXSKbcoWQ=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "aead506a9930c717ebf81cc83a2126e9ca08fa64",
+        "rev": "b6c7f46c8718cc484f2db8b485b06e2a98304cd0",
         "type": "github"
       },
       "original": {
@@ -994,6 +1039,28 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_4": {
+      "inputs": {
+        "nixpkgs": [
+          "stylix",
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733222881,
+        "narHash": "sha256-JIPcz1PrpXUCbaccEnrcUS8jjEb/1vJbZz5KkobyFdM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "49717b5af6f80172275d47a418c9719a31a78b53",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                        |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`21113945`](https://github.com/danth/stylix/commit/2111394586e922257168539142b2075e44c528b6) | `` Convert image path to string for Hyprlock fixing #918 (#925) ``             |
| [`b273375e`](https://github.com/danth/stylix/commit/b273375e6c2eab100e0f8a959d4932d0a6e50cad) | `` ci: add Cachix cache (#919) ``                                              |
| [`eab1ecf4`](https://github.com/danth/stylix/commit/eab1ecf41f2951e8655e7d66d19f21d5ab5fac4b) | `` docs: document configuring Standalone Nixvim ``                             |
| [`0a4755b6`](https://github.com/danth/stylix/commit/0a4755b656c28043c52063384fc68bbb30913903) | `` nixvim: expose config as read-only option ``                                |
| [`6c361e97`](https://github.com/danth/stylix/commit/6c361e9755d55df7c7eda10c5c40accdcf39da54) | `` nixvim: simplify enable conditions ``                                       |
| [`a98c363a`](https://github.com/danth/stylix/commit/a98c363a58accad047a2580382d90433619a08e0) | `` stylix: use new package name for Noto Color Emoji (#917) ``                 |
| [`c9195530`](https://github.com/danth/stylix/commit/c9195530b40e2589a70d3bf4154d2f92de1fafca) | `` stylix: apply testbed field separator check to each fields (#904) ``        |
| [`9d433a6b`](https://github.com/danth/stylix/commit/9d433a6b1a44670ac1bf7e37e107a63ee04d32eb) | `` swaylock: attempt to avoid infinite recursion (#899) ``                     |
| [`359084aa`](https://github.com/danth/stylix/commit/359084aae60e14d9223bd3fd67dba25854d88950) | `` doc: update GNOME testbed name in README (#909) ``                          |
| [`ebdcc2a1`](https://github.com/danth/stylix/commit/ebdcc2a1902a602eaf7dcf6246c830ddb10a96a7) | `` doc: add module README for Firefox and derivatives (#897) ``                |
| [`225b4c57`](https://github.com/danth/stylix/commit/225b4c57c9eebabcada52bc141e8c30ea28a3647) | `` qt: adds default value for qt.platform (#884) ``                            |
| [`59d2c0ec`](https://github.com/danth/stylix/commit/59d2c0ec52c420f0ddb96029e11be957af64d511) | `` stylix: update all flake inputs (#907) ``                                   |
| [`cbe42e21`](https://github.com/danth/stylix/commit/cbe42e21eed73ae135d1a30e0d722eb2d5fb61cd) | `` treewide: rename wpaperd and vscode options (#905) ``                       |
| [`2c4b5bec`](https://github.com/danth/stylix/commit/2c4b5bec3685da042a2241d3b26af5ea66f2b062) | `` hyprlock: fix background color definition (#906) ``                         |
| [`c8e4a0d2`](https://github.com/danth/stylix/commit/c8e4a0d2186d388e3c6f3240b8b3ae422a7780d7) | `` treewide: optionalize stylix.image option (#717) ``                         |
| [`f121a142`](https://github.com/danth/stylix/commit/f121a142abde1b6aa9738e4c21a330c0ddd4eb70) | `` stylix: parametrize and change testbed field separator (#887) ``            |
| [`689fd55f`](https://github.com/danth/stylix/commit/689fd55ff286b01017c7d77acee6c904ce12f85c) | `` ci: make get-derivations job fail when input command fails (#888) ``        |
| [`1398fc4d`](https://github.com/danth/stylix/commit/1398fc4dc8fd8e844ca23f275e87c988b0aa2c3f) | `` doc: use permalinks for option declarations ``                              |
| [`f4401071`](https://github.com/danth/stylix/commit/f4401071ea84ea6b4f90fb9b837760a0c9cceb63) | `` doc: add declaration entry ``                                               |
| [`4c04e0de`](https://github.com/danth/stylix/commit/4c04e0deceefb24ed4b8a0c788f3c673fd4ece06) | `` doc: redirect old reference pages to new location ``                        |
| [`2b2f260a`](https://github.com/danth/stylix/commit/2b2f260a69ac3a0c327119c1b03f8ca1481ff7ef) | `` doc: collapse platforms and modules ``                                      |
| [`99096ef3`](https://github.com/danth/stylix/commit/99096ef3e3dc186f67cc6470d2c92c67020a5c44) | `` doc: clarify global option ``                                               |
| [`13667122`](https://github.com/danth/stylix/commit/13667122ec568531e6447e0e8c14b06bf7d1ff08) | `` doc: standardize Bash code ``                                               |
| [`3a686a20`](https://github.com/danth/stylix/commit/3a686a20b8f4dc026e561c1c5a85671c8cfeeb4f) | `` firefox: add colorTheme.enable option (#881) ``                             |
| [`917e07af`](https://github.com/danth/stylix/commit/917e07af1451d7765be57c8b31bb3372c7b821a7) | `` plymouth: remove trailing whitespaces and consecutive empty lines (#889) `` |
| [`8b6edfdf`](https://github.com/danth/stylix/commit/8b6edfdfa87e725cd7b593b390f15e6556449269) | `` {vencord,vesktop}: remove duplicate testbeds (#885) ``                      |
| [`c424b223`](https://github.com/danth/stylix/commit/c424b22396c5e40d2513ce03f94d0aa6d9cdd38f) | `` swaylock: avoid inadvertently installing Swaylock ``                        |
| [`07797994`](https://github.com/danth/stylix/commit/0779799431088b10e0499ef04c2c7901df1087a4) | `` rio: init (#882) ``                                                         |
| [`472bd50c`](https://github.com/danth/stylix/commit/472bd50c8538dc35f5af7576a11c07b7fcbf1205) | `` doc: store module documentation as a README within the module ``            |
| [`7afc6fb4`](https://github.com/danth/stylix/commit/7afc6fb46da6dd54a2e1d84991aabd09c16cb1a1) | `` doc: describe how to create module documentation ``                         |
| [`aeb550ad`](https://github.com/danth/stylix/commit/aeb550add3bfa1ce3ce249c3b3dad71ebb018318) | `` doc: remove site-url setting (#878) ``                                      |
| [`eb7b19c2`](https://github.com/danth/stylix/commit/eb7b19c26030c534664c840405c995a493a98013) | `` plymouth: support question and message widgets (#842) ``                    |
| [`d6796ff3`](https://github.com/danth/stylix/commit/d6796ff307fa9b0fbebf7379126c5871658f427e) | `` doc: fix some alerts not being rendered by `substituteInPlace` ``           |
| [`de2057a0`](https://github.com/danth/stylix/commit/de2057a0006aec29370a39372a8c3f8269d005c4) | `` doc: disable section numbers ``                                             |
| [`77e58881`](https://github.com/danth/stylix/commit/77e58881df26be44ce8d04c8dbd5d4f179f7eefe) | `` doc: split modules into individual pages ``                                 |
| [`e87bf16d`](https://github.com/danth/stylix/commit/e87bf16df961757649de40ad91be00b065813012) | `` stylix: use absolute paths for module imports ``                            |
| [`9343b660`](https://github.com/danth/stylix/commit/9343b660c914a95d4a90f6bd40cda7c87b401445) | `` stylix: fix palette generator caching (#867) ``                             |
| [`d171b19c`](https://github.com/danth/stylix/commit/d171b19c1c76c32f9c8303a43d0176257aa25034) | `` qt: add temporary warnings for plasma6 (#845) ``                            |
| [`7feb1c29`](https://github.com/danth/stylix/commit/7feb1c29bf39ebe6b2984b2f77f9ad38f486e311) | `` discord: combine nixcord, vencord, and vesktop modules (#854) ``            |
| [`21d68dab`](https://github.com/danth/stylix/commit/21d68dab9dff35d88125f9ddd7d11477a628d071) | `` firefox: update GNOME theme input (#871) ``                                 |
| [`ba560ec1`](https://github.com/danth/stylix/commit/ba560ec19c78ce954f846f16fb9d5556d14a5c2a) | `` stylix: prevent silently overriding testbeds with the same name (#861) ``   |
| [`211a8440`](https://github.com/danth/stylix/commit/211a8440e7ebcbae5fa272d95612a4c1732d8bc4) | `` stylix: support multiple testbeds per module (#858) ``                      |