### PR TITLE
chore(flake/darwin): `113883e3` -> `43975d78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744224272,
-        "narHash": "sha256-cqePj5nuC7flJWNncaVAFq1YZncU0PSyO0DEqGn+vYc=",
+        "lastModified": 1744478979,
+        "narHash": "sha256-dyN+teG9G82G+m+PX/aSAagkC+vUv0SgUw3XkPhQodQ=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "113883e37d985d26ecb65282766e5719f2539103",
+        "rev": "43975d782b418ebf4969e9ccba82466728c2851b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                  |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`751a96bc`](https://github.com/nix-darwin/nix-darwin/commit/751a96bc1f97d0771ff6562e4a6c2990db9d8af8) | `` networking: backport `domain`, `fqdn` and `fqdnOrHostName` options `` |