### PR TITLE
chore(flake/home-manager): `b99e3e46` -> `d31710fb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745362344,
-        "narHash": "sha256-R4d7j2urn/W+K9crKJaxJvZOsVX5v7uCAymaDBq97SE=",
+        "lastModified": 1745439012,
+        "narHash": "sha256-TwbdiH28QK7Da2JQTqFHdb+UCJq6QbF2mtf+RxHVzEA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b99e3e46b86aefc01f229e0a29d0c03c1079aaed",
+        "rev": "d31710fb2cd536b1966fee2af74e99a0816a61a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`d31710fb`](https://github.com/nix-community/home-manager/commit/d31710fb2cd536b1966fee2af74e99a0816a61a8) | `` fcitx5: fix iniFormat usage (#6899) ``                                 |
| [`6d1f834c`](https://github.com/nix-community/home-manager/commit/6d1f834ca63700604a96d8c38aa8ac272d95071a) | `` fcitx5: add upstream options (#6892) ``                                |
| [`59de2dfb`](https://github.com/nix-community/home-manager/commit/59de2dfb0a08ebcbc73e3bb8488d2c23057e6ad8) | `` workflows: only run conflicts and update flake on main repo (#6893) `` |
| [`b7527e2d`](https://github.com/nix-community/home-manager/commit/b7527e2daf755437a2948f09761a8ed07debd075) | `` vesktop: only generate settings when configured (#6897) ``             |
| [`ff6adf83`](https://github.com/nix-community/home-manager/commit/ff6adf83b9cfdc88dc0b035a608e08d3eb674b3a) | `` input-method: fix enable condition (#6896) ``                          |
| [`6c132a09`](https://github.com/nix-community/home-manager/commit/6c132a098e61163fb559db986efe913acd3df4e7) | `` tests/darwinScrublist: add more darwin stubs ``                        |
| [`a3e713cb`](https://github.com/nix-community/home-manager/commit/a3e713cb82af628105480ae54dc7500b5ec8ebd1) | `` tests/darwinScrublist: move darwin scrub list to new file ``           |
| [`b01a9411`](https://github.com/nix-community/home-manager/commit/b01a94118403af8a3ce646b3d703ba3d18bed042) | `` tests/default: add more darwin stubs ``                                |
| [`814521fd`](https://github.com/nix-community/home-manager/commit/814521fdc16813b036415edb4bb42a8733729dd5) | `` flake.lock: Update (#6891) ``                                          |
| [`1d0e1390`](https://github.com/nix-community/home-manager/commit/1d0e13904bd8c444ab1595f686ede5eff377e881) | `` i18n.inputMethod: add awwpotato as maintainer ``                       |
| [`585bae4b`](https://github.com/nix-community/home-manager/commit/585bae4bbb48789ece06f4b18cb373651760c4ab) | `` i18n.inputMethod: align enable option with nixos ``                    |
| [`7ef31370`](https://github.com/nix-community/home-manager/commit/7ef3137035deca91854c38c114eeaf611707b005) | `` vesktop: fix config path on darwin (#6889) ``                          |
| [`97a62d8e`](https://github.com/nix-community/home-manager/commit/97a62d8eef74ab06b20152be0b323292dfe03c88) | `` tests/default: add zoxide darwin stub (#6888) ``                       |
| [`68bc080c`](https://github.com/nix-community/home-manager/commit/68bc080cdf00b1ec65f78c1d1e65e9828904cd22) | `` fcitx5: refactor logic (#6886) ``                                      |
| [`f1aabf1d`](https://github.com/nix-community/home-manager/commit/f1aabf1deb6981176b7608cdf67140519a3d442b) | `` zsh: deprecate initLocation options in favor of initContent (#6841) `` |
| [`c42f04c8`](https://github.com/nix-community/home-manager/commit/c42f04c83f866e3ad7d285072b253dffdabad6fe) | `` mkFirefoxModule: revert userChrome changes (#6887) ``                  |