### PR TITLE
chore(flake/nixvim-flake): `1397ea37` -> `55ab8930`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1741814789,
-        "narHash": "sha256-NbHsnnNwiYUcUaS4z8XK2tYpo3G8NXEKxaKkzMgMiLk=",
+        "lastModified": 1742255305,
+        "narHash": "sha256-XxygfriVXQt+5Iqh6AOjZL5Aes5dH2xzVKpHpL8pDQg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "33097dcf776d1fad0ff3842096c4e3546312f251",
+        "rev": "78f6166c23f80bdfbcc8c44b20f7f4132299a33f",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1742175854,
-        "narHash": "sha256-KjXfJ4qgpZQS85WbjS99YIDYTWtG5m+6ha5DbzpKvfI=",
+        "lastModified": 1742262150,
+        "narHash": "sha256-egt3wROoF0Qyo4EOQwhoWtBgXOgU8hBSeoZW8fDfPnw=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "1397ea37a70b9398e42e422294cda6cf3b05e367",
+        "rev": "55ab89309b452547e2ebcd51a9650af9ad9868db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`55ab8930`](https://github.com/alesauce/nixvim-flake/commit/55ab89309b452547e2ebcd51a9650af9ad9868db) | `` chore(flake/nixvim): 33097dcf -> 78f6166c `` |