### PR TITLE
chore(flake/home-manager): `eb0f617a` -> `da018181`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742416832,
-        "narHash": "sha256-ycok0eJJcoknqaibdv/TEEEOUqovC42XCqbfLDYmnoQ=",
+        "lastModified": 1742508854,
+        "narHash": "sha256-vQQTIl4+slrcu7ftVKNBql9ngBdY0dcYGujdT7zIVp0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "eb0f617aecbaf1eff5bacec789891e775af2f5a3",
+        "rev": "da0181819479ddc034a3db9a77ed21ea3bcc0668",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`da018181`](https://github.com/nix-community/home-manager/commit/da0181819479ddc034a3db9a77ed21ea3bcc0668) | `` tests: scrub lazy{docker,git} on darwin ``                          |
| [`2e9981ca`](https://github.com/nix-community/home-manager/commit/2e9981ca0d6cee56f54a5e265b5edcd4dfc1b554) | `` lazydocker: null package support ``                                 |
| [`65413f29`](https://github.com/nix-community/home-manager/commit/65413f297f8c4c42a99270c15bce7bda1bfea724) | `` lazydocker: remove with lib ``                                      |
| [`46efc3b2`](https://github.com/nix-community/home-manager/commit/46efc3b2e14783d39f595cb0e5954a3a1edb0217) | `` lazydocker: add module ``                                           |
| [`20ec3c10`](https://github.com/nix-community/home-manager/commit/20ec3c10498938c3ff78075b5fae94fe1cd4a715) | `` mcfly: Fix swapped shell names ``                                   |
| [`d725df5a`](https://github.com/nix-community/home-manager/commit/d725df5ad8cee60e61ee6fe3afb735e4fbc1ff41) | `` mcfly: fix mcfly-fzf in non-interactive shells (#6669) ``           |
| [`fc189507`](https://github.com/nix-community/home-manager/commit/fc189507bc0bc74b3794ee6912a5b80de8dfcc0c) | `` docs: nixos module declarative installation instructions (#6208) `` |
| [`c36cc49e`](https://github.com/nix-community/home-manager/commit/c36cc49e55aff5562b0ca924f34285de6d6273be) | `` onlyoffice: add module (#6667) ``                                   |
| [`94605dca`](https://github.com/nix-community/home-manager/commit/94605dcadefeaff6b35c8931c9f38e4f4dc7ad0a) | `` tests/firefox: add applicationName to mock (#6668) ``               |
| [`97a00e06`](https://github.com/nix-community/home-manager/commit/97a00e0659b2807454507eb3a593bd09b099bd80) | `` librespot: init module (#6229) ``                                   |
| [`8675edf7`](https://github.com/nix-community/home-manager/commit/8675edf7d36bfc972f66481a33f4f453d3b2d06e) | `` fish: add command option for abbreviations (#6666) ``               |
| [`cfaa4426`](https://github.com/nix-community/home-manager/commit/cfaa4426a3eee6e71ab02a4d72410e69abf06a12) | `` megasync: use getExe instead of getExe' (#6665) ``                  |