### PR TITLE
chore(flake/home-manager): `72526a5f` -> `67f60ebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744919155,
-        "narHash": "sha256-IJksPW32V9gid9vDxoloJMRk+YGjxq5drFHBFeBkKU8=",
+        "lastModified": 1745016969,
+        "narHash": "sha256-nDK8Z+LsNWrUsQ1JjnndNB57lvCmvy2QZUoCakoJCcI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72526a5f7cde2ef9075637802a1e2a8d2d658f70",
+        "rev": "67f60ebce88a89939fb509f304ac554bcdc5bfa6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`67f60ebc`](https://github.com/nix-community/home-manager/commit/67f60ebce88a89939fb509f304ac554bcdc5bfa6) | `` tests/home-cursor: don't use realPkgs ``            |
| [`4bc9b08c`](https://github.com/nix-community/home-manager/commit/4bc9b08c330842cb6e0cdafdb3c3b900cdde111a) | `` tests/broot: stub broot ``                          |
| [`39037b08`](https://github.com/nix-community/home-manager/commit/39037b08f11ed034f4e0649aadbcdd856fab0ced) | `` tests: darwin stub hjson-go ``                      |
| [`412eb166`](https://github.com/nix-community/home-manager/commit/412eb166eb6725549c7e6b317eb48dc2bc648e39) | `` tests/thunderbird: dont use realPkgs ``             |
| [`fc09cb7a`](https://github.com/nix-community/home-manager/commit/fc09cb7aaadb70d6c4898654ffc872f0d2415df9) | `` tests/labwc: fix autostart ``                       |
| [`4d6a8f59`](https://github.com/nix-community/home-manager/commit/4d6a8f590e46e62075e6787860f0ea030bab7651) | `` keepassxc: nullable package support ``              |
| [`54b494a7`](https://github.com/nix-community/home-manager/commit/54b494a77fb9fa68b0ebd7f75a8179cca0b286cd) | `` keepassxc: add module ``                            |
| [`5e6a8203`](https://github.com/nix-community/home-manager/commit/5e6a8203cee7cc33b2e0d9a0adb7268f46447292) | `` khard: add option to set mutiple subdirs (#6823) `` |