### PR TITLE
chore(flake/home-manager): `79461936` -> `543caa31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744223888,
-        "narHash": "sha256-reYpe0J1J+wH34JFs7KKp0G5nP7+XSQ5z0ZLFJcfJr8=",
+        "lastModified": 1744316889,
+        "narHash": "sha256-qS0BhvsL9J7gt4cOpBZdzT0EqylGPKyKnU9v/6SJvFI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79461936709b12e17adb9c91dd02d1c66d577f09",
+        "rev": "543caa313abe45b56520efdaa35d379703f79e3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`543caa31`](https://github.com/nix-community/home-manager/commit/543caa313abe45b56520efdaa35d379703f79e3a) | `` xmonad: fix binary name lookup on armv7l when cross-compiled (#6795) `` |
| [`8638a0b2`](https://github.com/nix-community/home-manager/commit/8638a0b28727a8cdbe851fefded3b8e96f4cf763) | `` sesh: add icons option (#6794) ``                                       |
| [`140a7df9`](https://github.com/nix-community/home-manager/commit/140a7df916f6257c755b8663fb27ed79e81c8e89) | `` formatter: use a different treefmt root (#6792) ``                      |
| [`92266c9a`](https://github.com/nix-community/home-manager/commit/92266c9a6f03b7d86efc056580a1fddb89635a59) | `` btop: adjust `themes` option example (#6793) ``                         |