### PR TITLE
chore(flake/nix-index-database): `26a0f969` -> `66537fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -520,11 +520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740886574,
-        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
+        "lastModified": 1741619381,
+        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
+        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5f83114e`](https://github.com/nix-community/nix-index-database/commit/5f83114eb638fba4f176cb81dd8795be1a632e1f) | `` README: fix links to flakes ``                       |
| [`296a2c99`](https://github.com/nix-community/nix-index-database/commit/296a2c992a28b37427d062ade6e20d467e479e3f) | `` update generated.nix to release 2025-03-09-025742 `` |
| [`bb527ad1`](https://github.com/nix-community/nix-index-database/commit/bb527ad1e2ab6c59f3d2344fe043abaa7fd5a27d) | `` flake.lock: Update ``                                |
| [`fdaa9d2f`](https://github.com/nix-community/nix-index-database/commit/fdaa9d2fb061b3c56e4db92df9d340ab268895dd) | `` More correct Darwin example ``                       |