### PR TITLE
chore(flake/stylix): `4846adbc` -> `11ceb2fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,15 +5,15 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1745452037,
+        "lastModified": 1745523430,
         "narHash": "sha256-EAYWV+kXbwsH+8G/8UtmcunDeKwLwSOyfcmzZUkWE/c=",
-        "owner": "awwpotato",
+        "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "985d704b4ff9f75627f279ef091b2899f8456690",
+        "rev": "58bfe2553d937d8af0564f79d5b950afbef69717",
         "type": "github"
       },
       "original": {
-        "owner": "awwpotato",
+        "owner": "SenchoPens",
         "repo": "base16.nix",
         "type": "github"
       }
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745541960,
-        "narHash": "sha256-CnkPq3sjuxB2HC93JVSotfMCF3dDrdKo3e4JOImKiLs=",
+        "lastModified": 1745618823,
+        "narHash": "sha256-WGKSI0+CY3Ep2YnRASmBRU8oMIvTW4ngFyjA0dVcKgQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4846adbc2a0334687c024aed0ca77ecd93ccdb0d",
+        "rev": "11ceb2fde1901dc227421bbbef2d0800339f5126",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                  |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`11ceb2fd`](https://github.com/danth/stylix/commit/11ceb2fde1901dc227421bbbef2d0800339f5126) | `` spotify-player: init (#1177) ``                       |
| [`245a167c`](https://github.com/danth/stylix/commit/245a167c75a221e5692c08b8a4aa15c76e32c041) | `` ci: backport dependabot by default (#1149) ``         |
| [`2dc32d8b`](https://github.com/danth/stylix/commit/2dc32d8bf0239ed025971853a1b6ad9ebddd93ba) | `` stylix: switch back to original base16.nix (#1173) `` |