### PR TITLE
chore(flake/home-manager): `5f217e5a` -> `015f1913`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746040799,
-        "narHash": "sha256-osgPX/SzIpkR50vev/rqoTEAVkEcOWXoQXmbzsaI4KU=",
+        "lastModified": 1746134275,
+        "narHash": "sha256-sxfY7TIP59o2hcueanoRAtg833PiNroZkQDwlKJxGvs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5f217e5a319f6c186283b530f8c975e66c028433",
+        "rev": "015f1913109d44c36e683b55f0e47e283b383caa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`015f1913`](https://github.com/nix-community/home-manager/commit/015f1913109d44c36e683b55f0e47e283b383caa) | `` ci: remove GitLab rycee/nur-expression update ``           |
| [`4e7ee4d0`](https://github.com/nix-community/home-manager/commit/4e7ee4d02cc323fc338ff978ca4a2b72e08f5d8d) | `` home-manager: new formatting of generated configuration `` |
| [`81431b6d`](https://github.com/nix-community/home-manager/commit/81431b6d6fa756db641109461fc943ba23b550b7) | `` gpg-agent: fix typo (#6950) ``                             |