### PR TITLE
chore(flake/stylix): `8fce9170` -> `eede7135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743289743,
-        "narHash": "sha256-N+6FE5K9yHJWBrk9RRXnLg5xPVoz/wgIDbfw5KmLeiI=",
+        "lastModified": 1743347063,
+        "narHash": "sha256-2wCoQhyHo3lIRkm/Y4d2ViknCQHhoS2qGvjm//Noo90=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8fce91704d59dbe5bf0d76b166866ed33f2359c9",
+        "rev": "eede71351571c60b87dbf9eefb7ddf2b11fb1354",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                        |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`eede7135`](https://github.com/danth/stylix/commit/eede71351571c60b87dbf9eefb7ddf2b11fb1354) | `` ci: prevent unintentional credential persistence (#1074) `` |
| [`20117a58`](https://github.com/danth/stylix/commit/20117a58eb73c0ac36d1421ba9dd89392053da9a) | `` ci: run all builds in a single job (#1069) ``               |