### PR TITLE
chore(flake/stylix): `f122d709` -> `7e990667`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742422444,
-        "narHash": "sha256-Djg5uMhIDPdFOZ7kTrqNlHaAqcx/4rp7BofZLsUHkLY=",
+        "lastModified": 1742496983,
+        "narHash": "sha256-UpJrU0DEhNLVZwL/RPVOEUHCG6iDOVDoYelkmgS4V38=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f122d70925ca44e5ee4216661769437ab36a6a3f",
+        "rev": "7e9906679d384472849272e5a5eef7adbdb1d87f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`7e990667`](https://github.com/danth/stylix/commit/7e9906679d384472849272e5a5eef7adbdb1d87f) | `` stylix: check whether maintainers list is sorted (#1014) `` |
| [`64b4369b`](https://github.com/danth/stylix/commit/64b4369b6b24751c555d5bf887b52d6dbc419c6f) | `` doc: display module maintainers (#1010) ``                  |
| [`07c4f39b`](https://github.com/danth/stylix/commit/07c4f39b5b8d19930235cacbc05600fdcf1a2551) | `` halloy: add copyright notice (#1035) ``                     |