### PR TITLE
chore(flake/nix-fast-build): `906af17f` -> `0ef0c606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -497,11 +497,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1736592044,
-        "narHash": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
+        "lastModified": 1741859942,
+        "narHash": "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
+        "rev": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8",
         "type": "github"
       },
       "original": {
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`ceb05be1`](https://github.com/Mic92/nix-fast-build/commit/ceb05be1771ee5a50a997f89a3b1f99ec464ae44) | `` chore(deps): update cachix/install-nix-action action to v31 `` |
| [`45ec3637`](https://github.com/Mic92/nix-fast-build/commit/45ec36371c00c3b5537af90f8eeccd5014161e46) | `` flake.lock: Update ``                                          |
| [`8dee9772`](https://github.com/Mic92/nix-fast-build/commit/8dee97729ffaca37e6d51b9d69fb8b7e70e3f49f) | `` chore: add .direnv to gitignore ``                             |
| [`6089b259`](https://github.com/Mic92/nix-fast-build/commit/6089b2590741087ff58e5e628492979658736584) | `` chore: replace show-config with non-deprecated alternative ``  |