### PR TITLE
chore(flake/stylix): `54721996` -> `194a91d0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743496321,
-        "narHash": "sha256-xhHg8ixBhZngvGOMb2SJuJEHhHA10n8pA02fEKuKzek=",
+        "lastModified": 1743630094,
+        "narHash": "sha256-irmHQhaHgq6iwHAuexgdqPA4X/254ss00zXPRcc8sZw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "54721996d6590267d095f63297d9051e9342a33d",
+        "rev": "194a91d0018daaf5bcfcea4702e6800426a82445",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                       |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`194a91d0`](https://github.com/danth/stylix/commit/194a91d0018daaf5bcfcea4702e6800426a82445) | `` doc: collapse flake.lock in GitHub bug template (#1059) `` |
| [`aee4df6d`](https://github.com/danth/stylix/commit/aee4df6dc1509fc38fb868c06bc58351446a5871) | `` doc: add link to CommonMark Spec (#1081) ``                |
| [`1832ffa9`](https://github.com/danth/stylix/commit/1832ffa9a27037388277591612af7437d1bd2bad) | `` stylix: prevent partially declared cursor (#1080) ``       |