### PR TITLE
chore(flake/nix-fast-build): `0ef0c606` -> `9d86462d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1741859942,
-        "narHash": "sha256-lOMeXwNYIiX+/8unr+6blKkeWBJ2TRfJ2xGJ1Xo/qFw=",
+        "lastModified": 1743551091,
+        "narHash": "sha256-wh/jJGlGu17wj2cjbOkxq+7EizJ4+lR/D7UQyppJcjU=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "0ef0c6065345426fb4872c9ee75a58c11f62d3f8",
+        "rev": "9d86462d2cbf8f91f99a2c92f2accb6aeff4f7b9",
         "type": "github"
       },
       "original": {
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1743081648,
+        "narHash": "sha256-WRAylyYptt6OX5eCEBWyTwOEqEtD6zt33rlUkr6u3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "29a3d7b768c70addce17af0869f6e2bd8f5be4b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`9d86462d`](https://github.com/Mic92/nix-fast-build/commit/9d86462d2cbf8f91f99a2c92f2accb6aeff4f7b9) | `` chore(deps): update flake-parts digest to c621e84 (#103) `` |
| [`611e285a`](https://github.com/Mic92/nix-fast-build/commit/611e285a5a218c67e76eabdfc3a5056cb53f402c) | `` chore(deps): update nixpkgs digest to a180027 (#102) ``     |
| [`8b69b58c`](https://github.com/Mic92/nix-fast-build/commit/8b69b58c51fb8f4b405c6c8d765ce7190e6f7f59) | `` drop mergify ``                                             |
| [`dcca80d1`](https://github.com/Mic92/nix-fast-build/commit/dcca80d195610471fcdcb534b11465876f79fa7a) | `` add auto-merge github action ``                             |
| [`8b883a50`](https://github.com/Mic92/nix-fast-build/commit/8b883a50b79aa96200c5fb24c5702a34c6c0070b) | `` drop github action to update lock files ``                  |
| [`ba64b4d8`](https://github.com/Mic92/nix-fast-build/commit/ba64b4d87937be0b33ad46a66dd8c03158372c63) | `` flake.lock: Update ``                                       |
| [`87241a45`](https://github.com/Mic92/nix-fast-build/commit/87241a458ddf7e6ef50b01331df22112b51efeee) | `` Don't report negative durations ``                          |
| [`5aceac97`](https://github.com/Mic92/nix-fast-build/commit/5aceac97475f3fb5de3276561d7202faf8c35a44) | `` List only the really failed attrs as failed ``              |