### PR TITLE
chore(flake/stylix): `c8bc1c1d` -> `31fdf606`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744150938,
-        "narHash": "sha256-MakfYLYXBM4n1JS8En0QDDGFpSEuKfU1WZa9kBBtEbw=",
+        "lastModified": 1744196911,
+        "narHash": "sha256-zzkDmUG04/1ALtUOoZNGkrtjjId8RbM38zlpYFtgXVs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c8bc1c1d9ec5f3c852da40983ae0e9cfe775dbda",
+        "rev": "31fdf60634beaa0bb14fa57fc64cd5a67d1bf101",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`31fdf606`](https://github.com/danth/stylix/commit/31fdf60634beaa0bb14fa57fc64cd5a67d1bf101) | `` stylix: disallow nixpkgs aliases in testbeds (#1124) ``  |
| [`85220767`](https://github.com/danth/stylix/commit/852207671fd11839e83b67b98efe82f1c7cad1f8) | `` ci: include release branch in update PR title (#1114) `` |