### PR TITLE
chore(flake/home-manager): `760eed59` -> `79461936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744138333,
-        "narHash": "sha256-l0Vjq1EZoYTfWImVmwsvMEuIdasrBRRCoNTV0rNtYi0=",
+        "lastModified": 1744223888,
+        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "760eed59594f2f258db0d66b7ca4a5138681fd97",
+        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`79461936`](https://github.com/nix-community/home-manager/commit/79461936709b12e17adb9c91dd02d1c66d577f09) | `` hyprland: load plugins using exec-once (#6789) ``      |
| [`542efdf2`](https://github.com/nix-community/home-manager/commit/542efdf2dfac351498f534eb71671525b9bd45ed) | `` flake.lock: Update (#6785) ``                          |
| [`9864a2f4`](https://github.com/nix-community/home-manager/commit/9864a2f421e859d9784b6c413ec25d1415ddfe08) | `` thunderbird: add accountsOrder option (#6310) ``       |
| [`a1036d4d`](https://github.com/nix-community/home-manager/commit/a1036d4d3e939d740149508aa68b2545c4964d37) | `` tests: stub notmuch darwin (#6788) ``                  |
| [`fcb8a2b6`](https://github.com/nix-community/home-manager/commit/fcb8a2b62b30ae054a4eadbf43c913a755f1d14c) | `` swaylock: fix path values in config file (#6786) ``    |
| [`4040c577`](https://github.com/nix-community/home-manager/commit/4040c5779ce56d36805bc7a83e072f0f894eae7d) | `` modules/programs/ssh: support identityAgent (#6783) `` |