### PR TITLE
chore(flake/nixvim-flake): `404e3203` -> `c061017b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745182672,
-        "narHash": "sha256-xh4O19Hre9LiJk0Aa3ZY/XlN00gAGhRUxCRz15j00JU=",
+        "lastModified": 1745244491,
+        "narHash": "sha256-UlwXkytxGW/aokB9fZ6cSznYKM9ynDLHqhjcPve0KL4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6c4e2d9279e57369203ecfa159696c6a2af22130",
+        "rev": "7a58109958d14bcece8ec3e2085e41ea3351e387",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1745245791,
-        "narHash": "sha256-dRxD3DuLqZurJcbpdMUAUBVlSSAFY+yqcT4hzdFXj2Y=",
+        "lastModified": 1745286352,
+        "narHash": "sha256-htdyjVyqYZMSM50zijuENLVVFJDiCoEeIbxOlSDz7bY=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "404e320393b7f052d023f87cdb1d25e902ab7dd5",
+        "rev": "c061017b2859edf85ebcef2ac8e83c0125cf9221",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`c061017b`](https://github.com/alesauce/nixvim-flake/commit/c061017b2859edf85ebcef2ac8e83c0125cf9221) | `` chore(flake/nixvim): 6c4e2d92 -> 7a581099 `` |