### PR TITLE
chore(flake/tinted-schemes): `5dc50019` -> `6db1e653`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -825,11 +825,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744537965,
-        "narHash": "sha256-WAt2QPvv/gy9oTpk0iUJOxB0rDLE+vqLD3a7k9wcOvE=",
+        "lastModified": 1744626413,
+        "narHash": "sha256-QHb1sns7cVOoDH9azcioIY9GCM+ZWXz1OZlv5n/HjwI=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "5dc50019e932e772f4f8e2d8af8ca9ca202b9bdd",
+        "rev": "6db1e6536a81339ff06bfe8aaaaf35f5a9032d5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                              |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`6db1e653`](https://github.com/tinted-theming/schemes/commit/6db1e6536a81339ff06bfe8aaaaf35f5a9032d5f) | `` Add and update github schemes to reflect the Tinted Theming styling spec (#52) `` |
| [`0f18375c`](https://github.com/tinted-theming/schemes/commit/0f18375cac261b94e7fafa12ac1fd0d29c07349a) | `` Ensure relevant scheme-system exists in yaml file (#51) ``                        |