### PR TITLE
chore(flake/stylix): `953e7247` -> `e51b3e64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -729,11 +729,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746223791,
-        "narHash": "sha256-R/DWYbY+Yr/QULujNlozfBUU2s9nZPoRikjIGPTYcR8=",
+        "lastModified": 1746307762,
+        "narHash": "sha256-Ss8FaZEOpZgQiH3Z/LkSokxsIfrpy+jdlq4PxCRLwJ0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "953e7247ac340e5036f8af47eaccf1a23f1a0257",
+        "rev": "e51b3e64f90960a523ff39baa271f373cd60321a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                         |
| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`e51b3e64`](https://github.com/danth/stylix/commit/e51b3e64f90960a523ff39baa271f373cd60321a) | `` lazygit: add testbed (#1191) ``                              |
| [`fe3feecf`](https://github.com/danth/stylix/commit/fe3feecf23f8c71067c47a2cfaca5e86c8723450) | `` testbed: wrap autostart command in a shell script (#1204) `` |