### PR TITLE
chore(flake/nixvim-flake): `1b572710` -> `38097b64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742058297,
-        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
+        "lastModified": 1742300892,
+        "narHash": "sha256-QmF0proyjXI9YyZO9GZmc7/uEu5KVwCtcdLsKSoxPAI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
+        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1742348521,
-        "narHash": "sha256-eOrTt/yrBYbPe5wXdf8ABoW5xtPGG3B9E51GvXQEhd8=",
+        "lastModified": 1742434863,
+        "narHash": "sha256-32EP7daROgie/H9f9h9vNCLxo1Rhc81xkMeSUew8Ik8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "1b5727102ed8d8b968338f28b0e28bb05a002385",
+        "rev": "38097b6465945c2a06033b8faf403953ff08286b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                            |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`38097b64`](https://github.com/alesauce/nixvim-flake/commit/38097b6465945c2a06033b8faf403953ff08286b) | `` chore(flake/git-hooks): 59f17850 -> ea26a82d `` |