### PR TITLE
chore(flake/nix-fast-build): `ec4be4cf` -> `84440fb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743607527,
-        "narHash": "sha256-8wCcCtRauu2qESry1a1oEXiTO8g7H/u2LuaUPkrdwV4=",
+        "lastModified": 1743692086,
+        "narHash": "sha256-YWI/WmqlB6oNR0yRuGJHP3SeL6zJBkuKawl1bsubyv4=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ec4be4cfb202a72926e53afcd6e3400ab54d99d2",
+        "rev": "84440fb14c64dbe0b2a683bd6f89e0c68839e292",
         "type": "github"
       },
       "original": {
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743589519,
-        "narHash": "sha256-iBzr7Zb11nQxwX90bO1+Bm1MGlhMSmu4ixgnQFB+j4E=",
+        "lastModified": 1743677901,
+        "narHash": "sha256-eWZln+k+L/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "18bed671738e36c5504e188aadc18b7e2a6e408f",
+        "rev": "57dabe2a6255bd6165b2437ff6c2d1f6ee78421a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`84440fb1`](https://github.com/Mic92/nix-fast-build/commit/84440fb14c64dbe0b2a683bd6f89e0c68839e292) | `` chore(deps): update nixpkgs digest to 2bfc080 (#110) ``     |
| [`2098f760`](https://github.com/Mic92/nix-fast-build/commit/2098f7602e271f4dab8a39f5a41e55e36a4b921d) | `` chore(deps): update treefmt-nix digest to 57dabe2 (#109) `` |
| [`14ddba15`](https://github.com/Mic92/nix-fast-build/commit/14ddba15ecd5fcde6b2ca58199fe6c48806582fa) | `` chore(deps): update nixpkgs digest to f90d0a3 (#108) ``     |