### PR TITLE
chore(flake/nix-index-database): `895d81b6` -> `46579253`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739071773,
-        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
+        "lastModified": 1740281615,
+        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
+        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`46579253`](https://github.com/nix-community/nix-index-database/commit/465792533d03e6bb9dc849d58ab9d5e31fac9023) | `` update generated.nix to release 2025-02-23-031515 `` |
| [`fb4ee0d4`](https://github.com/nix-community/nix-index-database/commit/fb4ee0d4d8a501a7c8b84cfb87c222b05eac53f0) | `` flake.lock: Update ``                                |
| [`ae15068e`](https://github.com/nix-community/nix-index-database/commit/ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63) | `` update generated.nix to release 2025-02-16-031500 `` |
| [`52ef1072`](https://github.com/nix-community/nix-index-database/commit/52ef1072d57cfd0b4d2c375d646e7420ae2f5901) | `` flake.lock: Update ``                                |