### PR TITLE
chore(flake/home-manager): `67f60ebc` -> `9676e8a5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745016969,
-        "narHash": "sha256-nDK8Z+LsNWrUsQ1JjnndNB57lvCmvy2QZUoCakoJCcI=",
+        "lastModified": 1745071558,
+        "narHash": "sha256-bvcatss0xodcdxXm0LUSLPd2jjrhqO3yFSu3stOfQXg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "67f60ebce88a89939fb509f304ac554bcdc5bfa6",
+        "rev": "9676e8a52a177d80c8a42f66566362a6d74ecf78",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`9676e8a5`](https://github.com/nix-community/home-manager/commit/9676e8a52a177d80c8a42f66566362a6d74ecf78) | `` inori: init module (#6289) ``                              |
| [`ae84885d`](https://github.com/nix-community/home-manager/commit/ae84885d9b6b62dc58ccd300e9ab321a3fd9f9c7) | `` workflows/conflicts: init (#6845) ``                       |
| [`307281bf`](https://github.com/nix-community/home-manager/commit/307281bfda7f3e3469234a03a7dd9d0026bf9f36) | `` labeler: expand labels (#6846) ``                          |
| [`991a4804`](https://github.com/nix-community/home-manager/commit/991a4804720669220f7cbba078a2a27e2496eb69) | `` mkFirefoxModule: userchrome support derivations (#6844) `` |