### PR TITLE
chore(flake/home-manager): `1ad12323` -> `5f217e5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745894335,
-        "narHash": "sha256-m47zhftaod/oHOwoVT25jstdcVLhkrVGyvEHKjbnFHI=",
+        "lastModified": 1746040799,
+        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1ad123239957d40e11ef66c203d0a7e272eb48aa",
+        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`5f217e5a`](https://github.com/nix-community/home-manager/commit/5f217e5a319f6c186283b530f8c975e66c028433) | `` restic: change service type from `simple` to `oneshot` ``                   |
| [`7f301a4d`](https://github.com/nix-community/home-manager/commit/7f301a4d968f3b846efde5a43455d959b69a348f) | `` restic: fix certain integration tests ``                                    |
| [`272eb00d`](https://github.com/nix-community/home-manager/commit/272eb00d1396bd86e77ebefd1abc47dfcab837b3) | `` fcitx5: ensure config doesn't get overwritten (#6940) ``                    |
| [`c9c2c1a1`](https://github.com/nix-community/home-manager/commit/c9c2c1a14e8d6292857272a0a56a4213664ec8fa) | `` kime: fix systemd service (#6911) ``                                        |
| [`d2b3e6c8`](https://github.com/nix-community/home-manager/commit/d2b3e6c83d457aa0e7f9344c61c3fed32bad0f7e) | `` flake.lock: Update (#6937) ``                                               |
| [`ca39b348`](https://github.com/nix-community/home-manager/commit/ca39b348299bb772a7cca2271cef9b91845a390a) | `` carapace: fix nushell PATH env var (#6936) ``                               |
| [`84d26211`](https://github.com/nix-community/home-manager/commit/84d262115e10ad321ef01cd85903d0f5c3ec113f) | `` nixos,darwin: add osClass (_class) as a specialArg (#6906) ``               |
| [`9389f373`](https://github.com/nix-community/home-manager/commit/9389f373bee64cc8459253e0ab00635b05c0bcb6) | `` pls: enableAliases -> enableShellIntegration (#6932) ``                     |
| [`e9c80e27`](https://github.com/nix-community/home-manager/commit/e9c80e277b572f642835afbf0d793b72cf49f551) | `` tests/gpg-agent: add pinentry-program test ``                               |
| [`a4c3ce44`](https://github.com/nix-community/home-manager/commit/a4c3ce44fcd65849751caab203c2076b092e7069) | `` gpg-agent: pinentryPackage -> pinentry.package and add pinentry.program` `` |