### PR TITLE
chore(flake/home-manager): `b71edac7` -> `486b0660`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740699498,
-        "narHash": "sha256-r9hkKzX99CGiP1ZqH0e+SWKK4CMsRNRLyotuwrUjhTI=",
+        "lastModified": 1741217763,
+        "narHash": "sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b71edac7a3167026aabea82a54d08b1794088c21",
+        "rev": "486b066025dccd8af7fbe5dd2cc79e46b88c80da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`486b0660`](https://github.com/nix-community/home-manager/commit/486b066025dccd8af7fbe5dd2cc79e46b88c80da) | `` specialisation: escape specialisation name ``                                      |
| [`f6ac8a34`](https://github.com/nix-community/home-manager/commit/f6ac8a3414181cb7e97fb76973a14bd661e9492f) | `` flake.lock: Update ``                                                              |
| [`def0dbbc`](https://github.com/nix-community/home-manager/commit/def0dbbcea715d4514ca343ab4d6d7f3a1742da0) | `` vscode: Support Cursor AI (#6417) ``                                               |
| [`b1b964ea`](https://github.com/nix-community/home-manager/commit/b1b964ea9348aef08cab514fa88e9c99def6fd63) | `` mbsync: support maildir paths containing spaces ``                                 |
| [`6f71acf7`](https://github.com/nix-community/home-manager/commit/6f71acf71bd6a8a6f3152769737a53af6da6ae63) | `` git: apply sendmailCmd instead of smtpServer (#6399) ``                            |
| [`3f08cd8e`](https://github.com/nix-community/home-manager/commit/3f08cd8ef77dcd7586075a460a61c8432baf25a9) | `` ci: add labels for firefox (#6520) ``                                              |
| [`70fbbf05`](https://github.com/nix-community/home-manager/commit/70fbbf05a5594b0a72124ab211bff1d502c89e3f) | `` Firefox: Apply global extension force setting to declarative extensions (#6567) `` |
| [`fcac3d6d`](https://github.com/nix-community/home-manager/commit/fcac3d6d88302a5e64f6cb8014ac785e08874c8d) | `` xdg: use mkOptionDefault ``                                                        |
| [`66505b85`](https://github.com/nix-community/home-manager/commit/66505b851b160a6937053a73b9b9808659df8c56) | `` xdg: add missing stateHome default for legacy ``                                   |
| [`47c69496`](https://github.com/nix-community/home-manager/commit/47c694963e86b3e0f5d387506642a830871f331e) | `` tests: move xdg to cross platform tests ``                                         |
| [`17fd27a8`](https://github.com/nix-community/home-manager/commit/17fd27a8ea2d38c52f66c7685e766113ca4b2982) | `` tests: use mkDefault with enable ``                                                |
| [`30da4310`](https://github.com/nix-community/home-manager/commit/30da4310935450ea38931abf775ffe1dfab15355) | `` librewolf: support darwin (#6561) ``                                               |
| [`4f05ef6a`](https://github.com/nix-community/home-manager/commit/4f05ef6a8adb5c2e9de83fee6d316ce168daf705) | `` firefox: fix wrong syntax grammar for search setting isAppProvided (#6556) ``      |
| [`f0b5e7e8`](https://github.com/nix-community/home-manager/commit/f0b5e7e8a75abdea32bbff09ddd7b6eeb4b9b445) | `` xdg: add option 'xdg.cacheFile' (#6548) ``                                         |