### PR TITLE
chore(flake/home-manager): `63e77d09` -> `ad0614a1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742670145,
-        "narHash": "sha256-xQ2F9f+ICAGBp/nNv3ddD2U4ZvzuLOci0u/5lyMXPvk=",
+        "lastModified": 1742771635,
+        "narHash": "sha256-HQHzQPrg+g22tb3/K/4tgJjPzM+/5jbaujCZd8s2Mls=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "63e77d09a133ac641a0c204e7cfb0c97e133706d",
+        "rev": "ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ad0614a1`](https://github.com/nix-community/home-manager/commit/ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818) | `` firefox: don't show migration warning when bookmarks isn't set (#6689) `` |
| [`4f453846`](https://github.com/nix-community/home-manager/commit/4f4538467fd29a8f5037c0939592cd89cd401155) | `` firefox: fix migrate search v7 test for all firefox forks (#6690) ``      |
| [`0e75a404`](https://github.com/nix-community/home-manager/commit/0e75a40458d065d1e5c6a10d0b74b9e35b550ae6) | `` firefox: fix assertion when missing force for extensions (#6688) ``       |
| [`ecbcd792`](https://github.com/nix-community/home-manager/commit/ecbcd792e1f6cd018b0858b5b3d11733cd19c46f) | `` firefox: check if bookmarks attrset is of correct type ``                 |
| [`d7f451d7`](https://github.com/nix-community/home-manager/commit/d7f451d7b13bbe075abecfd345f8b149a000216a) | `` firefox: replace with-lib-expression with inherit-expression ``           |
| [`62d6a893`](https://github.com/nix-community/home-manager/commit/62d6a8931eb03b8bcaca425dbbe5b327c794ec37) | `` firefox: fix bookmarks backwards compatibility ``                         |
| [`5ff90f09`](https://github.com/nix-community/home-manager/commit/5ff90f09d1bd189b722e60798513724cdd3580b6) | `` wofi: merge multiple style definitions (#6673) ``                         |
| [`b61ae3b6`](https://github.com/nix-community/home-manager/commit/b61ae3b677a07c30cf6be5233e772b97a3a8b2fb) | `` flake.lock: Update (#6684) ``                                             |
| [`57e9a8a2`](https://github.com/nix-community/home-manager/commit/57e9a8a290cbeeb173b12d6bec1681e177ce6570) | `` davmail: init module (#6674) ``                                           |
| [`9172a6f9`](https://github.com/nix-community/home-manager/commit/9172a6f956f7e0f7810861b9b1146f1c43d9abcb) | `` skhd: add module (#6682) ``                                               |
| [`7853236f`](https://github.com/nix-community/home-manager/commit/7853236fae80bb625c319df8d730cad2a5584f26) | `` rclone: ensure remotes have a type field ``                               |
| [`7a08b8c8`](https://github.com/nix-community/home-manager/commit/7a08b8c898bb594f271bbabd3972af2c89d68b11) | `` rclone: correctly escape whitespace in secrets ``                         |