### PR TITLE
chore(flake/stylix): `be86a9aa` -> `c8bc1c1d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744073349,
-        "narHash": "sha256-Ecc8SEfQ5RN2y2BtPGhnW+AQ+horuOHGGWIcT80a3JA=",
+        "lastModified": 1744150938,
+        "narHash": "sha256-MakfYLYXBM4n1JS8En0QDDGFpSEuKfU1WZa9kBBtEbw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "be86a9aadb0519bf0e5fd98e5b63c57e049fba67",
+        "rev": "c8bc1c1d9ec5f3c852da40983ae0e9cfe775dbda",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`c8bc1c1d`](https://github.com/danth/stylix/commit/c8bc1c1d9ec5f3c852da40983ae0e9cfe775dbda) | `` treewide: remove use of multiple with statements (#1085) ``              |
| [`a2f8840b`](https://github.com/danth/stylix/commit/a2f8840bed6daade6b980426c9f72dd672e92329) | `` hyprland: disable default wallpaper when hyprpaper is enabled (#1120) `` |