### PR TITLE
chore(flake/stylix): `11ceb2fd` -> `764fd329`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745618823,
-        "narHash": "sha256-WGKSI0+CY3Ep2YnRASmBRU8oMIvTW4ngFyjA0dVcKgQ=",
+        "lastModified": 1745962538,
+        "narHash": "sha256-UmQxI4ocPZUVHuxtaQN3zNNBU8KLK9x2gXl2kWUhMKY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "11ceb2fde1901dc227421bbbef2d0800339f5126",
+        "rev": "764fd32955e79f2742a7975f0150175f93add2fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                     |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`764fd329`](https://github.com/danth/stylix/commit/764fd32955e79f2742a7975f0150175f93add2fb) | `` btop: add testbed (#1106) ``                                             |
| [`8a35410a`](https://github.com/danth/stylix/commit/8a35410a28d346622936cb9f3f9d2592d71a6a9f) | `` treewide: add stylix.testbed.ui.{command,application} options (#1110) `` |
| [`de0870f0`](https://github.com/danth/stylix/commit/de0870f075737eac147c31fcef77df9b9525abfa) | `` wezterm: adapt for breaking change in hm (#1182) ``                      |
| [`594336f4`](https://github.com/danth/stylix/commit/594336f425edb579f11a61d76e3d866412358486) | `` stylix: switch to using treefmt (#1076) ``                               |