### PR TITLE
chore(flake/darwin): `73d59580` -> `113883e3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743496612,
-        "narHash": "sha256-emPWa5lmKbnyuj8c1mSJUkzJNT+iJoU9GMcXwjp2oVM=",
+        "lastModified": 1744224272,
+        "narHash": "sha256-cqePj5nuC7flJWNncaVAFq1YZncU0PSyO0DEqGn+vYc=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "73d59580d01e9b9f957ba749f336a272869c42dd",
+        "rev": "113883e37d985d26ecb65282766e5719f2539103",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                     |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`5417dfd5`](https://github.com/nix-darwin/nix-darwin/commit/5417dfd58cbc1c475a0b3ffc5b016b29514d6fb8) | `` services/netdata: add cacheDir option `` |