### PR TITLE
chore(flake/darwin): `5d6e0851` -> `adf5c88b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -90,11 +90,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740755725,
-        "narHash": "sha256-amZbqP84H/ApugaT+TADXTB3NbjkVHI9Vac1saIk0kE=",
+        "lastModified": 1741229100,
+        "narHash": "sha256-0HwrTDXp9buEwal/1ymK9uQmzUD5ozIA7CJGqnT/gLs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "5d6e0851b60508cffd66b4a6982440a40720338d",
+        "rev": "adf5c88ba1fe21af5c083b4d655004431f20c5ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`df599ea8`](https://github.com/LnL7/nix-darwin/commit/df599ea8f10e86985c1b09e3cd7a3a331dc702f3) | `` readme: update instructions as Determinate Nix is now the default `` |
| [`d06cf700`](https://github.com/LnL7/nix-darwin/commit/d06cf700ee589527fde4bd9b91f899e7137c05a6) | `` homebrew: remove `--no-lock` flag ``                                 |
| [`fdc512d1`](https://github.com/LnL7/nix-darwin/commit/fdc512d107d2777e9af89f4dc0191c8878b57aa5) | `` services/dnscrypt-proxy: Fix use of pkg alias ``                     |