### PR TITLE
chore(flake/stylix): `bcc674f1` -> `fa288c0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742040559,
-        "narHash": "sha256-Hb3aw00C1/5ORiTCASwMd8vcLAl/GNJfyjXZyl/EKpc=",
+        "lastModified": 1742234510,
+        "narHash": "sha256-dQoo4XivjZuJiSi8ePv9CuP0ncE64RLyz2vb46blRx0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "bcc674f1994396137438bac9d905971453d33b12",
+        "rev": "fa288c0dc695b49c9af38614af8da981371fe92a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                              |
| --------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`fa288c0d`](https://github.com/danth/stylix/commit/fa288c0dc695b49c9af38614af8da981371fe92a) | `` doc: fix testbed names (#1013) `` |