### PR TITLE
chore(flake/home-manager): `9676e8a5` -> `496fa9c0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745071558,
-        "narHash": "sha256-bvcatss0xodcdxXm0LUSLPd2jjrhqO3yFSu3stOfQXg=",
+        "lastModified": 1745190356,
+        "narHash": "sha256-2tOi3l1E1qwG3P5dzTN4yJ52SSENNXAWZMyPwcPx9gw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9676e8a52a177d80c8a42f66566362a6d74ecf78",
+        "rev": "496fa9c054d3a212c8bcb3ac80ab310841eed361",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`496fa9c0`](https://github.com/nix-community/home-manager/commit/496fa9c054d3a212c8bcb3ac80ab310841eed361) | `` PR_TEMPLATE: mention nix fmt (#6859) ``                                      |
| [`b71ca269`](https://github.com/nix-community/home-manager/commit/b71ca269615b0837724dac13358a2f0d6816d372) | `` uv: nullable package support ``                                              |
| [`1d2d6b95`](https://github.com/nix-community/home-manager/commit/1d2d6b95688a6cb7555e2d50ba6ef1ebaa916546) | `` uv: init module ``                                                           |
| [`a0461b67`](https://github.com/nix-community/home-manager/commit/a0461b67ff657b6b6e51bb4a547ad98907d28dc8) | `` vesktop: created module ``                                                   |
| [`3cecde80`](https://github.com/nix-community/home-manager/commit/3cecde80a57211a05972aad49dab3ab4957178ae) | `` maintainers: added lilleaila ``                                              |
| [`642d3e3b`](https://github.com/nix-community/home-manager/commit/642d3e3bad75f688fa68edc01f2c3c8fe9833737) | `` atuin: add support for str + path themes (#6849) ``                          |
| [`6a676ee4`](https://github.com/nix-community/home-manager/commit/6a676ee476543fcaea916d3b7a6e130112c44603) | `` wallust: null package support ``                                             |
| [`aa2c7ac4`](https://github.com/nix-community/home-manager/commit/aa2c7ac40455ba98a106b9b5b22959a19e05a629) | `` wallust: add module ``                                                       |
| [`48bbe7bc`](https://github.com/nix-community/home-manager/commit/48bbe7bc4895a976e563b559316e8b178d474a0c) | `` maintainers: add kiara ``                                                    |
| [`f98314bb`](https://github.com/nix-community/home-manager/commit/f98314bb064cf8f8446c44afbadaaad2505875a7) | `` restic: init module (#6729) ``                                               |
| [`bb8d2866`](https://github.com/nix-community/home-manager/commit/bb8d286649e97b89ad7dedae90418ff78f028c9d) | `` zed-editor: add themes option (#6832) ``                                     |
| [`e8b68f99`](https://github.com/nix-community/home-manager/commit/e8b68f99c6921c3ea8a79df85a2e980a71b17bfb) | `` eza: add theme option (#6850) ``                                             |
| [`f6d295ce`](https://github.com/nix-community/home-manager/commit/f6d295cee3f6c9f8e968e1bfa4fda29bf9314bc5) | `` flake.lock: Update (#6854) ``                                                |
| [`b8d186ab`](https://github.com/nix-community/home-manager/commit/b8d186abf8e14b3cffc8e0aee6459a323bc83eb0) | `` fish: allow multiple commands for command option in abbreviations (#6851) `` |
| [`20705949`](https://github.com/nix-community/home-manager/commit/20705949f101952182694be8e7ccd890f61824c2) | `` kitty: add git diff integration (#6855) ``                                   |