### PR TITLE
chore(flake/home-manager): `0b0baed7` -> `30cce684`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741894454,
-        "narHash": "sha256-Mu2YXrGr/8Cid6W44AXci/YYnASoXjGrMV9Sjs66oyc=",
+        "lastModified": 1741914680,
+        "narHash": "sha256-Vu4DIZvgfWMzhUyxbHUrJaQb5232S5vuwxQ2sBcBVHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0b0baed7b2bf6a5e365d4cba042b580a2bc32e34",
+        "rev": "30cce6848a5aa41ceb5fb33185b84868cc3e9bef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`30cce684`](https://github.com/nix-community/home-manager/commit/30cce6848a5aa41ceb5fb33185b84868cc3e9bef) | `` synthing: fix synthing config being deleted on rebuild (#6621) `` |
| [`6914c15c`](https://github.com/nix-community/home-manager/commit/6914c15c09e3e635ce678eb72f5781e5a85a6b24) | `` tests/default: scrub zsh ``                                       |
| [`8f8f5432`](https://github.com/nix-community/home-manager/commit/8f8f5432d152d64dfde0e77c61530c3754dce660) | `` tests/zsh: fix zshrc content priority test ``                     |