### PR TITLE
chore(flake/stylix): `113643f3` -> `d9df91c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1742591463,
-        "narHash": "sha256-CguaHULcm4RuIGN+i4u80dYZujFgZaeOTiShFxCwFhw=",
+        "lastModified": 1742753562,
+        "narHash": "sha256-EBXgl3sPi5AQUM58XGuuC8HQl/Df+Dbt6pOLInInJ/k=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "113643f332e1f70d90991722f8c4e5a0ace6fd06",
+        "rev": "d9df91c55643a8b5229a3ae3a496a30f14965457",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`d9df91c5`](https://github.com/danth/stylix/commit/d9df91c55643a8b5229a3ae3a496a30f14965457) | `` vscode: theme default profile by default (#1015) ``   |
| [`a55488c2`](https://github.com/danth/stylix/commit/a55488c247928380ee6a18c0a3a56a2d52fe06bc) | `` doc: reduce overuse of alerts (#1041) ``              |
| [`f537d507`](https://github.com/danth/stylix/commit/f537d507c3ac287ee0cbf36b7e514c403daed0f8) | `` doc: add subheading before module metadata (#1042) `` |