### PR TITLE
chore(flake/home-manager): `c4d5d728` -> `0ff53f6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742851132,
-        "narHash": "sha256-8vEcDefstheV1whup+5fSpZu4g9Jr7WpYzOBKAMSHn4=",
+        "lastModified": 1742946951,
+        "narHash": "sha256-us5DS0XGVpZBMbYs3TSQYn61bswEPmLpBOYITD4/bUE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c4d5d72805d14ea43c140eeb70401bf84c0f11b4",
+        "rev": "0ff53f6d336edb3ad81647dc931ad1c9c7f890ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                          |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`0ff53f6d`](https://github.com/nix-community/home-manager/commit/0ff53f6d336edb3ad81647dc931ad1c9c7f890ca) | `` helix: add extraConfig option (#6575) ``                                                      |
| [`2321c688`](https://github.com/nix-community/home-manager/commit/2321c6889bd473d384b687c7d536d88fec3b3256) | `` ripgrep-all: Add module (#5459) ``                                                            |
| [`338b2eab`](https://github.com/nix-community/home-manager/commit/338b2eabdfde14a79755341ea472e2c55d1064c4) | `` waybar: integrate with tray.target (#6675) ``                                                 |
| [`b9da58d5`](https://github.com/nix-community/home-manager/commit/b9da58d50551ebd74226fb8487b248a5a36c988f) | `` carapace: conditionally disable unnecessary fish completion workaround on fish 4.0 (#6694) `` |
| [`f565da89`](https://github.com/nix-community/home-manager/commit/f565da89e759ebf57b236510aa955b8a2d41c779) | `` davmail: add package option (#6705) ``                                                        |
| [`d8b4ba07`](https://github.com/nix-community/home-manager/commit/d8b4ba070f5dfcb6c051c74fb31eafb58127580b) | `` mergiraf: init module (#6633) ``                                                              |
| [`8bef8b7a`](https://github.com/nix-community/home-manager/commit/8bef8b7a0a95d347018f09b291e2fa0a77abd23f) | `` direnv: fix typo ``                                                                           |
| [`529906d6`](https://github.com/nix-community/home-manager/commit/529906d6a2ef020130110f4f8214a4513aa7996f) | `` podman: fix typo ``                                                                           |
| [`5abb21dc`](https://github.com/nix-community/home-manager/commit/5abb21dc10e4a9aaee5874c36e800a2609eceaef) | `` distrobox: fix typo ``                                                                        |
| [`e3dded7a`](https://github.com/nix-community/home-manager/commit/e3dded7a85c68f8445a735d70920fc00a808621b) | `` fish: Fix manpage completion generation with paths containing spaces (#6703) ``               |
| [`29806065`](https://github.com/nix-community/home-manager/commit/298060655681ec239491252da9b295d854ff51fe) | `` distrobox: replace hardcoded path with config package's path (#6701) ``                       |
| [`869f2ec2`](https://github.com/nix-community/home-manager/commit/869f2ec2add75ce2a70a6dbbf585b8399abec625) | `` zsh: fix concatenation of aliases and global aliases (#6698) ``                               |