### PR TITLE
chore(flake/stylix): `eede7135` -> `711bd28a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743347063,
-        "narHash": "sha256-2wCoQhyHo3lIRkm/Y4d2ViknCQHhoS2qGvjm//Noo90=",
+        "lastModified": 1743464673,
+        "narHash": "sha256-XQXrK7o2c/5VgiyaSbaIeKhtfhSiF5ykppITYzPnXtk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "eede71351571c60b87dbf9eefb7ddf2b11fb1354",
+        "rev": "711bd28ac96dec8c9187f8db4a297677eef2e654",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                      |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`711bd28a`](https://github.com/danth/stylix/commit/711bd28ac96dec8c9187f8db4a297677eef2e654) | `` stylix: add missing parentheses around mkMerge (#1078) `` |
| [`b45eb498`](https://github.com/danth/stylix/commit/b45eb498944ffeae47aba8d1e42b8449fd07ca08) | `` docs: add trick about lib.mkAfter (#1055) ``              |
| [`1a2f1af9`](https://github.com/danth/stylix/commit/1a2f1af9f999b23c44a0b15a8841a7a297576a9c) | `` discord: add extraCss option (#1058) ``                   |
| [`eb19696b`](https://github.com/danth/stylix/commit/eb19696b18fd65ddcc6fbec5056b92b75b4f4343) | `` stylix: add overlay module (#1048) ``                     |
| [`c546582b`](https://github.com/danth/stylix/commit/c546582bae1a2c8745295a167b8db779215d780b) | `` bat: add copyright notice (#1070) ``                      |