### PR TITLE
chore(flake/home-manager): `abfad3d2` -> `4d2d3223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745494811,
-        "narHash": "sha256-YZCh2o9Ua1n9uCvrvi5pRxtuVNml8X2a03qIFfRKpFs=",
+        "lastModified": 1745627989,
+        "narHash": "sha256-mOCdFmxocBPae7wg7RYWOtJzWMJk34u9493ItY0dVqw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "abfad3d2958c9e6300a883bd443512c55dfeb1be",
+        "rev": "4d2d32231797bfa7213ae5e8ac89d25f8caaae82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`4d2d3223`](https://github.com/nix-community/home-manager/commit/4d2d32231797bfa7213ae5e8ac89d25f8caaae82) | `` thefuck: Add alias option (#6909) ``                                                             |
| [`54207806`](https://github.com/nix-community/home-manager/commit/542078066b1a99cdc5d5fce1365f98b847ca0b5a) | `` wezterm: don't create config if extraConfig is empty, and don't create one by default (#6908) `` |
| [`98f4fef7`](https://github.com/nix-community/home-manager/commit/98f4fef7fd7b4a77245db12e33616023162bc6d9) | `` format: Fix failing due to no cache access ``                                                    |
| [`dedfde15`](https://github.com/nix-community/home-manager/commit/dedfde15f6ad102596d0a3110f9f2852063cbc35) | `` format: Set {,XDG_CONFIG_}HOME to empty dir rather than empty string ``                          |