### PR TITLE
chore(flake/stylix): `2fb8321e` -> `8fce9170`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743075971,
-        "narHash": "sha256-8fSI6C19ZTcHgvoLK17wfEEVI08tgnZfSLgVe3E/22w=",
+        "lastModified": 1743289743,
+        "narHash": "sha256-N+6FE5K9yHJWBrk9RRXnLg5xPVoz/wgIDbfw5KmLeiI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "2fb8321ea16c595e0208b22021ddaf1f471c634a",
+        "rev": "8fce91704d59dbe5bf0d76b166866ed33f2359c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`8fce9170`](https://github.com/danth/stylix/commit/8fce91704d59dbe5bf0d76b166866ed33f2359c9) | `` doc: add license check to PR template (#1072) ``             |
| [`21b90991`](https://github.com/danth/stylix/commit/21b90991afd366f7bf9d2c7fd51095c7015907eb) | `` doc: improve maintainer subheading in PR template (#1071) `` |
| [`0323253b`](https://github.com/danth/stylix/commit/0323253b3ee48ba132071fe626eddfcb5cbb8b6b) | `` mpv: init mpvScripts.modernz (#1067) ``                      |