### PR TITLE
chore(flake/home-manager): `4d2d3223` -> `2f5819a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745627989,
-        "narHash": "sha256-mOCdFmxocBPae7wg7RYWOtJzWMJk34u9493ItY0dVqw=",
+        "lastModified": 1745703610,
+        "narHash": "sha256-KgaGPlmjJItZ+Xf8mSoRmrsso+sf3K54n9oIP9Q17LY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4d2d32231797bfa7213ae5e8ac89d25f8caaae82",
+        "rev": "2f5819a962489e037a57835f63ed6ff8dbc2d5fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`2f5819a9`](https://github.com/nix-community/home-manager/commit/2f5819a962489e037a57835f63ed6ff8dbc2d5fb) | `` onedrive: add module (#6907) `` |