### PR TITLE
chore(flake/home-manager): `496fa9c0` -> `81541ea3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745190356,
-        "narHash": "sha256-2tOi3l1E1qwG3P5dzTN4yJ52SSENNXAWZMyPwcPx9gw=",
+        "lastModified": 1745272532,
+        "narHash": "sha256-+sFbKw1vFkulKYxsAbz84N0V/goSg808IgFh8iWe/As=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "496fa9c054d3a212c8bcb3ac80ab310841eed361",
+        "rev": "81541ea36d1fead4be7797e826ee325d4c19308b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`81541ea3`](https://github.com/nix-community/home-manager/commit/81541ea36d1fead4be7797e826ee325d4c19308b) | `` lorri: fix missing makeSearchPath (#6875) ``                |
| [`42d90297`](https://github.com/nix-community/home-manager/commit/42d90297b38424a62235550a191fca875913e2f7) | `` git: support maintenance on darwin (#6868) ``               |
| [`22b326b4`](https://github.com/nix-community/home-manager/commit/22b326b42bf42973d5e4fe1044591fb459e6aeac) | `` television: add module (#6866) ``                           |
| [`be4e5ec6`](https://github.com/nix-community/home-manager/commit/be4e5ec62ce5703a00e40668f7a1a79d04c2195d) | `` nix-init: add module (#6864) ``                             |
| [`08b85bd0`](https://github.com/nix-community/home-manager/commit/08b85bd0002c7ac500b8d9ac0112467885712b1f) | `` vesktop: add support for multiple themes (#6860) ``         |
| [`ca836711`](https://github.com/nix-community/home-manager/commit/ca8367117a20e11139b6b887aa19cb5d48dc1075) | `` atuin: Fix deprecated string type warning (#6861) ``        |
| [`ddda2b1f`](https://github.com/nix-community/home-manager/commit/ddda2b1f20ffc92b803fc5c8c0d80bbfb54cd478) | `` direnv: only set sessionVariable for old version (#6842) `` |
| [`82ee14ff`](https://github.com/nix-community/home-manager/commit/82ee14ff60611b46588ea852f267aafcc117c8c8) | `` treewide: remove with lib (#6871) ``                        |
| [`6695b1d4`](https://github.com/nix-community/home-manager/commit/6695b1d477246e30a3f14a7084c82775b30c09c1) | `` kconfig: escape arguments properly (#6867) ``               |
| [`3fbe9a2b`](https://github.com/nix-community/home-manager/commit/3fbe9a2b76ff5c4dcb2a2a2027dac31cfc993c8c) | `` tests/ranger: null package ``                               |
| [`63bfbf55`](https://github.com/nix-community/home-manager/commit/63bfbf55b6e561f5c517a29f9bf9157ff9dd8c87) | `` ranger: nullable package support ``                         |
| [`14eda3db`](https://github.com/nix-community/home-manager/commit/14eda3db4e0347bb03f0d2e32f28f4467744abe1) | `` clock-rs: add module ``                                     |
| [`ac21ae37`](https://github.com/nix-community/home-manager/commit/ac21ae37168f339cccfd7002039314aeb3829bf6) | `` maintainers: add Oughie ``                                  |
| [`b0cc0924`](https://github.com/nix-community/home-manager/commit/b0cc092405da805da6fa964f5a178343658ceaf0) | `` shikane: init module (#4096) ``                             |