### PR TITLE
chore(flake/nixvim-flake): `5c208734` -> `6185ed6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745415369,
-        "narHash": "sha256-XcbDjFXADOGDRXq9da4gvlKBLuMdDQ32ZSem5kf9MmE=",
+        "lastModified": 1745538632,
+        "narHash": "sha256-f2BzxQNoMF+wb+7b5O5p3fQ5r7I9u0ezzGBq2f38kl8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "78f6ff036918dcb6369f8b48abcef6a8788096e8",
+        "rev": "d86fe3df569c748b2632cfa5d27da0ea59709212",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1745459200,
-        "narHash": "sha256-YFN+3ukVyLvEJqyNZD/AIgACCRo7lpuNQEHCYkSfvlY=",
+        "lastModified": 1745622885,
+        "narHash": "sha256-m4YYZyBD5syBO8hEeKPxCTVbORnVsIS5Rt0wmmGmftA=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5c2087347f74b7de4ddadd0324c1dbc16dd301dd",
+        "rev": "6185ed6da8c378be024999cb9dfbcde8d6e9a662",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
| [`6185ed6d`](https://github.com/alesauce/nixvim-flake/commit/6185ed6da8c378be024999cb9dfbcde8d6e9a662) | `` chore(flake/nixpkgs): c11863f1 -> 8a2f738d ``                                     |
| [`5dca6366`](https://github.com/alesauce/nixvim-flake/commit/5dca6366fcbc6a6e85b8d2a7db6496deb68e99e1) | `` chore(deps): bump DeterminateSystems/nix-installer-action from 16 to 17 (#467) `` |
| [`4a4e6109`](https://github.com/alesauce/nixvim-flake/commit/4a4e61097d3a7766b4e6f53c21e050f088a3c319) | `` chore(flake/nixvim): 78f6ff03 -> d86fe3df ``                                      |