### PR TITLE
chore(flake/stylix): `44957b25` -> `716e6669`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1745459908,
-        "narHash": "sha256-bWqgohVf/py9EW3bLS/dYbenD2p9N2/Qsw1+CJk1S04=",
+        "lastModified": 1746056780,
+        "narHash": "sha256-/emueQGaoT4vu0QjU9LDOG5roxRSfdY0K2KkxuzazcM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dbc4ba3233b2bf951521177bf0ee0a7679959035",
+        "rev": "d476cd0972dd6242d76374fcc277e6735715c167",
         "type": "github"
       },
       "original": {
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746060582,
-        "narHash": "sha256-hQ9t3iMYT3SIkrvWNteIjzR9zFbQdeTVX5fUVLtjf0U=",
+        "lastModified": 1746111784,
+        "narHash": "sha256-94MEscICizhXBJvP5o6f9lcY2vWXTSg1XKZZbS19Yso=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "44957b251b236ec89dc1923885141cd04e5e82ab",
+        "rev": "716e6669a9840e4ba0d8deb6ab1d016ef01c475a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                                    |
| --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`716e6669`](https://github.com/danth/stylix/commit/716e6669a9840e4ba0d8deb6ab1d016ef01c475a) | `` {neovim,nixvim}: add transparentBackground.numberLine option (#1178) `` |
| [`b4d3137c`](https://github.com/danth/stylix/commit/b4d3137c5ce960073a991bd99a333cad1b233101) | `` ci: use format for flake update title (#1197) ``                        |
| [`7476be8b`](https://github.com/danth/stylix/commit/7476be8b0bfdd4f6135e8a72678b2b9487069fe3) | `` ci: fix stable pr title for update flake (#1196) ``                     |
| [`51cc5640`](https://github.com/danth/stylix/commit/51cc5640d9532874274f754c64c2ef32ada1a703) | `` stylix: update all flake inputs ``                                      |