### PR TITLE
chore(flake/nix-index-database): `5c77c6d6` -> `2cfb4e1c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742096597,
-        "narHash": "sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU=",
+        "lastModified": 1742174123,
+        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "5c77c6d6f2e8cc6007c2b1a4df1a507834404a67",
+        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                         |
| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`2cfb4e1c`](https://github.com/nix-community/nix-index-database/commit/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c) | `` build(deps): bump cachix/cachix-action from 15 to 16 ``      |
| [`9791fde5`](https://github.com/nix-community/nix-index-database/commit/9791fde548b1f5dc93aef0e8bc0cba7f67d223d8) | `` build(deps): bump cachix/install-nix-action from 30 to 31 `` |