### PR TITLE
chore(flake/darwin): `75f8e4db` -> `53d0f0ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743125241,
-        "narHash": "sha256-TA/xYqZbBwCCprXf8ABORDsjJy0Idw6OdQNqYQhgKCM=",
+        "lastModified": 1743221873,
+        "narHash": "sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "75f8e4dbc553d3052f917e66ee874f69d49c9981",
+        "rev": "53d0f0ed11487a4476741fde757d0feabef4cc4e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`75a7fb88`](https://github.com/nix-darwin/nix-darwin/commit/75a7fb885d0afcaa77e6c930be991aab6a6755ab) | `` website: try to fix redirect ``               |
| [`516590cf`](https://github.com/nix-darwin/nix-darwin/commit/516590cf1299aceb7f987d433e14f406f9089973) | `` website: fix manual path ``                   |
| [`2c77fdbf`](https://github.com/nix-darwin/nix-darwin/commit/2c77fdbfba643fbd201837c1dcff5fcdf340da39) | `` ci: deploy the website from GitHub Actions `` |
| [`a5af2a5b`](https://github.com/nix-darwin/nix-darwin/commit/a5af2a5b22f991987a19cee673ac9f9c09587f1f) | `` readme: use logo from GitHub attachments ``   |