### PR TITLE
chore(flake/darwin): `53d0f0ed` -> `eaff8219`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743221873,
-        "narHash": "sha256-i8VPNm4UBsC3Ni6VwjojVJvCpS9GZ4vPrpFRtCGJzBs=",
+        "lastModified": 1743350051,
+        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "53d0f0ed11487a4476741fde757d0feabef4cc4e",
+        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`e7bd2f8f`](https://github.com/nix-darwin/nix-darwin/commit/e7bd2f8f2f0829149ce99142e2ad1cdce9dff155) | `` nix-tools: re‐add `nixPackage` `` |