### PR TITLE
chore(flake/nixvim-flake): `332a8e72` -> `1397ea37`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1742058297,
+        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1742089570,
-        "narHash": "sha256-EbOq+EMFkila0p6Ebuyw4sZmIZep4i6SGvEANkthTaM=",
+        "lastModified": 1742175854,
+        "narHash": "sha256-KjXfJ4qgpZQS85WbjS99YIDYTWtG5m+6ha5DbzpKvfI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "332a8e72285b2315ceaca05b5f61624364666278",
+        "rev": "1397ea37a70b9398e42e422294cda6cf3b05e367",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                            |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`1397ea37`](https://github.com/alesauce/nixvim-flake/commit/1397ea37a70b9398e42e422294cda6cf3b05e367) | `` chore(flake/git-hooks): b5a62751 -> 59f17850 `` |