### PR TITLE
chore(flake/nixvim-flake): `0c771ea4` -> `d0b7a19d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1744712683,
-        "narHash": "sha256-C6jHAgNi50A4yZS4YzsT4hY1b6FjVgkJb3DcglbeKXw=",
+        "lastModified": 1744962259,
+        "narHash": "sha256-qiczbsj5lRZc/f0jHxADD0M32hxlPbrhNhWz3zx3MBg=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "c2d972bed84323146535ac2e3e69e8a2d995eabd",
+        "rev": "188b1f5c400c2349b6c4a1d130dc893d2b29f60c",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1744940617,
-        "narHash": "sha256-pydLcm7yZ7yDTXWf5b6Rko7L6Ijd6ZWR4wFixJneAJc=",
+        "lastModified": 1745026886,
+        "narHash": "sha256-fFHnGyrgvu+okMbpuJMb3LRQm6nwUIJvJixIrb5CL1Y=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "0c771ea43ff1939fc7dee832f96690f1b2be5f16",
+        "rev": "d0b7a19d01c30772c004914b2357afa28a4be985",
         "type": "github"
       },
       "original": {
@@ -900,11 +900,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1744707583,
-        "narHash": "sha256-IPFcShGro/UUp8BmwMBkq+6KscPlWQevZi9qqIwVUWg=",
+        "lastModified": 1744961264,
+        "narHash": "sha256-aRmUh0AMwcbdjJHnytg1e5h5ECcaWtIFQa6d9gI85AI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49d05555ccdd2592300099d6a657cc33571f4fe0",
+        "rev": "8d404a69efe76146368885110f29a2ca3700bee6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`d0b7a19d`](https://github.com/alesauce/nixvim-flake/commit/d0b7a19d01c30772c004914b2357afa28a4be985) | `` chore(flake/nix-fast-build): c2d972be -> 188b1f5c `` |