### PR TITLE
chore(flake/nix-fast-build): `84440fb1` -> `65f8b77c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1743692086,
-        "narHash": "sha256-YWI/WmqlB6oNR0yRuGJHP3SeL6zJBkuKawl1bsubyv4=",
+        "lastModified": 1743779076,
+        "narHash": "sha256-RhIEwFHGqdxXsCSbhp4DicOlMSldthNRhTn2yLdTc4g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "84440fb14c64dbe0b2a683bd6f89e0c68839e292",
+        "rev": "65f8b77cb4c212749885bc79bafaec9b9d5c33e6",
         "type": "github"
       },
       "original": {
@@ -878,11 +878,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743677901,
-        "narHash": "sha256-eWZln+k+L/VHO69tUTzEmgeDWNQNKIpSUa9nqQgBrSE=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "57dabe2a6255bd6165b2437ff6c2d1f6ee78421a",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`65f8b77c`](https://github.com/Mic92/nix-fast-build/commit/65f8b77cb4c212749885bc79bafaec9b9d5c33e6) | `` chore(deps): update nixpkgs digest to 3070507 (#113) ``     |
| [`beba6aa1`](https://github.com/Mic92/nix-fast-build/commit/beba6aa1456d1a61becf8fca3d3044a223894ffb) | `` chore(deps): update nixpkgs digest to a462b94 (#112) ``     |
| [`8a6b59d8`](https://github.com/Mic92/nix-fast-build/commit/8a6b59d8c3854552f3d2b5346e500c1fbab2d45c) | `` chore(deps): update treefmt-nix digest to 815e412 (#111) `` |