### PR TITLE
chore(flake/nixvim-flake): `f6962861` -> `8ff470c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744010047,
-        "narHash": "sha256-VblOQvp2aj7IVMGAqgLdWu/KLocKJf7l5bmONgpfa8I=",
+        "lastModified": 1744182287,
+        "narHash": "sha256-o9O4KA7R/evL/KT7UsdKHTT+em+BvnxuGa0vn9U3U60=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "ce8bd0c16597629f567e7ec5dda8fd4a60f0e523",
+        "rev": "93b318c24112dd435a265ecc6bf09401e63ade63",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1744028177,
-        "narHash": "sha256-etbUDe2Httgl6oI14M1nTV39+478dJ0UyLJKx/DtZi8=",
+        "lastModified": 1744200902,
+        "narHash": "sha256-BqTLjxT1C1XfREDBQSxPrfKI9DBpZHBVLHzfXZs+h8M=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "cc8918663a711a10cd45650e7bb4c933c5ec4ad7",
+        "rev": "51203927e395535c4a427295efed4e1b2ef8349b",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1744163112,
-        "narHash": "sha256-UFq40FpLG7YoqpO4JuSTtCZc3nh6aRlQA32T7nslAa0=",
+        "lastModified": 1744322696,
+        "narHash": "sha256-tBsKZMqUOOcUxXb0J/WPq9Jq/0QjYBI+ySTnB6nvcr4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "f69628618ef0a15f3fd943c4468276e294e969ce",
+        "rev": "8ff470c43db98ce64d49e5f9130eba016a616360",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`8ff470c4`](https://github.com/alesauce/nixvim-flake/commit/8ff470c43db98ce64d49e5f9130eba016a616360) | `` refactor(config/lang/java): update nvim-jdtls -> jdtls, update renamed options `` |
| [`9c98291e`](https://github.com/alesauce/nixvim-flake/commit/9c98291e747f090ed1e6c34f5a67b65ee52bfb4d) | `` chore(flake/nixvim): cc891866 -> 51203927 ``                                      |
| [`738d8eab`](https://github.com/alesauce/nixvim-flake/commit/738d8eabdb4739263904b9ead9e63e46e763d473) | `` fix(config/lsp/blink): Disable preselect for blink-cmp ``                         |
| [`136f8cb4`](https://github.com/alesauce/nixvim-flake/commit/136f8cb44f18ac8a45e921490181231156370d24) | `` chore(flake/nixpkgs): 2c8d3f48 -> c8cd8142 ``                                     |
| [`1e925021`](https://github.com/alesauce/nixvim-flake/commit/1e925021cbccc508a3c1609fcac416bbc0d1502d) | `` chore(flake/nix-fast-build): ce8bd0c1 -> 93b318c2 ``                              |