### PR TITLE
chore(flake/stylix): `de4ee589` -> `11780517`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -857,11 +857,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1740769934,
-        "narHash": "sha256-iyxUwII/NQNClT77VqQiDpaXJz1r0Z8tNVxgY64mLak=",
+        "lastModified": 1741112087,
+        "narHash": "sha256-dBGwN4aHmX2QUXolZDhV+p06+WM5ZykL4wd9BD6bT7k=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "de4ee5899042801b62f988687acd454d4d411075",
+        "rev": "11780517948f214b9f93d1bf5a2d29bc181d3a33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`11780517`](https://github.com/danth/stylix/commit/11780517948f214b9f93d1bf5a2d29bc181d3a33) | `` ncspot: match style guide better and add transparent bg (#938) ``        |
| [`afee64f3`](https://github.com/danth/stylix/commit/afee64f3c5090b4eadc30df46bad001015744858) | `` rio: add emoji font family and convert font size to pixel unit (#937) `` |
| [`65c42633`](https://github.com/danth/stylix/commit/65c42633d4d0ebc49e8f077c289786b13a145509) | `` ci: ignore Cachix errors (#952) ``                                       |
| [`2f47285f`](https://github.com/danth/stylix/commit/2f47285f9dbd63d33f8d56517afd70758d68aa11) | `` btop: memory and disk color gradient following logical color (#935) ``   |
| [`489833b2`](https://github.com/danth/stylix/commit/489833b201a84488c6b4371a261fdbcafa6abcb6) | `` treewide: give mustache files correct file extensions (#946) ``          |