### PR TITLE
chore(flake/stylix): `8d5cd725` -> `179220cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1744910471,
-        "narHash": "sha256-HItOUMA2whFnPMJuyN2XHq9TZttgrgOAZcoUXsaD4Js=",
+        "lastModified": 1745196775,
+        "narHash": "sha256-k1P/5858UoNcdaBB5L4gFMFid4OPvWJmV+tgc/BB0BQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "8d5cd725ad591890c0cd804bf68cc842b8afca51",
+        "rev": "179220cfc24b77e206fe240fac76d7974c32c8d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                     |
| --------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`179220cf`](https://github.com/danth/stylix/commit/179220cfc24b77e206fe240fac76d7974c32c8d4) | `` gitui: switch from rgb to hex (#1144) `` |
| [`758fe634`](https://github.com/danth/stylix/commit/758fe63490093650075ec7587b7a6eb38614a4dd) | `` helix: use theme option ``               |
| [`8b0d9317`](https://github.com/danth/stylix/commit/8b0d9317edd57c5374adcf6957ae4775875c2a9d) | `` btop: use theme option (#1126) ``        |