### PR TITLE
chore(flake/git-hooks): `ea26a82d` -> `dcf50727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742300892,
-        "narHash": "sha256-QmF0proyjXI9YyZO9GZmc7/uEu5KVwCtcdLsKSoxPAI=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`215e290e`](https://github.com/cachix/git-hooks.nix/commit/215e290e965202a4094c301231e31013e2a9aceb) | `` chore(deps): update cachix/install-nix-action action to v31 `` |