### PR TITLE
chore(flake/home-manager): `81541ea3` -> `b99e3e46`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745272532,
-        "narHash": "sha256-+sFbKw1vFkulKYxsAbz84N0V/goSg808IgFh8iWe/As=",
+        "lastModified": 1745362344,
+        "narHash": "sha256-R4d7j2urn/W+K9crKJaxJvZOsVX5v7uCAymaDBq97SE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "81541ea36d1fead4be7797e826ee325d4c19308b",
+        "rev": "b99e3e46b86aefc01f229e0a29d0c03c1079aaed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`b99e3e46`](https://github.com/nix-community/home-manager/commit/b99e3e46b86aefc01f229e0a29d0c03c1079aaed) | `` ci: fixed redundant rule (#6883) ``                           |
| [`6899001a`](https://github.com/nix-community/home-manager/commit/6899001a762b0e089ad7b8ec7637d0a678640b8e) | `` fcitx5: add `themes` and `classicUiConfig` options (#6876) `` |
| [`c9433ae6`](https://github.com/nix-community/home-manager/commit/c9433ae62fbb4bd09609e242569edc3b551e21a9) | `` keepassxc: register as native messaging host (#6879) ``       |
| [`b925865c`](https://github.com/nix-community/home-manager/commit/b925865c74a783c2fd42f0f340f18f2276baa316) | `` ci: label msmtp changes with "mail" (#6881) ``                |
| [`342b3e3e`](https://github.com/nix-community/home-manager/commit/342b3e3e6df239dc972372e6a641acf052ff74aa) | `` msmtp: rename environment variables (#6839) ``                |
| [`cf0c5e01`](https://github.com/nix-community/home-manager/commit/cf0c5e0105c5920f203473b571bbdc051c46995a) | `` xdg-autostart: fix runCommandNoCCLocal deprecation (#6880) `` |
| [`ce8dc1f7`](https://github.com/nix-community/home-manager/commit/ce8dc1f77ada561f4deee2c76f7cd6f6c7b8feec) | `` xsettingsd: Remove erroneous `lib.` insertion (#6877) ``      |