### PR TITLE
chore(flake/home-manager): `c6b75d69` -> `72526a5f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744833442,
-        "narHash": "sha256-BBMWW2m64Grcc5FlXz74+vdkUyCJOfUGnl+VcS/4x44=",
+        "lastModified": 1744919155,
+        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c6b75d69b6994ba68ec281bd36faebcc56097800",
+        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`72526a5f`](https://github.com/nix-community/home-manager/commit/72526a5f7cde2ef9075637802a1e2a8d2d658f70) | `` tests/firefox: fix test commands (#6840) ``                     |
| [`e72178b8`](https://github.com/nix-community/home-manager/commit/e72178b84e440703e17ff5d393ba060784bed099) | `` tests/atuin: add theme test ``                                  |
| [`88e61873`](https://github.com/nix-community/home-manager/commit/88e61873646616ed80605e14b75332de22934481) | `` atuin: add support for themes ``                                |
| [`2c71aae6`](https://github.com/nix-community/home-manager/commit/2c71aae678c03a39c2542e136b87bd040ae1b3cb) | `` tests/firefox: validate folder linking ``                       |
| [`baa2a0b3`](https://github.com/nix-community/home-manager/commit/baa2a0b3bd23de23ba23f50508e44e9d77819ec2) | `` tests/firefox: consolidate userChrome.css test files ``         |
| [`c3c91dd8`](https://github.com/nix-community/home-manager/commit/c3c91dd8b4974ce221748b997e644c4838e3ebbc) | `` mkFirefoxModule: fix userChrome with leading comment (#6836) `` |