### PR TITLE
chore(flake/home-manager): `c630dfa8` -> `18780912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -443,11 +443,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741701235,
-        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
+        "lastModified": 1741791118,
+        "narHash": "sha256-4Y427uj0eql4yRU5rely3EcOlB9q457UDbG9omPtXiA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
+        "rev": "18780912345970e5b546b1b085385789b6935a83",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`18780912`](https://github.com/nix-community/home-manager/commit/18780912345970e5b546b1b085385789b6935a83) | `` home-cursor: louder deprecation ``                        |
| [`74f2ed6a`](https://github.com/nix-community/home-manager/commit/74f2ed6a64a087fadb39a4af84c5ecc8083b686d) | `` test/home-cursor: add new .enable check ``                |
| [`dcc20acf`](https://github.com/nix-community/home-manager/commit/dcc20acf93f338a47468996a0055cda1112c051c) | `` home-cursor: add doticons option ``                       |
| [`00712ac0`](https://github.com/nix-community/home-manager/commit/00712ac0fb87bbfa13e892603863469ac4fd96a0) | `` home-cursor: use .enable pattern ``                       |
| [`32531e45`](https://github.com/nix-community/home-manager/commit/32531e457215000b739da6cd40acfb080823f396) | `` home-cursor: explicit lib usage ``                        |
| [`144f13f5`](https://github.com/nix-community/home-manager/commit/144f13f535be35c906241043f6bfcf21c1c419a0) | `` flake.lock: Update (#6606) ``                             |
| [`dd41a390`](https://github.com/nix-community/home-manager/commit/dd41a39055d7eb54330b5cd0611467e5d687d022) | `` swaylock: accept path type for settings values (#6607) `` |
| [`5871e21c`](https://github.com/nix-community/home-manager/commit/5871e21c1145f3f5e278545d1c09539b52183ccd) | `` screen-locker: add lockCmdEnv option (#6592) ``           |