### PR TITLE
chore(flake/tinted-schemes): `6db1e653` -> `28c26a62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -825,11 +825,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1744626413,
-        "narHash": "sha256-QHb1sns7cVOoDH9azcioIY9GCM+ZWXz1OZlv5n/HjwI=",
+        "lastModified": 1744974599,
+        "narHash": "sha256-Fg+rdGs5FAgfkYNCs74lnl8vkQmiZVdBsziyPhVqrlY=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "6db1e6536a81339ff06bfe8aaaaf35f5a9032d5f",
+        "rev": "28c26a621123ad4ebd5bbfb34ab39421c0144bdd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                           |
| ------------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`28c26a62`](https://github.com/tinted-theming/schemes/commit/28c26a621123ad4ebd5bbfb34ab39421c0144bdd) | `` Fix scheme naming bug (#54) `` |