### PR TITLE
chore(flake/nixvim-flake): `5e316e9c` -> `fca80c30`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1743362786,
-        "narHash": "sha256-XbXIRDbb8/vLBX1M096l7lM5wfzBTp1ZXfUl9bUhVGU=",
+        "lastModified": 1743536158,
+        "narHash": "sha256-/jlBU7EGIfaa5VKwvVyrSspuuNmgKYOjAuTd2ywyevg=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d81f37256d0a8691b837b74979d27bf89be8ecdd",
+        "rev": "754b8df7e37be04b7438decee5a5aa18af72cbe1",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1743385685,
-        "narHash": "sha256-7Lfx/l3CTzacqyphXBYSH+bEDSuAx23QgsUDlTk2+m4=",
+        "lastModified": 1743558306,
+        "narHash": "sha256-5OXMF/1YiSZurKQjKFICRjZqpKsG1UsmzoEB421Gb/A=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5e316e9c234dd3dfbde046142bba8e3b4670f3d5",
+        "rev": "fca80c30422ef7250d7a2389c7a85c5c3a9ee8c8",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742659553,
-        "narHash": "sha256-i/JCrr/jApVorI9GkSV5to+USrRCa0rWuQDH8JSlK2A=",
+        "lastModified": 1743201766,
+        "narHash": "sha256-bb/dqoIjtIWtJRzASOe8g4m8W2jUIWtuoGPXdNjM/Tk=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "508752835128a3977985a4d5225ff241f7756181",
+        "rev": "2651dbfad93d6ef66c440cbbf23238938b187bde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`fca80c30`](https://github.com/alesauce/nixvim-flake/commit/fca80c30422ef7250d7a2389c7a85c5c3a9ee8c8) | `` chore(flake/nixvim): d81f3725 -> 754b8df7 `` |