### PR TITLE
chore(flake/git-hooks): `59f17850` -> `ea26a82d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742058297,
-        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
+        "lastModified": 1742300892,
+        "narHash": "sha256-QmF0proyjXI9YyZO9GZmc7/uEu5KVwCtcdLsKSoxPAI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
+        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                              |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`b34e865b`](https://github.com/cachix/git-hooks.nix/commit/b34e865b1b69361ed66a3b6f39545cc336ea09af) | `` vale: fix outdated configuration variable name `` |