### PR TITLE
chore(flake/nix-index-database): `a36f6a71` -> `4fc9ea78`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743911143,
-        "narHash": "sha256-4j4JPwr0TXHH4ZyorXN5yIcmqIQr0WYacsuPA4ktONo=",
+        "lastModified": 1744518957,
+        "narHash": "sha256-RLBSWQfTL0v+7uyskC5kP6slLK1jvIuhaAh8QvB75m4=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "a36f6a7148aec2c77d78e4466215cceb2f5f4bfb",
+        "rev": "4fc9ea78c962904f4ea11046f3db37c62e8a02fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4fc9ea78`](https://github.com/nix-community/nix-index-database/commit/4fc9ea78c962904f4ea11046f3db37c62e8a02fd) | `` update generated.nix to release 2025-04-13-041853 `` |
| [`9fba28cf`](https://github.com/nix-community/nix-index-database/commit/9fba28cf3d5dff9abd4e8fd7a942294294c01a6d) | `` flake.lock: Update ``                                |