### PR TITLE
chore(flake/home-manager): `0ff53f6d` -> `693840c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742946951,
-        "narHash": "sha256-us5DS0XGVpZBMbYs3TSQYn61bswEPmLpBOYITD4/bUE=",
+        "lastModified": 1742996658,
+        "narHash": "sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0ff53f6d336edb3ad81647dc931ad1c9c7f890ca",
+        "rev": "693840c01b9bef9e54100239cef937e53d4661bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`693840c0`](https://github.com/nix-community/home-manager/commit/693840c01b9bef9e54100239cef937e53d4661bf) | `` vscode: Fix version checks when using Cursor (#6680) `` |
| [`ce287a5c`](https://github.com/nix-community/home-manager/commit/ce287a5cd3ef78203bc78021447f937a988d9f6f) | `` mpdscribble: add module (#6259) ``                      |