### PR TITLE
chore(flake/tinted-schemes): `c37771c4` -> `5c481ad9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -825,11 +825,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1742851696,
-        "narHash": "sha256-sR4K+OVFKeUOvNIqcCr5Br7NLxOBEwoAgsIyjsZmb8s=",
+        "lastModified": 1744505470,
+        "narHash": "sha256-omAtxbs8R26eGaTwMcWECzwI/XHnMXYEMWRvXtbrfh8=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "c37771c4ae8ff1667e27ddcf24991ebeb94a4e77",
+        "rev": "5c481ad9e963540fb4260ef8ee51f8ce35c7d7d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                               |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`5c481ad9`](https://github.com/tinted-theming/schemes/commit/5c481ad9e963540fb4260ef8ee51f8ce35c7d7d7) | `` Added Digital Rain theme (#49) ``                                                  |
| [`186585a5`](https://github.com/tinted-theming/schemes/commit/186585a5aac077916489ac8af2937cadc95ba7dd) | `` Add Kanagawa Dragon scheme (#48) ``                                                |
| [`7b0b2dd9`](https://github.com/tinted-theming/schemes/commit/7b0b2dd90e0fdf84a69972e4e8e0affdea677413) | `` Set gruvbox scheme colors according to https://github.com/morhetz/gruvbox (#46) `` |