### PR TITLE
chore(flake/stylix): `38aff11a` -> `8d5cd725`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744668092,
-        "narHash": "sha256-XDmpI3ywMkypsHKRF2am6BzZ5OjwpQMulAe8L87Ek8U=",
+        "lastModified": 1744910471,
+        "narHash": "sha256-HItOUMA2whFnPMJuyN2XHq9TZttgrgOAZcoUXsaD4Js=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "38aff11a7097f4da6b95d4c4d2c0438f25a08d52",
+        "rev": "8d5cd725ad591890c0cd804bf68cc842b8afca51",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                        |
| --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`8d5cd725`](https://github.com/danth/stylix/commit/8d5cd725ad591890c0cd804bf68cc842b8afca51) | `` qt: fix kvantum breaking plasma6 (#1128) `` |