### PR TITLE
chore(flake/home-manager): `543caa31` -> `b74b22bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744316889,
-        "narHash": "sha256-qS0BhvsL9J7gt4cOpBZdzT0EqylGPKyKnU9v/6SJvFI=",
+        "lastModified": 1744400600,
+        "narHash": "sha256-qYhUgA98mhq1QK13r9qVY+sG1ri6FBgyp+GApX6wS20=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "543caa313abe45b56520efdaa35d379703f79e3a",
+        "rev": "b74b22bb6167e8dff083ec6988c98798bf8954d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`b74b22bb`](https://github.com/nix-community/home-manager/commit/b74b22bb6167e8dff083ec6988c98798bf8954d3) | `` waybar: add debug option ``                                                |
| [`d8e2fdc0`](https://github.com/nix-community/home-manager/commit/d8e2fdc09c9ee737ec66e64578413690833be3d9) | `` .git-blame-ignore-revs: fix fmt hash ``                                    |
| [`cfd7df8a`](https://github.com/nix-community/home-manager/commit/cfd7df8a2151682ea8efadf4618e98a08c6a8907) | `` waybar: systemd cleanup ``                                                 |
| [`e43c6bcb`](https://github.com/nix-community/home-manager/commit/e43c6bcb101ba3301522439c459288c4a248f624) | `` anyrun: init module (#6804) ``                                             |
| [`6bccb54a`](https://github.com/nix-community/home-manager/commit/6bccb54a4f98408f22d2e45921bb401f393f2174) | `` aerospace: revert flattening on-window-detected rules (#6803) ``           |
| [`f0c69ede`](https://github.com/nix-community/home-manager/commit/f0c69ede700deeef5aa0d7b8604f35a4e7d292bf) | `` way-displays: init module (#6791) ``                                       |
| [`e15c4203`](https://github.com/nix-community/home-manager/commit/e15c4203ea04cd80edbd8005d0eadb53eded45ea) | `` hyprland: plugins use hyprctl from path (#6801) ``                         |
| [`da624eaa`](https://github.com/nix-community/home-manager/commit/da624eaad0fefd4dac002e1f09d300d150c20483) | `` jujutsu: evaluate the settings after merging with other options (#6775) `` |
| [`f1ffd097`](https://github.com/nix-community/home-manager/commit/f1ffd097e717a8d1b441577b8d23f9d2c96e0657) | `` hyprsunset: support multiple commands to IPC ``                            |
| [`cf6314f8`](https://github.com/nix-community/home-manager/commit/cf6314f8e173e208882e32ed85158f78bf74d085) | `` hyprsunset: init ``                                                        |
| [`47eb2d80`](https://github.com/nix-community/home-manager/commit/47eb2d80f943521ec88fe92899925c5f444c8a5c) | `` accounts/contact: add sensible defaults to the localModule (#6799) ``      |