### PR TITLE
chore(flake/tinted-schemes): `5c481ad9` -> `5dc50019`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -825,11 +825,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744505470,
-        "narHash": "sha256-omAtxbs8R26eGaTwMcWECzwI/XHnMXYEMWRvXtbrfh8=",
+        "lastModified": 1744537965,
+        "narHash": "sha256-WAt2QPvv/gy9oTpk0iUJOxB0rDLE+vqLD3a7k9wcOvE=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "5c481ad9e963540fb4260ef8ee51f8ce35c7d7d7",
+        "rev": "5dc50019e932e772f4f8e2d8af8ca9ca202b9bdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`5dc50019`](https://github.com/tinted-theming/schemes/commit/5dc50019e932e772f4f8e2d8af8ca9ca202b9bdd) | `` Added Embarcadero & Mission Brogue Schemes (#42) `` |
| [`c4672071`](https://github.com/tinted-theming/schemes/commit/c4672071e58a947fee17a548a682e443449ac27c) | `` Fix bug where system is incorrectly named (#50) ``  |