### PR TITLE
chore(flake/stylix): `179220cf` -> `45aa31f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745196775,
-        "narHash": "sha256-k1P/5858UoNcdaBB5L4gFMFid4OPvWJmV+tgc/BB0BQ=",
+        "lastModified": 1745267573,
+        "narHash": "sha256-fSmjCxVoBv76TzAHK/wnJA+F8IWSlWj+FVZAk9r391o=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "179220cfc24b77e206fe240fac76d7974c32c8d4",
+        "rev": "45aa31f5a4975e6f28596fa3c49997b8a35c78a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                     |
| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`45aa31f5`](https://github.com/danth/stylix/commit/45aa31f5a4975e6f28596fa3c49997b8a35c78a1) | `` stylix: apply standardized message convention (#1155) `` |
| [`ae74f20c`](https://github.com/danth/stylix/commit/ae74f20cc25a24b9440b2ef9b95e6eb71a79186d) | `` zed: use themes option (#1151) ``                        |
| [`039e938b`](https://github.com/danth/stylix/commit/039e938b29ce870ba326be1d60ae6d7c0a58f84e) | `` doc: promote lib.singleton in testbeds (#1148) ``        |