### PR TITLE
chore(flake/nixvim-flake): `75c7b6f7` -> `f7a727bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1743598191,
-        "narHash": "sha256-30aI8rWjX64E9vIlE4iqgQguTjItvTnQLTqHtFppF/w=",
+        "lastModified": 1743723573,
+        "narHash": "sha256-yxONmoimNU0hy0s8pF5lKCSZNqxVmbIHuag3sdk3R30=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a183298bf67307bdb7a25a2a3c565e76029f1b9e",
+        "rev": "9f495dda930ceca1653813ded11859d6b1342803",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1743701872,
-        "narHash": "sha256-80KWxKcaI6fY15A4Uab160e8ZIlpXOX9gYVVLf9fcuM=",
+        "lastModified": 1743731014,
+        "narHash": "sha256-WCDQsfsyVjwy13KpLzFD454/gyBUqj5nFCcwxdIlmJM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "75c7b6f749b18fe957ddce4e67307df5f340e490",
+        "rev": "f7a727bdaf3545750ea64d639668d1d9ab7bfddf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`f7a727bd`](https://github.com/alesauce/nixvim-flake/commit/f7a727bdaf3545750ea64d639668d1d9ab7bfddf) | `` chore(flake/nixvim): a183298b -> 9f495dda `` |