### PR TITLE
chore(flake/stylix): `711bd28a` -> `54721996`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743464673,
-        "narHash": "sha256-XQXrK7o2c/5VgiyaSbaIeKhtfhSiF5ykppITYzPnXtk=",
+        "lastModified": 1743496321,
+        "narHash": "sha256-xhHg8ixBhZngvGOMb2SJuJEHhHA10n8pA02fEKuKzek=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "711bd28ac96dec8c9187f8db4a297677eef2e654",
+        "rev": "54721996d6590267d095f63297d9051e9342a33d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                 |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`54721996`](https://github.com/danth/stylix/commit/54721996d6590267d095f63297d9051e9342a33d) | `` doc: add links between NVF, Neovim, Nixvim, and Vim pages (#1040) `` |