### PR TITLE
chore(flake/stylix): `764fd329` -> `44957b25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1745962538,
-        "narHash": "sha256-UmQxI4ocPZUVHuxtaQN3zNNBU8KLK9x2gXl2kWUhMKY=",
+        "lastModified": 1746060582,
+        "narHash": "sha256-hQ9t3iMYT3SIkrvWNteIjzR9zFbQdeTVX5fUVLtjf0U=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "764fd32955e79f2742a7975f0150175f93add2fb",
+        "rev": "44957b251b236ec89dc1923885141cd04e5e82ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                    |
| --------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`44957b25`](https://github.com/danth/stylix/commit/44957b251b236ec89dc1923885141cd04e5e82ab) | `` fcitx5: use upstream options (#1158) `` |
| [`e11bc9a5`](https://github.com/danth/stylix/commit/e11bc9a59d45c36c7e5e47f4ff0fab21a1f52f8c) | `` wofi: add testbed (#1180) ``            |