### PR TITLE
chore(flake/darwin): `eaff8219` -> `73d59580`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743350051,
-        "narHash": "sha256-QtVfBQe5VBnRPP5ustegPlsTdV/SZzt8akOIN5Hlwjk=",
+        "lastModified": 1743496612,
+        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "eaff8219d629bb86e71e3274e1b7915014e7fb22",
+        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                 |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`1b8d7118`](https://github.com/nix-darwin/nix-darwin/commit/1b8d71182676c7820b4cac0067ac0432860edb63) | `` linux-builder: format ``                                             |
| [`b8939c4f`](https://github.com/nix-darwin/nix-darwin/commit/b8939c4fe41adbcb619b8ee477a309c8baca0dcf) | `` linux-builder: remove /nix/store external directory when disabled `` |
| [`a175c68f`](https://github.com/nix-darwin/nix-darwin/commit/a175c68f3fa3d072b935518d0dd3d20c71048458) | `` linux-builder: upgrade working directory ``                          |