### PR TITLE
chore(flake/nixvim-flake): `8637f51e` -> `0775d26c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1741922795,
-        "narHash": "sha256-a2ThdIwkwTibFb4CeJNOc6E8BhEyjwYIoK8ijyJCjjs=",
+        "lastModified": 1742013979,
+        "narHash": "sha256-MXpuSxSoexsaTbalVp2OhXAiccUwgbkMjOPCh94xuVA=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "8637f51e4af5d09c71fb48a2dc8656c2f4f4f2a3",
+        "rev": "0775d26c8193ec9f49322f2e3077617e97539f4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                     |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`0775d26c`](https://github.com/alesauce/nixvim-flake/commit/0775d26c8193ec9f49322f2e3077617e97539f4b) | `` feat: Add snacks pickers and disable telescope (#416) `` |