### PR TITLE
chore(flake/nixvim-flake): `6f30aa09` -> `cf86e2cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -597,11 +597,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1741321338,
-        "narHash": "sha256-cPvigQYhLhxPrbLO1ee9khU8T+hbv4arEXGf3c++wr4=",
+        "lastModified": 1741716493,
+        "narHash": "sha256-nKIJ/2c5pEvsaWAcz0+zZs+dsagJdpFY+3acyj96lzU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "6f30aa09b30669f45343b5505b5702a82620e200",
+        "rev": "cf86e2cb1ecc1a649cc19eda6f2c08102fa49aa8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                             |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
| [`cf86e2cb`](https://github.com/alesauce/nixvim-flake/commit/cf86e2cb1ecc1a649cc19eda6f2c08102fa49aa8) | `` ci: Add support for building aarch64-linux on GitHub hosted ubuntu arm runner `` |
| [`d48d84c2`](https://github.com/alesauce/nixvim-flake/commit/d48d84c200d19cdad1580d5fd0200c93d429c233) | `` ci: Run update-flakes workflow daily instead of twice monthly ``                 |
| [`c5e1356e`](https://github.com/alesauce/nixvim-flake/commit/c5e1356e902048fddb6a6fa429cddf4f896d7471) | `` feat(config/lsp): Migrate to blink.cmp from nvim-cmp (#405) ``                   |