### PR TITLE
chore(flake/git-hooks): `42b1ba08` -> `b5a62751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740915799,
-        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                          |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`f4cdd2cc`](https://github.com/cachix/git-hooks.nix/commit/f4cdd2cc618f1ad3d8e4e43da36a120d55ee2b72) | `` Improve `configPath` docs ``                                  |
| [`e2fcecd7`](https://github.com/cachix/git-hooks.nix/commit/e2fcecd7db11ee277dc9fd8c285ddfd2ae7840af) | `` Improve the error message when an existing config is found `` |
| [`d952b5be`](https://github.com/cachix/git-hooks.nix/commit/d952b5be9c76833413cd8e4dab74a6e89b3e3719) | `` Pass through all options in `run` ``                          |
| [`5af65eba`](https://github.com/cachix/git-hooks.nix/commit/5af65eba2b5d1a27111a3605dc06d59bed07aa86) | `` Use the correct path when unlinking the exising config ``     |
| [`10907c7f`](https://github.com/cachix/git-hooks.nix/commit/10907c7f1298610682d748e4476316d979d13455) | `` Remove extraneous check for git in PATH ``                    |
| [`843e005b`](https://github.com/cachix/git-hooks.nix/commit/843e005b4877e80446c87788e362537891b063ff) | `` disable expensive julia tests ``                              |
| [`316f09cb`](https://github.com/cachix/git-hooks.nix/commit/316f09cb683baabd66d8b4a55c9b28d090005ff4) | `` docs: sort sections by name ``                                |
| [`fcea9160`](https://github.com/cachix/git-hooks.nix/commit/fcea91603f24a41113c1b9e4043510b1b96e10bb) | `` Revert "ci: use self-hosted runners" ``                       |
| [`61fa9623`](https://github.com/cachix/git-hooks.nix/commit/61fa9623cba72d8bde0b84e264725584602e8cf2) | `` ci: use self-hosted runners ``                                |
| [`75796622`](https://github.com/cachix/git-hooks.nix/commit/75796622e2775e624944ff08e74777c383d2b65d) | `` docs: add supported but non-mentioned hooks ``                |
| [`1b310e63`](https://github.com/cachix/git-hooks.nix/commit/1b310e63b6934f1231c47631fd6fe56214346c08) | `` docs: sort hook sections by name ``                           |
| [`69f02f04`](https://github.com/cachix/git-hooks.nix/commit/69f02f043e8ad95dd34eb988343daea3481112f1) | `` feat: add selene hook ``                                      |