### PR TITLE
chore(flake/home-manager): `22a36aa7` -> `eb0f617a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742326330,
-        "narHash": "sha256-Tumt3tcMXJniSh7tw2gW+WAnVLeB3WWm+E+yYFnLBXo=",
+        "lastModified": 1742416832,
+        "narHash": "sha256-ycok0eJJcoknqaibdv/TEEEOUqovC42XCqbfLDYmnoQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "22a36aa709de7dd42b562a433b9cefecf104a6ee",
+        "rev": "eb0f617aecbaf1eff5bacec789891e775af2f5a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`eb0f617a`](https://github.com/nix-community/home-manager/commit/eb0f617aecbaf1eff5bacec789891e775af2f5a3) | `` tex-fmt: add null package support ``                                    |
| [`9556d3c2`](https://github.com/nix-community/home-manager/commit/9556d3c2b48c0ec9a5cf4aa444b368cfb85fa60e) | `` tex-fmt: add module ``                                                  |
| [`8b629b54`](https://github.com/nix-community/home-manager/commit/8b629b5424dd2b10ff5cbca7fa52fa66ef33a196) | `` firefox: migrate search config to v12 ``                                |
| [`b44d79a5`](https://github.com/nix-community/home-manager/commit/b44d79a5b2d63ec1286fd4cb6d347df2b90679cb) | `` firefox: migrate search config to v11 ``                                |
| [`c1dc900a`](https://github.com/nix-community/home-manager/commit/c1dc900a1ac0b2688115508c7b3c2a70a990ff8d) | `` firefox: migrate search config to v7 ``                                 |
| [`b5976017`](https://github.com/nix-community/home-manager/commit/b5976017741653251258112f7e6ee5d8b9e3a832) | `` easyeffects: remove with lib ``                                         |
| [`e278f46a`](https://github.com/nix-community/home-manager/commit/e278f46a0990344b3186d09a35350fbcb6fa4dbd) | `` easyeffects: add hausken as maintainer ``                               |
| [`6b8cea64`](https://github.com/nix-community/home-manager/commit/6b8cea647349f53f2d57399535478001bebed053) | `` easyeffects: add option to import presets ``                            |
| [`e4a40b44`](https://github.com/nix-community/home-manager/commit/e4a40b441e49443ffd25c05614ad9c134a12e53c) | `` waylogout: add path support ``                                          |
| [`16a2a802`](https://github.com/nix-community/home-manager/commit/16a2a802de24a122800ec744639976cb457dde23) | `` waylogout: nullable package support ``                                  |
| [`e0be70bc`](https://github.com/nix-community/home-manager/commit/e0be70bcf94be20f8f0f6d215d909b614ab6ebeb) | `` waylogout: remove with lib ``                                           |
| [`1e0c64b6`](https://github.com/nix-community/home-manager/commit/1e0c64b6a23f2b7cd02106b0083069476c7fab61) | `` waylogout: added configuration module ``                                |
| [`0d616edb`](https://github.com/nix-community/home-manager/commit/0d616edbacaa4e6a8cf794e573244f3d948f4150) | `` maintainers: add noodlez ``                                             |
| [`27a72d99`](https://github.com/nix-community/home-manager/commit/27a72d991305cfd9b15018a6e7eb3db93a32bc60) | `` podman: include systemd in quadlet service path ``                      |
| [`bb72d79f`](https://github.com/nix-community/home-manager/commit/bb72d79f5d319a11fd6226303ebf7a5dd1fd1913) | `` podman: use type in attr name of built quadlets ``                      |
| [`8bb07191`](https://github.com/nix-community/home-manager/commit/8bb071912b32e858cfc4daba1a5683d5c62f1955) | `` podman: warn if values match a quadlet only by name ``                  |
| [`81bf639d`](https://github.com/nix-community/home-manager/commit/81bf639da70763a844b79ffecd5de59b83f5ecb2) | `` podman: link dependent quadlets during build ``                         |
| [`4108ec3a`](https://github.com/nix-community/home-manager/commit/4108ec3aa80244948d86f95c82c1dfc22daeb35c) | `` podman: use dependency quadlets directly in build for generator ``      |
| [`eb5d59da`](https://github.com/nix-community/home-manager/commit/eb5d59dac9d77717135fdec1ef51c14a72e8c9f9) | `` rclone: add module ``                                                   |
| [`66f565db`](https://github.com/nix-community/home-manager/commit/66f565db48ebc9cef33f651c44151e7355400e10) | `` maintainers: add jess ``                                                |
| [`9d554281`](https://github.com/nix-community/home-manager/commit/9d554281e059196661f4dbb44e99f2eff9bfd381) | `` firefox: refactor bookmarks into a submodule & require force (#6402) `` |
| [`1727f417`](https://github.com/nix-community/home-manager/commit/1727f417b7774953fe081ebb3757b60dab8a2943) | `` flake.lock: Update (#6636) ``                                           |
| [`62dc8c30`](https://github.com/nix-community/home-manager/commit/62dc8c30ef292c003610ebae62ec5ec7544cdffe) | `` home-manager: add autocomplete for `--log-format` ``                    |
| [`229648c5`](https://github.com/nix-community/home-manager/commit/229648c51e732cb8e70de7e0af5223f3e8160304) | `` home-manager: support `--log-format` flag (#6093) ``                    |