### PR TITLE
chore(flake/nixvim-flake): `c2505f50` -> `6bc64d4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1742862631,
-        "narHash": "sha256-TGeFlONiQxKbgt39pKPnh5gD0NQ/DD8v6FRisD7q+MI=",
+        "lastModified": 1742916868,
+        "narHash": "sha256-2eN75OsaNpL3FzAs3hz9Xm3+htIP3iLdfRP6PGfOoS8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ec92a1816e7deb33d03ff0ab7692fa504e3d1910",
+        "rev": "6b95b825529aa2d8536f7684fe64382ef4d15d84",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1742867045,
-        "narHash": "sha256-kRjIC/zCSPIDG6eevvGV2+ArNN2gkOjeqRMYOM/lw7M=",
+        "lastModified": 1742953370,
+        "narHash": "sha256-/UhkLaHVLri/Pdf/83tpalzxk9hdKqLYoArzal4Ky1M=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "c2505f508623093831cb57c4d11aa1801f79bacc",
+        "rev": "6bc64d4e93ae97ec9cc900d715a9c271fce306ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`6bc64d4e`](https://github.com/alesauce/nixvim-flake/commit/6bc64d4e93ae97ec9cc900d715a9c271fce306ce) | `` chore(flake/nixvim): ec92a181 -> 6b95b825 `` |