### PR TITLE
chore(flake/home-manager): `579a71b9` -> `66a6ec65`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743639371,
-        "narHash": "sha256-eywYn8ayhVUzFFvIiAIIHn+00Irmhyjqe2cNdyPCLNE=",
+        "lastModified": 1743717835,
+        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "579a71b948533667c6c65e603f18990bdffc8530",
+        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`66a6ec65`](https://github.com/nix-community/home-manager/commit/66a6ec65f84255b3defb67ff45af86c844dd451b) | `` cliphist: use configured systemdTargets throughout service (#6751) `` |
| [`107352dd`](https://github.com/nix-community/home-manager/commit/107352dde4ff3c01cb5a0b3fe17f5beef37215bc) | `` treewide: add missing package option ``                               |
| [`fcdd04e0`](https://github.com/nix-community/home-manager/commit/fcdd04e0f9948a7c7814b10b56bd9c9b15ddc1f4) | `` astroid: only generate `poll.sh` when script provided ``              |
| [`a99c12d2`](https://github.com/nix-community/home-manager/commit/a99c12d23e108ad40b7da75d46a55cad9871c146) | `` antidote: null package support ``                                     |
| [`0bbc3fc5`](https://github.com/nix-community/home-manager/commit/0bbc3fc5c6092a57d7e3a1999e0809fa7d2efa6a) | `` alacritty: null package support ``                                    |
| [`b24689a1`](https://github.com/nix-community/home-manager/commit/b24689a173f085e506d16e2f5e88ce3ce1819f94) | `` treewide: use mkPackageOption ``                                      |