### PR TITLE
chore(flake/stylix): `45aa31f5` -> `f46d58be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745267573,
-        "narHash": "sha256-fSmjCxVoBv76TzAHK/wnJA+F8IWSlWj+FVZAk9r391o=",
+        "lastModified": 1745366676,
+        "narHash": "sha256-PM5GUWR6O4b4cETjkbtLdzGI9IUOM/sP+AUz7rf6lHo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "45aa31f5a4975e6f28596fa3c49997b8a35c78a1",
+        "rev": "f46d58be39a7822a88f29b1650ec14c961c81414",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`f46d58be`](https://github.com/danth/stylix/commit/f46d58be39a7822a88f29b1650ec14c961c81414) | `` gtk: invert extraCss warning (#1159) ``                                 |
| [`b37f3052`](https://github.com/danth/stylix/commit/b37f305238354eee2701bf790921834e14614141) | `` doc: display GitHub handles in maintainer sections (#1140) ``           |
| [`375b1de2`](https://github.com/danth/stylix/commit/375b1de2424aac1338ee6e8b4ef15976b64b0462) | `` gtk: warn about non-functional gtk.gtk{3,4}.extraCss options (#1153) `` |
| [`a7a0682b`](https://github.com/danth/stylix/commit/a7a0682b3e5e61601c7372102d891aed981292cb) | `` gitui: fix config.lib.stylix.colors.withHashtag typo (#1154) ``         |