### PR TITLE
chore(flake/nixvim-flake): `2a7cabf6` -> `8637f51e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1736592044,
-        "narHash": "sha256-HkaJeIFgxncLm8MC1BaWRTkge9b1/+mjPcbzXTRshoM=",
+        "lastModified": 1741859942,
+        "narHash": "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "906af17fcd50c84615a4660d9c08cf89c01cef7d",
+        "rev": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1741802161,
-        "narHash": "sha256-Qb1KV+jwLb+dPo53qmF7HDyenuIg5vNCkN7pMYJX+1I=",
+        "lastModified": 1741922795,
+        "narHash": "sha256-a2ThdIwkwTibFb4CeJNOc6E8BhEyjwYIoK8ijyJCjjs=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "2a7cabf6a07d03dc516ef2b54ef3c525cc633a78",
+        "rev": "8637f51e4af5d09c71fb48a2dc8656c2f4f4f2a3",
         "type": "github"
       },
       "original": {
@@ -900,11 +900,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736154270,
-        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                     |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- |
| [`8637f51e`](https://github.com/alesauce/nixvim-flake/commit/8637f51e4af5d09c71fb48a2dc8656c2f4f4f2a3) | `` feat(config/snacks): Init snacks.nvim configuration. Removing indent-blankline (#415) `` |
| [`ee706910`](https://github.com/alesauce/nixvim-flake/commit/ee70691078487cbd0ca0aaa70c079accee56730c) | `` chore(flake/nixpkgs): e3e32b64 -> 6607cf78 ``                                            |
| [`bad9aeab`](https://github.com/alesauce/nixvim-flake/commit/bad9aeab41fe4bf26b75954cdfe8e6fad28b839c) | `` feat(config/lsp): Init trouble.nvim config and enable (#412) ``                          |
| [`86b8df8b`](https://github.com/alesauce/nixvim-flake/commit/86b8df8bc1f15fbeb3c2267f8ee756f409d0ac5f) | `` chore(flake/nix-fast-build): 906af17f -> 0ef0c606 ``                                     |