### PR TITLE
chore(flake/home-manager): `66a6ec65` -> `0f5908da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743717835,
-        "narHash": "sha256-LJm6FoIcUoBw3w25ty12/sBfut4zZuNGdN0phYj/ekU=",
+        "lastModified": 1743788974,
+        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66a6ec65f84255b3defb67ff45af86c844dd451b",
+        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`0f5908da`](https://github.com/nix-community/home-manager/commit/0f5908daf890c3d7e7052bef1d6deb0f2710aaa1) | `` home-environment: enable home aliases for nushell (#6754) `` |
| [`07547d29`](https://github.com/nix-community/home-manager/commit/07547d29e12deeb82dedf893cdc89b127fe7195c) | `` swaync: use lib.getExe (#6755) ``                            |
| [`bb036cb3`](https://github.com/nix-community/home-manager/commit/bb036cb35383982066e01a6ac8d45597132cf5d5) | `` swaync: Add onChange (#6233) ``                              |
| [`a802defb`](https://github.com/nix-community/home-manager/commit/a802defb16dcdcc7fd0ff5a2d7be913ce2fe79e7) | `` playerctld: add to `$PATH` (#6753) ``                        |
| [`f3ac07f2`](https://github.com/nix-community/home-manager/commit/f3ac07f2f7c368952a9e7da64ec0991526f49020) | `` smug: init module (#6696) ``                                 |