### PR TITLE
chore(flake/home-manager): `ccd7df83` -> `938e802b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743438213,
-        "narHash": "sha256-ZZDN+0v1r4I1xkQWlt8euOJv5S4EvElUCZMrDjTCEsY=",
+        "lastModified": 1743553103,
+        "narHash": "sha256-mfqG5NEa1APkqiGT2arkBDHUeDm+1afFpTcwyE+Szbo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ccd7df836e1f42ea84806760f25b77b586370259",
+        "rev": "938e802b70ee7700141b18ef8dca05ad89917a37",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`938e802b`](https://github.com/nix-community/home-manager/commit/938e802b70ee7700141b18ef8dca05ad89917a37) | `` alacritty: add `theme` option (#5238) ``                                                   |
| [`e355ae93`](https://github.com/nix-community/home-manager/commit/e355ae93a3cdaff64a3152c78b944ef36a85e8ce) | `` docs: add docs for mkOutOfStoreSymlink (#6660) ``                                          |
| [`89279a66`](https://github.com/nix-community/home-manager/commit/89279a66f4c6c32ea39940a6af63171dae75aafd) | `` fcitx5: set SDL_IM_MODULE (#6742) ``                                                       |
| [`f4d9d1e2`](https://github.com/nix-community/home-manager/commit/f4d9d1e2ad19d544a0a0cf3f8f371c6139c762e9) | `` broot: get rid of IFDs (#6723) ``                                                          |
| [`0afad8f0`](https://github.com/nix-community/home-manager/commit/0afad8f08014c992c832466c1d46a0aa96ca2563) | `` Revert "nixos-module: Fix potential recursion between users.users and home-ma…" (#6745) `` |
| [`55cf1f16`](https://github.com/nix-community/home-manager/commit/55cf1f16324e694c991e846ad5fc897f0f75ac64) | `` firefox: fix missing lib (#6744) ``                                                        |
| [`c21383b5`](https://github.com/nix-community/home-manager/commit/c21383b556609ce1ad901aa08b4c6fbd9e0c7af0) | `` streamlink: init module (#6031) ``                                                         |
| [`5e193cdc`](https://github.com/nix-community/home-manager/commit/5e193cdcab61b5e7096ef3c132fdc0149e14f2d9) | `` msmtp: fix missing inherits (#6741) ``                                                     |
| [`0b491b46`](https://github.com/nix-community/home-manager/commit/0b491b460f52e87e23eb17bbf59c6ae64b7664c1) | `` treewide: remove with lib (#6735) ``                                                       |