### PR TITLE
chore(flake/home-manager): `71703001` -> `b6fd653e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743295846,
-        "narHash": "sha256-hKKz07d4RV9gzxzE5Qu3RQWX8a7XpzRrP5timoxoGRQ=",
+        "lastModified": 1743360001,
+        "narHash": "sha256-HtpS/ZdgWXw0y+aFdORcX5RuBGTyz3WskThspNR70SM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "717030011980e9eb31eb8ce011261dd532bce92c",
+        "rev": "b6fd653ef8fbeccfd4958650757e91767a65506d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                           |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`b6fd653e`](https://github.com/nix-community/home-manager/commit/b6fd653ef8fbeccfd4958650757e91767a65506d) | `` newsboat: add a package option to the module (#6717) ``                        |
| [`09280e17`](https://github.com/nix-community/home-manager/commit/09280e17bbd29536efd1549751038fa155489bd4) | `` xdg-autostart: Add readOnly option (#6629) ``                                  |
| [`1d2ed9c5`](https://github.com/nix-community/home-manager/commit/1d2ed9c503cf41ca7f3db091edc8519dcdcd8b41) | `` flake.lock: Update (#6730) ``                                                  |
| [`802653e5`](https://github.com/nix-community/home-manager/commit/802653e5d1f654ac67c045ca6eea8c8cfa8fc052) | `` auto-upgrade: unbreak on unattended, loginctl enable-linger systems (#6719) `` |
| [`8ce84337`](https://github.com/nix-community/home-manager/commit/8ce84337430492b984a7ddd73371773e8d19ad73) | `` granted: Add override for package (#6722) ``                                   |
| [`2760046f`](https://github.com/nix-community/home-manager/commit/2760046f34780cc72f67e06240ccf6a7a3ae3765) | `` docs: correct improper import of home.nix (#6732) ``                           |