### PR TITLE
chore(flake/stylix): `31fdf606` -> `ce45f19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744196911,
-        "narHash": "sha256-zzkDmUG04/1ALtUOoZNGkrtjjId8RbM38zlpYFtgXVs=",
+        "lastModified": 1744270948,
+        "narHash": "sha256-+1psY8uBaDdkqV/P3G40SzulPvUcb9VHisqQnDozC0U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "31fdf60634beaa0bb14fa57fc64cd5a67d1bf101",
+        "rev": "ce45f19e8acb43e5f02888d873d451e2f994546b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`ce45f19e`](https://github.com/danth/stylix/commit/ce45f19e8acb43e5f02888d873d451e2f994546b) | `` kde: add run wrapper (#1117) ``             |
| [`82f67a36`](https://github.com/danth/stylix/commit/82f67a36eba1b111f8d568bf5e5ceb30e4b623d6) | `` doc: align module capitalization (#1115) `` |