### PR TITLE
chore(flake/stylix): `11780517` -> `9e3ab4d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -106,11 +106,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1739223196,
-        "narHash": "sha256-vAxN2f3rvl5q62gQQjZGVSvF93nAsOxntuFz+e/655w=",
+        "lastModified": 1741628778,
+        "narHash": "sha256-RsvHGNTmO2e/eVfgYK7g+eYEdwwh7SbZa+gZkT24MEA=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "a89108e6272426f4eddd93ba17d0ea101c34fb21",
+        "rev": "5a81d390bb64afd4e81221749ec4bffcbeb5fa80",
         "type": "github"
       },
       "original": {
@@ -341,11 +341,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {
@@ -668,11 +668,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1740408283,
-        "narHash": "sha256-2xECnhgF3MU9YjmvOkrRp8wRFo2OjjewgCtlfckhL5s=",
+        "lastModified": 1741693509,
+        "narHash": "sha256-emkxnsZstiJWmGACimyAYqIKz2Qz5We5h1oBVDyQjLw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "496a4a11162bdffb9a7b258942de138873f019f7",
+        "rev": "5479646b2574837f1899da78bdf9a48b75a9fb27",
         "type": "github"
       },
       "original": {
@@ -745,11 +745,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741112087,
-        "narHash": "sha256-dBGwN4aHmX2QUXolZDhV+p06+WM5ZykL4wd9BD6bT7k=",
+        "lastModified": 1741801299,
+        "narHash": "sha256-ZN5xn3HmG5+RWBc3gGdRfkyt98Tc1IhsUK7txwAw46s=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "11780517948f214b9f93d1bf5a2d29bc181d3a33",
+        "rev": "9e3ab4d208e2cc2aef5ab0f8e18932ebf8064fc5",
         "type": "github"
       },
       "original": {
@@ -825,11 +825,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1740351358,
-        "narHash": "sha256-Hdk850xgAd3DL8KX0AbyU7tC834d3Lej1jOo3duWiOA=",
+        "lastModified": 1741468895,
+        "narHash": "sha256-YKM1RJbL68Yp2vESBqeZQBjTETXo8mCTTzLZyckCfZk=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "a1bc2bd89e693e7e3f5764cfe8114e2ae150e184",
+        "rev": "47c8c7726e98069cade5827e5fb2bfee02ce6991",
         "type": "github"
       },
       "original": {
@@ -841,11 +841,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1740272597,
-        "narHash": "sha256-/etfUV3HzAaLW3RSJVwUaW8ULbMn3v6wbTlXSKbcoWQ=",
+        "lastModified": 1740877430,
+        "narHash": "sha256-zWcCXgdC4/owfH/eEXx26y5BLzTrefjtSLFHWVD5KxU=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "b6c7f46c8718cc484f2db8b485b06e2a98304cd0",
+        "rev": "d48ee86394cbe45b112ba23ab63e33656090edb4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                              |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`9e3ab4d2`](https://github.com/danth/stylix/commit/9e3ab4d208e2cc2aef5ab0f8e18932ebf8064fc5) | `` stylix: system.darwin.release -> system.darwinRelease (#989) ``   |
| [`e28bd4de`](https://github.com/danth/stylix/commit/e28bd4de28a51216fd7c89158d82b688c3793e8e) | `` glance: fix RGB to HSL conversion (#932) ``                       |
| [`599d5a5e`](https://github.com/danth/stylix/commit/599d5a5ecaf8d3cc2d6e8a1fafcdda4c74852abb) | `` vscode: use base01 for title bar (#979) ``                        |
| [`4a8718e5`](https://github.com/danth/stylix/commit/4a8718e5a14faeef3e57ededb4efb88b0deed329) | `` stylix: add missing comma in flake description ``                 |
| [`e3233ead`](https://github.com/danth/stylix/commit/e3233ead63f555bba891b991b384eac9eb5ea76e) | `` stylix: init droid (#778) ``                                      |
| [`9dc48274`](https://github.com/danth/stylix/commit/9dc48274889d1f5349b8ebc7c83f0907f3c86588) | `` stylix: update all flake inputs (#981) ``                         |
| [`6b5afdbb`](https://github.com/danth/stylix/commit/6b5afdbb3e9e06de68d7c44dfe78a1359d422a45) | `` {firefox,floorp,librewolf}: add profile warning (#963) ``         |
| [`9388f64e`](https://github.com/danth/stylix/commit/9388f64ebe5d6bf99f35b67146f2aa0d765a12d0) | `` river: add cursor size and background color (#968) ``             |
| [`a742ba73`](https://github.com/danth/stylix/commit/a742ba739b61ac8ed344886e5c5e59cc8b0c7e1a) | `` waybar: add font option and change default to monospace (#972) `` |
| [`fc5acae5`](https://github.com/danth/stylix/commit/fc5acae54b03d9282f68d0f392cfffefbfade649) | `` stylix: add version checks (#924) ``                              |
| [`6c42dc31`](https://github.com/danth/stylix/commit/6c42dc31ef80f41d8b201ff79a3788a02d7f1834) | `` mpv: init (#949) ``                                               |
| [`6a7d5633`](https://github.com/danth/stylix/commit/6a7d563370269237f6a83f5d184e4f25233056b2) | `` vim: fix incorrect input path (#976) ``                           |
| [`2c20aed3`](https://github.com/danth/stylix/commit/2c20aed3b39a87b8ab7c0d1fef44987f8a69b2d3) | `` qt: autoenable hm module only on NixOS (#942) ``                  |
| [`c97bcf77`](https://github.com/danth/stylix/commit/c97bcf77bd2383438d6a4498881bd0f91af8e176) | `` doc: overhaul README ``                                           |
| [`5d363a00`](https://github.com/danth/stylix/commit/5d363a0051da5b2bbf14eff26c712c42f9c516ec) | `` stylix: add flake description ``                                  |
| [`a7606826`](https://github.com/danth/stylix/commit/a76068262cfc16c04f9c07a6458715548b067450) | `` palette: fix eval fail when image is null (#941) ``               |
| [`3fce9fb0`](https://github.com/danth/stylix/commit/3fce9fb038b7e24d5d6a2d5c10979d742364ef00) | `` treewide: propagate inputs and remove templates (#926) ``         |
| [`6eea250b`](https://github.com/danth/stylix/commit/6eea250b10386be0fc23496d1039d76b3147680e) | `` dunst: fix opacity rounding (#965) ``                             |
| [`4891f147`](https://github.com/danth/stylix/commit/4891f1471b682af073574dc51fa4810f1470ef8f) | `` stylix: simplify dummy values (#959) ``                           |
| [`74f1ac55`](https://github.com/danth/stylix/commit/74f1ac55d3b09fb3be23563d398b430e756a6e83) | `` fnott: init (#948) ``                                             |
| [`7fc0a871`](https://github.com/danth/stylix/commit/7fc0a8716e753f0341300ebe34cda5f8a90527f8) | `` stylix: add editorconfig (#945) ``                                |
| [`6fada03c`](https://github.com/danth/stylix/commit/6fada03cd5e223aa9c111e7073118692065a7ee1) | `` nvf: init (#939) ``                                               |
| [`48538792`](https://github.com/danth/stylix/commit/4853879264376ae7d20dea2a7af58490f179bc7a) | `` vscode: support arbitrary profiles (#914) ``                      |