### PR TITLE
chore(flake/home-manager): `db56335c` -> `ac3c1f4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744498625,
-        "narHash": "sha256-pL52uCt9CUoTTmysGG91c2FeU7XUvpB7Cep6yon2vDk=",
+        "lastModified": 1744584414,
+        "narHash": "sha256-uk9NgZvkTkHEuTdnZ2GGO/Y4q4sbHdAMzPPoASpIpWo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db56335ca8942d86f2200664acdbd5b9212b26ad",
+        "rev": "ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`ac3c1f4f`](https://github.com/nix-community/home-manager/commit/ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4) | `` foot: enable duplicate key-bindings (#6815) ``           |
| [`14229249`](https://github.com/nix-community/home-manager/commit/1422924908881faf59722810884addf109ebea07) | `` Translate using Weblate (Czech) (#6813) ``               |
| [`cfa196c7`](https://github.com/nix-community/home-manager/commit/cfa196c705a896372319249d757085876ab62448) | `` flake.lock: Update (#6812) ``                            |
| [`4f898f37`](https://github.com/nix-community/home-manager/commit/4f898f373d8b0bfdac635b036396c90b0ad17be8) | `` helix: add support for path and string themes (#6814) `` |