### PR TITLE
chore(flake/home-manager): `ac3c1f4f` -> `d5cdf55b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744584414,
-        "narHash": "sha256-uk9NgZvkTkHEuTdnZ2GGO/Y4q4sbHdAMzPPoASpIpWo=",
+        "lastModified": 1744663884,
+        "narHash": "sha256-a6QGaZMDM1miK8VWzAITsEPOdmLk+xTPyJSTjVs3WhI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ac3c1f4fa40497b07f1f3ea3c4f644ce5dbcd2a4",
+        "rev": "d5cdf55bd9f19a3debd55b6cb5d38f7831426265",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`d5cdf55b`](https://github.com/nix-community/home-manager/commit/d5cdf55bd9f19a3debd55b6cb5d38f7831426265) | `` direnv: add tests for silent option ``                      |
| [`ae5fcad7`](https://github.com/nix-community/home-manager/commit/ae5fcad746ac79ea2f791c6369089e4db7ad6bc1) | `` direnv: fix silent option after update to direnv v2.36.0 `` |
| [`5a096a88`](https://github.com/nix-community/home-manager/commit/5a096a8822cb98584c5dc4f2616dcd5ed394bfd7) | `` superfile: initial support (#6610) ``                       |
| [`273ad32f`](https://github.com/nix-community/home-manager/commit/273ad32fbb4769ac56e15caccdbdaad2c2e6b88a) | `` tests/nh: init tests (#6819) ``                             |
| [`33754144`](https://github.com/nix-community/home-manager/commit/337541447773985f825512afd0f9821a975186be) | `` helix: fix str + path theme (#6816) ``                      |
| [`85dd758c`](https://github.com/nix-community/home-manager/commit/85dd758c703ffbf9d97f34adcef3a898b54b4014) | `` yazi: remove assertions (#6817) ``                          |
| [`e980d0e0`](https://github.com/nix-community/home-manager/commit/e980d0e0e216f527ea73cfd12c7b019eceffa7f1) | `` nh: support 4.0 for flake option (#6818) ``                 |