### PR TITLE
chore(flake/stylix): `f98c2c42` -> `be86a9aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1743961983,
-        "narHash": "sha256-azG6Dnaj4lPVBUMTINIbL6c7+u59IvhLGbceYxdmFxs=",
+        "lastModified": 1744073349,
+        "narHash": "sha256-Ecc8SEfQ5RN2y2BtPGhnW+AQ+horuOHGGWIcT80a3JA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f98c2c42b210128f5a62099c12bc566b0050fea9",
+        "rev": "be86a9aadb0519bf0e5fd98e5b63c57e049fba67",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                    |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`be86a9aa`](https://github.com/danth/stylix/commit/be86a9aadb0519bf0e5fd98e5b63c57e049fba67) | `` ci: bump actions/create-github-app-token from 1 to 2 `` |