### PR TITLE
chore(flake/stylix): `5053a63c` -> `e43eb4e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1741880767,
-        "narHash": "sha256-tXtop1zIJMyRt1LDERIWwMAMVKdfDtFp/g37YKy2Ke4=",
+        "lastModified": 1741976991,
+        "narHash": "sha256-74Q3Kpzde+S3pWaZihNFMjCn8lo4wmDVmg+Uvw8YLLQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5053a63c87fea3508439b7e9c1a66fa6979a4694",
+        "rev": "e43eb4e2a7dfbd96454df2b1c9418299b4373773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e43eb4e2`](https://github.com/danth/stylix/commit/e43eb4e2a7dfbd96454df2b1c9418299b4373773) | `` stylix: init module maintainers framework (#977) ``         |
| [`52b1cc72`](https://github.com/danth/stylix/commit/52b1cc7247085301e94e0b77889ce2cc0b995bb3) | `` doc: implement custom option list generation (#955) ``      |
| [`6a2e5258`](https://github.com/danth/stylix/commit/6a2e5258876c46b62edacb3e51a759ed1c06332b) | `` stylix: optionalize cursor and disable by default (#943) `` |
| [`08e0c91d`](https://github.com/danth/stylix/commit/08e0c91d76e05a61ffe15bcd17ef7fa3160c5bd8) | `` ci: bump cachix/cachix-action from 15 to 16 ``              |