### PR TITLE
chore(flake/nixvim-flake): `5f20138f` -> `305840a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1743844372,
-        "narHash": "sha256-59T+ikFiTt0CiSvuja3/xYahT6SL2s3XtNykfG8l0gk=",
+        "lastModified": 1744028177,
+        "narHash": "sha256-etbUDe2Httgl6oI14M1nTV39+478dJ0UyLJKx/DtZi8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7b4311333b542178828e90f6997d8f03e8327b89",
+        "rev": "cc8918663a711a10cd45650e7bb4c933c5ec4ad7",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1743990381,
-        "narHash": "sha256-EsYrAHqAV+GNoDuXTV00X3MOxscscOQrPBlBoUXjTxM=",
+        "lastModified": 1744076708,
+        "narHash": "sha256-+MuPVwRHqhoCIJjwZ8Hg5A9iUqTfIIDlz9a61apGc/Y=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5f20138f6e5cde0b699b804583ab423deef1357d",
+        "rev": "305840a997b209ba252cee17e740c289e8fa6aa2",
         "type": "github"
       },
       "original": {
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743201766,
-        "narHash": "sha256-bb/dqoIjtIWtJRzASOe8g4m8W2jUIWtuoGPXdNjM/Tk=",
+        "lastModified": 1743683223,
+        "narHash": "sha256-LdXtHFvhEC3S64dphap1pkkzwjErbW65eH1VRerCUT0=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "2651dbfad93d6ef66c440cbbf23238938b187bde",
+        "rev": "56a49ffef2908dad1e9a8adef1f18802bc760962",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`305840a9`](https://github.com/alesauce/nixvim-flake/commit/305840a997b209ba252cee17e740c289e8fa6aa2) | `` chore(flake/nixvim): 7b431133 -> cc891866 `` |