### PR TITLE
chore(flake/home-manager): `343646e0` -> `b71edac7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -486,11 +486,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740679976,
-        "narHash": "sha256-6U/zvgtcGJqpOTKsIgf+mRO7/djwV07ImU/t0nZBix8=",
+        "lastModified": 1740699498,
+        "narHash": "sha256-r9hkKzX99CGiP1ZqH0e+SWKK4CMsRNRLyotuwrUjhTI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "343646e092696d94b6f22b6875ae685756fd4cf0",
+        "rev": "b71edac7a3167026aabea82a54d08b1794088c21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`b71edac7`](https://github.com/nix-community/home-manager/commit/b71edac7a3167026aabea82a54d08b1794088c21) | `` launchd: sync up with changes from nix-darwin (#6508) `` |