### PR TITLE
chore(flake/home-manager): `ad0614a1` -> `c4d5d728`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742771635,
-        "narHash": "sha256-HQHzQPrg+g22tb3/K/4tgJjPzM+/5jbaujCZd8s2Mls=",
+        "lastModified": 1742851132,
+        "narHash": "sha256-8vEcDefstheV1whup+5fSpZu4g9Jr7WpYzOBKAMSHn4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818",
+        "rev": "c4d5d72805d14ea43c140eeb70401bf84c0f11b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`c4d5d728`](https://github.com/nix-community/home-manager/commit/c4d5d72805d14ea43c140eeb70401bf84c0f11b4) | `` neomutt: remove empty lines (#6523) ``                        |
| [`2d057cd9`](https://github.com/nix-community/home-manager/commit/2d057cd9d4f767737498e0aae75b07353c75bdee) | `` zellij: use mkPackageOption ``                                |
| [`a9042b53`](https://github.com/nix-community/home-manager/commit/a9042b53c2be62487c33ec296a27623989320e2a) | `` zellij: default integration disabled again ``                 |
| [`82a32114`](https://github.com/nix-community/home-manager/commit/82a32114771cb3d7f392c48d679a7f66c064dd46) | `` zellij: add khaneliman maintainer ``                          |
| [`10dca990`](https://github.com/nix-community/home-manager/commit/10dca990ae02aaf41ff12c5b18dd3dcf258c0d04) | `` zellij: remove with lib ``                                    |
| [`6d4148df`](https://github.com/nix-community/home-manager/commit/6d4148df8e531b264c87ad86a151a4ea3047a1b5) | `` zellij: refactor implementation ``                            |
| [`0394c71f`](https://github.com/nix-community/home-manager/commit/0394c71f2bc00be1e8e76d2931549721c710904c) | `` zellij: Add additional options for integrating with shells `` |
| [`908e055e`](https://github.com/nix-community/home-manager/commit/908e055e157a0b35466faf4125d7e7410ff56160) | `` git: option to use difftastic as difftool (#5335) ``          |