### PR TITLE
chore(flake/nix-index-database): `18752471` -> `13ba07d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745725746,
+        "lastModified": 1746054057,
         "narHash": "sha256-iR+idGZJ191cY6NBXyVjh9QH8GVWTkvZw/w+1Igy45A=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "187524713d0d9b2d2c6f688b81835114d4c2a7c6",
+        "rev": "13ba07d54c6ccc5af30a501df669bf3fe3dd4db8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`4181625d`](https://github.com/nix-community/nix-index-database/commit/4181625d0140d261b62bbac10b4d3dfbad03f806) | `` Revert "treewide: disable programs.nix-index.enable option by default" `` |
| [`fcd80500`](https://github.com/nix-community/nix-index-database/commit/fcd8050007dabcc7f17a31407882d90f3c10a9c2) | `` treewide: disable programs.nix-index.enable option by default ``          |