### PR TITLE
chore(flake/home-manager): `693840c0` -> `b14a70c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742996658,
-        "narHash": "sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA=",
+        "lastModified": 1743097780,
+        "narHash": "sha256-5tUbaMBKYbfTe/4aXACxmiXG22TgwPBNcfZ8Kg3rt+g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "693840c01b9bef9e54100239cef937e53d4661bf",
+        "rev": "b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`b14a70c4`](https://github.com/nix-community/home-manager/commit/b14a70c40f4fd0b73d095ab04a7c6e31fbc18e52) | `` fzf: update zsh integration to be after plugins (#6716) ``      |
| [`171915bf`](https://github.com/nix-community/home-manager/commit/171915bfce41018528fda9960211e81946d999b7) | `` fzf: fix zsh integration (keybinds rewritten by omz) (#6712) `` |