### PR TITLE
chore(flake/stylix): `ff9ae322` -> `f122d709`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742299802,
-        "narHash": "sha256-enlpX8hwrfmjv/dHTKWzAB5Cwt1Kr6+ptikjX3Ob+FY=",
+        "lastModified": 1742422444,
+        "narHash": "sha256-Djg5uMhIDPdFOZ7kTrqNlHaAqcx/4rp7BofZLsUHkLY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ff9ae322bcaeccabc65812390000276455331123",
+        "rev": "f122d70925ca44e5ee4216661769437ab36a6a3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                              |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`f122d709`](https://github.com/danth/stylix/commit/f122d70925ca44e5ee4216661769437ab36a6a3f) | `` avizo: hotfix aviOpcaity missing (#1023) ``                                       |
| [`41a773fb`](https://github.com/danth/stylix/commit/41a773fb0fe47c8652e7c7fd6971c8d0d2ac15ba) | `` k9s: tweak color assignment to style guide (#999) ``                              |
| [`603fe2dc`](https://github.com/danth/stylix/commit/603fe2dc7938dd1030da3ed37392b0bfb34222d1) | `` treewide: add Flameopathic as maintainer (#1026) ``                               |
| [`421e09fc`](https://github.com/danth/stylix/commit/421e09fc7351012f8f8feb1d3db556668cfa77ac) | `` doc: format Nix code in Maintainers section according to our formatter (#1024) `` |
| [`ccb411c5`](https://github.com/danth/stylix/commit/ccb411c5db16341455d82d955fef4db9985741a6) | `` mpv: set background to black (#1008) ``                                           |
| [`968f13d4`](https://github.com/danth/stylix/commit/968f13d47044bdfe07d7a96310e386145900384e) | `` starship: init (#995) ``                                                          |
| [`6e992741`](https://github.com/danth/stylix/commit/6e9927413fca18e82f1eaf5865ebf6d5ae11d5fb) | `` stylix: add editorconfig-checker pre-commit hook (#1006) ``                       |
| [`0c4ec73d`](https://github.com/danth/stylix/commit/0c4ec73df6cbf06e2baa5cb2664540906e4bdc40) | `` firefox: improve option descriptions for extensions (#998) ``                     |
| [`cca176fc`](https://github.com/danth/stylix/commit/cca176fce11ba11dca6ea3ad9d44dca742b9f732) | `` stylix: fix cursor undefined error on darwin (#1004) ``                           |