### PR TITLE
chore(flake/stylix): `f32b1c08` -> `581fa67c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743701771,
-        "narHash": "sha256-fmAOyD6iCS0jqcoUL4lxuUApSmjXbRcm6e94J/j2wNA=",
+        "lastModified": 1743775855,
+        "narHash": "sha256-ZhhiYvHlA9f/Ck1i76ilfapLS7abLPRlWJQRxJEDTnQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f32b1c0875ee573ecf5967a76e125317e1f202a2",
+        "rev": "581fa67c818aaf91a1533149fb737d3e8c0949b8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`581fa67c`](https://github.com/danth/stylix/commit/581fa67c818aaf91a1533149fb737d3e8c0949b8) | `` stylix: guard entire overlay declarations (#1088) ``    |
| [`a214b330`](https://github.com/danth/stylix/commit/a214b330e5d8940b05ccd951eb5c6ac0f13d125f) | `` mpv: unset subtitle font size (#1090) ``                |
| [`9ef80628`](https://github.com/danth/stylix/commit/9ef806283b87f99dfa574b6642165cf052a1d49e) | `` discord: fix template for  new ui redesign (#1063) ``   |
| [`ac8dd8b1`](https://github.com/danth/stylix/commit/ac8dd8b1a6bc2d367f7ec8e39e0032f03ae9a458) | `` ci: bump actions/create-github-app-token from 1 to 2 `` |