### PR TITLE
chore(flake/home-manager): `0f5908da` -> `d094c676`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743788974,
-        "narHash": "sha256-2LeVyQZI2wTkSzMLvnN/kJjXVWp4HCVUoq17Bv8TNTk=",
+        "lastModified": 1743869639,
+        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0f5908daf890c3d7e7052bef1d6deb0f2710aaa1",
+        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`d094c676`](https://github.com/nix-community/home-manager/commit/d094c6763c6ddb860580e7d3b4201f8f496a6836) | `` news: create an individual file for each news entry (#6747) `` |
| [`b5e29565`](https://github.com/nix-community/home-manager/commit/b5e29565131802cc8adee7dccede794226da8614) | `` redshift/gammastep: add tray tests ``                          |
| [`46f93825`](https://github.com/nix-community/home-manager/commit/46f93825af684a094950ae66ba5ef24a4b10c49f) | `` redshift/gammastep: fix tray.target dependency ``              |