### PR TITLE
chore(flake/nix-index-database): `36dc43cb` -> `b3696bfb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742701275,
-        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
+        "lastModified": 1743306489,
+        "narHash": "sha256-LROaIjSLo347cwcHRfSpqzEOa2FoLSeJwU4dOrGm55E=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
+        "rev": "b3696bfb6c24aa61428839a99e8b40c53ac3a82d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b3696bfb`](https://github.com/nix-community/nix-index-database/commit/b3696bfb6c24aa61428839a99e8b40c53ac3a82d) | `` update generated.nix to release 2025-03-30-032852 `` |
| [`08fe8035`](https://github.com/nix-community/nix-index-database/commit/08fe80353defd342c4eaef5fce236f48516f46d3) | `` flake.lock: Update ``                                |