### PR TITLE
chore(flake/nixvim-flake): `110c0dbc` -> `2a7cabf6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -645,11 +645,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1741752391,
-        "narHash": "sha256-miWHYI7OBO+dNDqIqA7fkU6ExLWakgJx6ggAQT36kBU=",
+        "lastModified": 1741802161,
+        "narHash": "sha256-Qb1KV+jwLb+dPo53qmF7HDyenuIg5vNCkN7pMYJX+1I=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "110c0dbcb794d7ab5b32a99829bdda8df4427a6d",
+        "rev": "2a7cabf6a07d03dc516ef2b54ef3c525cc633a78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                        |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------- |
| [`2a7cabf6`](https://github.com/alesauce/nixvim-flake/commit/2a7cabf6a07d03dc516ef2b54ef3c525cc633a78) | `` fix(config/lsp/blink): Switch to enter preset for keymap `` |