### PR TITLE
chore(flake/stylix): `e7c09d20` -> `de4ee589`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -857,11 +857,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740644467,
-        "narHash": "sha256-i2ArXwncE2OmneLBllo5OlpLB2UsXU5JX+T+7or5OX4=",
+        "lastModified": 1740769934,
+        "narHash": "sha256-iyxUwII/NQNClT77VqQiDpaXJz1r0Z8tNVxgY64mLak=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7c09d206680e6fe6771e1ac9a83515313feaf95",
+        "rev": "de4ee5899042801b62f988687acd454d4d411075",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                       |
| --------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`de4ee589`](https://github.com/danth/stylix/commit/de4ee5899042801b62f988687acd454d4d411075) | `` firefox: add gnome-theme testbed (#879) `` |
| [`c74352a1`](https://github.com/danth/stylix/commit/c74352a1459ac0d350b22a3a45bbaa18ab7b7e2d) | `` qt: adapt to style guide (#920) ``         |