### PR TITLE
chore(flake/home-manager): `d094c676` -> `a4d80208`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743869639,
-        "narHash": "sha256-Xhe3whfRW/Ay05z9m1EZ1/AkbV1yo0tm1CbgjtCi4rQ=",
+        "lastModified": 1744038920,
+        "narHash": "sha256-9a4V1wQXS8hXZtc7mRtz0qINkGW+C99aDrmXY6oYBFg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d094c6763c6ddb860580e7d3b4201f8f496a6836",
+        "rev": "a4d8020820a85b47f842eae76ad083b0ec2a886a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`a4d80208`](https://github.com/nix-community/home-manager/commit/a4d8020820a85b47f842eae76ad083b0ec2a886a) | `` flake.nix: include more doc outputs ``                        |
| [`1a186efb`](https://github.com/nix-community/home-manager/commit/1a186efb48030b06975677a6b8331fbe9e9a3e46) | `` default.nix: add htmlOpenTool output for docs ``              |
| [`14269b06`](https://github.com/nix-community/home-manager/commit/14269b06a06601aecfd10c33f3f2a45b304b23d5) | `` docs/flake.nix: add flake outputs for docs ``                 |
| [`f463902a`](https://github.com/nix-community/home-manager/commit/f463902a3f03e15af658e48bcc60b39188ddf734) | `` .git-blame-ignore-revs: init (#6767) ``                       |
| [`c15ab0ce`](https://github.com/nix-community/home-manager/commit/c15ab0ce0dbe64843358a3081b09ed35144dfd65) | `` swayr: systemd.target default to wayland.systemd target ``    |
| [`320e152d`](https://github.com/nix-community/home-manager/commit/320e152d0bade4ca3c1054c1ddee97bb50dfb541) | `` wlsunset: systemdTarget used for all targets ``               |
| [`a90ab0ab`](https://github.com/nix-community/home-manager/commit/a90ab0ab5f00efce68729df4e0ea196f03b2d2c6) | `` wlsunset: systemdTarget default to wayland.systemd target ``  |
| [`8871d0b1`](https://github.com/nix-community/home-manager/commit/8871d0b1ef705554db56982916bbceefd3253e78) | `` cliphist: systemdTargets default to wayland.systemd target `` |
| [`8c9b5450`](https://github.com/nix-community/home-manager/commit/8c9b54504c89f3aec9c82b262c1f4304407fbad6) | `` swaync: use x-restart-triggers for reload (#6764) ``          |
| [`ef3b2a6b`](https://github.com/nix-community/home-manager/commit/ef3b2a6b602c3f1a80c6897d6de3ee62339a3eb7) | `` flake.lock: Update (#6762) ``                                 |