### PR TITLE
chore(flake/nixvim-flake): `6185ed6d` -> `15c4adf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1745538632,
-        "narHash": "sha256-f2BzxQNoMF+wb+7b5O5p3fQ5r7I9u0ezzGBq2f38kl8=",
+        "lastModified": 1745593478,
+        "narHash": "sha256-GV0YnG6ZLW+BDsEKS2rjTtKcfTcTbdlVaf0ESQDBsK8=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "d86fe3df569c748b2632cfa5d27da0ea59709212",
+        "rev": "b72ba2e4e2af53269a19b99bf684480f3ad4a78f",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1745622885,
-        "narHash": "sha256-m4YYZyBD5syBO8hEeKPxCTVbORnVsIS5Rt0wmmGmftA=",
+        "lastModified": 1745631806,
+        "narHash": "sha256-9d+uxixkt5sMlKB8ot9jgiKTm0VZYSO5Zb1nzEvOZg0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "6185ed6da8c378be024999cb9dfbcde8d6e9a662",
+        "rev": "15c4adf53dae8508eea3f99b8ed8c2e84de06546",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`15c4adf5`](https://github.com/alesauce/nixvim-flake/commit/15c4adf53dae8508eea3f99b8ed8c2e84de06546) | `` chore(flake/nixvim): d86fe3df -> b72ba2e4 `` |