### PR TITLE
chore(flake/home-manager): `db7738e6` -> `c6b75d69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744735751,
-        "narHash": "sha256-OPpfgL3qUIbQdbmp1/ZwnlsuTLooHN4or0EABnZTFRY=",
+        "lastModified": 1744833442,
+        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "db7738e67a101ad945abbcb447e1310147afaf1b",
+        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                  |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`c6b75d69`](https://github.com/nix-community/home-manager/commit/c6b75d69b6994ba68ec281bd36faebcc56097800) | `` tests/firefox: add userchrome test cases ``                           |
| [`1827e843`](https://github.com/nix-community/home-manager/commit/1827e84344ff7cb814e3e4dfad51a45856ea50f6) | `` mkFirefoxModule: fix userChrome ``                                    |
| [`cb65c814`](https://github.com/nix-community/home-manager/commit/cb65c81403f61f49483858730b087ff6699c61c1) | `` chawan: init module (#6768) ``                                        |
| [`b35bccc3`](https://github.com/nix-community/home-manager/commit/b35bccc32d3fc49f6fcc4e08ccfd6025c9eefa20) | `` home-manager-auto-expire: fix spelling error (#6829) ``               |
| [`7ede02c3`](https://github.com/nix-community/home-manager/commit/7ede02c32a729db0d6340bdb41d10e73ec511ca0) | `` progs: firefox: *.userChrome may be path or drv (#6761) ``            |
| [`d8263c0b`](https://github.com/nix-community/home-manager/commit/d8263c0b845cec48869dc6b2ba80125fa002ff03) | `` labwc: Add module for Labwc (#6807) ``                                |
| [`5d48f3de`](https://github.com/nix-community/home-manager/commit/5d48f3ded3b55ef32d5853c9022fb4df29b3fc45) | `` mcfly: Fix mcfly-fzf initialization crash for fish and zsh (#6827) `` |
| [`401e7b54`](https://github.com/nix-community/home-manager/commit/401e7b544e7c8e8a59f4ec7f1745f7619bbfbde3) | `` Translate using Weblate (Dutch) (#6828) ``                            |