### PR TITLE
chore(flake/home-manager): `1e8c62c6` -> `45c29856`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -603,11 +603,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1747436826,
-        "narHash": "sha256-uLyPKU5V9hRO6lsHkrMg2f+N6o7cIG+XiO7PXNOJyFk=",
+        "lastModified": 1747607161,
+        "narHash": "sha256-73mz+f6XlVsRxLbjQeCrgW7mZnUihoPoHDa+GIg2j/o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ffdeb40a505c6f7d2dfd9bcae6358e4e97bb0d2e",
+        "rev": "563fdaeef95599e584fcff2e8f8d6f72011ffb99",
         "type": "github"
       },
       "original": {
@@ -630,11 +630,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1747533418,
-        "narHash": "sha256-KLQQUvn7nWnrJNs0jr85bzFvSD1x1qkK/s/ZBo4F0lc=",
+        "lastModified": 1747619737,
+        "narHash": "sha256-9emDcKctwfA8C0zYDdqdlgD/yDYiGvm1N6hkLkb1Qy8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "84d1564deb9e63edd5a08cbdf1a4c39145256591",
+        "rev": "7c86dbdb2f15fe3079deb1cbd874e2ba53e84e7e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747563892,
-        "narHash": "sha256-FB7tItU9FO5bROIrSYQR3pTtIK0z7HtqBOaEiXh0sXU=",
+        "lastModified": 1747648711,
+        "narHash": "sha256-I1l/Mjry4wspuUBqIScXVg2Iy9ZdVKgGavV5FDCJ694=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4ade860f015131c12ab0317289ad9336c5e882c7",
+        "rev": "214d92233e3b125efaaa2c2931448ab6f5bccd61",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1745523430,
-        "narHash": "sha256-EAYWV+kXbwsH+8G/8UtmcunDeKwLwSOyfcmzZUkWE/c=",
+        "lastModified": 1746562888,
+        "narHash": "sha256-YgNJQyB5dQiwavdDFBMNKk1wyS77AtdgDk/VtU6wEaI=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "58bfe2553d937d8af0564f79d5b950afbef69717",
+        "rev": "806a1777a5db2a1ef9d5d6f493ef2381047f2b89",
         "type": "github"
       },
       "original": {
@@ -194,7 +194,6 @@
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
-          "nur",
           "nixpkgs"
         ]
       },
@@ -215,27 +214,6 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -406,16 +384,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -645,7 +623,10 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
         "nixpkgs": [
           "stylix",
           "nixpkgs"
@@ -712,7 +693,7 @@
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_2",
+        "flake-parts": "flake-parts_3",
         "git-hooks": "git-hooks_3",
         "gnome-shell": "gnome-shell",
         "home-manager": [
@@ -730,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746307762,
-        "narHash": "sha256-Ss8FaZEOpZgQiH3Z/LkSokxsIfrpy+jdlq4PxCRLwJ0=",
+        "lastModified": 1747675820,
+        "narHash": "sha256-Z8o3Tu/FN4GOtZl4WNY0Gcp/Uzuz06ILkRy0oPVteM0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e51b3e64f90960a523ff39baa271f373cd60321a",
+        "rev": "f8833c5e0c64287cd51a27e6061a88f4225b6b70",
         "type": "github"
       },
       "original": {
@@ -808,17 +789,16 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746204974,
-        "narHash": "sha256-Evu4H0/kzaQoCNLGQTp+JGTqkywzPx0IAo20Ci2zNck=",
+        "lastModified": 1747688838,
+        "narHash": "sha256-FZq4/3OtGV/cti9Vccsy2tGSUrxTO4hkDF9oeGRTen4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e8c62c651242fc685b10efc4a48ab777635fb7f",
+        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {

--- a/users/alesauce/core/atuin.nix
+++ b/users/alesauce/core/atuin.nix
@@ -17,7 +17,7 @@
 
   # Zsh-vi-mode overwrites the Ctrl-R keybinding for atuin, this loads atuin after zvm.
   # https://github.com/atuinsh/atuin/issues/1826
-  programs.zsh.initExtra = ''
+  programs.zsh.initContent = ''
     if [[ $options[zle] = on ]]; then
       zvm_after_init_commands+=(eval "$(${lib.getExe pkgs.atuin} init zsh)")
     fi

--- a/users/alesauce/core/zsh.nix
+++ b/users/alesauce/core/zsh.nix
@@ -22,7 +22,7 @@
       export LESSHISTFILE="${config.xdg.dataHome}/less_history"
       export CARGO_HOME="${config.xdg.cacheHome}/cargo"
     '';
-    initExtra = ''
+    initContent = ''
       source ${pkgs.zsh-vi-mode}/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh
 
       source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh

--- a/users/alesauce/dev/amzn.nix
+++ b/users/alesauce/dev/amzn.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  lib,
   ...
 }: {
   home = {
@@ -22,7 +23,7 @@
     };
   };
 
-  programs.zsh.initExtraBeforeCompInit = ''
+  programs.zsh.initContent = lib.mkOrder 550 ''
     fpath+=("${config.home.homeDirectory}/.zsh/completion")
     fpath+=("${config.home.homeDirectory}/.brazil_completion/zsh_completion")
   '';


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                                 |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`45c29856`](https://github.com/nix-community/home-manager/commit/45c2985644b60ab64de2a2d93a4d132ecb87cf66) | `` ci: bump DeterminateSystems/update-flake-lock from 24 to 25 (#7091) ``               |
| [`97118a31`](https://github.com/nix-community/home-manager/commit/97118a310eb8e13bc1b9b12d67267e55b7bee6c8) | `` flake-module: use toString primop ``                                                 |
| [`ee85cfc5`](https://github.com/nix-community/home-manager/commit/ee85cfc5c132e2cf956a7b5ab156ddaedaefcbbc) | `` home-manager: add missing file ``                                                    |
| [`10d13a62`](https://github.com/nix-community/home-manager/commit/10d13a62e3ab95ba904cbc3d2a44ac177d85da65) | `` flake.lock: Update ``                                                                |
| [`9a4a9f1d`](https://github.com/nix-community/home-manager/commit/9a4a9f1d6e43fe4044f6715ae7cc85ccb1d2fe09) | `` home-manager: prepare 25.11 ``                                                       |
| [`e08e6e23`](https://github.com/nix-community/home-manager/commit/e08e6e2389234000b0447e57abf61d8ccd59a68e) | `` home-manager: set 25.05 as stable ``                                                 |
| [`ae755329`](https://github.com/nix-community/home-manager/commit/ae755329092c87369b9e9a1510a8cf1ce2b1c708) | `` templates/nix-darwin: nixpkgs track nixpkgs-unstable ``                              |
| [`5d132608`](https://github.com/nix-community/home-manager/commit/5d13260881eae0e9894f2c1dffd2cb97d6b79a07) | `` treewide: lnl7 -> nix-darwin ``                                                      |
| [`74d31e11`](https://github.com/nix-community/home-manager/commit/74d31e1165341bf510ee2017841a599f5cfc1608) | `` ptyxis: init module (#7075) ``                                                       |
| [`d2263ce5`](https://github.com/nix-community/home-manager/commit/d2263ce5f4c251c0f7608330e8fdb7d1f01f0667) | `` nix-darwin: use `launchctl asuser` now that activation runs as root (#7051) ``       |
| [`a1a72d18`](https://github.com/nix-community/home-manager/commit/a1a72d18ee75ce4559b5f59296a7b2d37f608c1c) | `` pgcli: init (#7072) ``                                                               |
| [`098e365d`](https://github.com/nix-community/home-manager/commit/098e365dd83311cc8236f83ea6be42abb49a6c76) | `` borgmatic: add darwin-specific documentation to services.borgmatic.frequency ``      |
| [`8ae36f8e`](https://github.com/nix-community/home-manager/commit/8ae36f8ea2e0621b6cdea862e938aaa018e0ef27) | `` nix-gc: fix documentation ``                                                         |
| [`dbc90cc3`](https://github.com/nix-community/home-manager/commit/dbc90cc3ae9c8f927200a6ceaf4aa247ea6bc443) | `` rclone: declarative mounts (#7060) ``                                                |
| [`b022c9e3`](https://github.com/nix-community/home-manager/commit/b022c9e3b805484e44aaad1973ed7572b0c1b5c4) | `` vscode: allow specifying paths for VSCode JSON settings (#7055) ``                   |
| [`a99bddfe`](https://github.com/nix-community/home-manager/commit/a99bddfe53cb5ae488bfb0dc0170dae258b2c572) | `` lapce: fix no argument hash for pluginFromRegistry (#7062) ``                        |
| [`ec8205c3`](https://github.com/nix-community/home-manager/commit/ec8205c3d7d4b19998d9b762d2c5abd2fc11faa7) | `` dconf: set env var ``                                                                |
| [`ff73544e`](https://github.com/nix-community/home-manager/commit/ff73544e4a59dce43a6de7051858a453186ae9bb) | `` dconf: Provide dconf package and dbus service file ``                                |
| [`c310818d`](https://github.com/nix-community/home-manager/commit/c310818dca3d92fa6ab769a572c46e04f24b1f87) | `` mako: Fix missing dbus service file (#7065) ``                                       |
| [`c09ccd7d`](https://github.com/nix-community/home-manager/commit/c09ccd7d39eb4c246fcb0e2b3e4be0361a85c19a) | `` services.borgmatic: add initial support for darwin ``                                |
| [`34d44d7f`](https://github.com/nix-community/home-manager/commit/34d44d7f1b7da16509538f72ec6bee121932a3e1) | `` services.borgmatic: wrap systemd configuration within a isLinux condition ``         |
| [`1c2fccef`](https://github.com/nix-community/home-manager/commit/1c2fccef832e5fbf2df4162f742f76a153aa5443) | `` services.nix-gc: extract darwin agent interval code to new library file ``           |
| [`3b930bb6`](https://github.com/nix-community/home-manager/commit/3b930bb653dd9ed7da5fe86c147bbc67492efe2c) | `` services.nix-gc: improve error message when nix.gc.frequency is invalid on darwin `` |
| [`ad1e8bb7`](https://github.com/nix-community/home-manager/commit/ad1e8bb782ed91b4966ab5b642f9b2c5813354ce) | `` dbus: Create with pacakges options (#7064) ``                                        |
| [`954615c5`](https://github.com/nix-community/home-manager/commit/954615c510c9faa3ee7fb6607ff72e55905e69f2) | `` flake.lock: Update (#7058) ``                                                        |
| [`02ea7985`](https://github.com/nix-community/home-manager/commit/02ea79853ce42853d019ce689f533dc93e462862) | `` emacs: respect `defaultEditor` on Darwin (#7063) ``                                  |
| [`6bf057fc`](https://github.com/nix-community/home-manager/commit/6bf057fc8326e83bda05a669fc08d106547679fb) | `` zsh: do not duplicate zsh.{profile,login,logout,env}Extra in prezto (#7061) ``       |
| [`7c1cefb9`](https://github.com/nix-community/home-manager/commit/7c1cefb98369cc85440642fdccc1c1394ca6dd2c) | `` zsh: avoid IFD while sourcing prezto ``                                              |
| [`5f36563a`](https://github.com/nix-community/home-manager/commit/5f36563a5cae05bcfbaa5e08a69d2e8d94242f61) | `` zsh: consider zsh.{profile,login,logout,env}Extra in prezto ``                       |
| [`b44c39cf`](https://github.com/nix-community/home-manager/commit/b44c39cf4618ccf58df2b68827ca95a3fecf0655) | `` foliate: fix theme settings example (#7053) ``                                       |
| [`8d832ddf`](https://github.com/nix-community/home-manager/commit/8d832ddfda9facf538f3dda9b6985fb0234f151c) | `` foliate: init (#7049) ``                                                             |
| [`df556f2a`](https://github.com/nix-community/home-manager/commit/df556f2a17b7b94148d0275c1a57fed20e62ad18) | `` tests/mako: add a original deprecation test ``                                       |
| [`78ad8e3c`](https://github.com/nix-community/home-manager/commit/78ad8e3c31cc5239674dfd7ca6159e5ca14da0e8) | `` tests/mako: add a deprecation test ``                                                |
| [`0be2c246`](https://github.com/nix-community/home-manager/commit/0be2c246e37a5b6e851111bfcf07ab37194e4954) | `` mako: deprecate criteria option ``                                                   |
| [`dc589997`](https://github.com/nix-community/home-manager/commit/dc5899978f8fa5d72424d5242784fb7e84e8573e) | `` services/mako: refactor settings to support INI sections ``                          |
| [`535a541b`](https://github.com/nix-community/home-manager/commit/535a541b429c1e89f0955c160df1d6d2bfeaf802) | `` halloy: fix themes example (#7046) ``                                                |
| [`012cc9e1`](https://github.com/nix-community/home-manager/commit/012cc9e1666b8ce0d6f677b902651f6858dfbe45) | `` halloy: add note about server being required (#7047) ``                              |
| [`665c49e0`](https://github.com/nix-community/home-manager/commit/665c49e0c2982d94f30a9826712850a59f70eeb4) | `` gnome-terminal: add package option (#7048) ``                                        |
| [`628d8cfa`](https://github.com/nix-community/home-manager/commit/628d8cfa5441eabe07fbb24861df1236a8e6dde5) | `` news: migrate news entries to YYYY/MM directory structure ``                         |
| [`bc13c13e`](https://github.com/nix-community/home-manager/commit/bc13c13ed7f7545a9f34010fa8c3febd1a92c58b) | `` news: reorganize news into YYYY/MM directory structure ``                            |
| [`f0a7db5e`](https://github.com/nix-community/home-manager/commit/f0a7db5ec1d369721e770a45e4d19f8e48186a69) | `` direnv: update nushell env conversion logic (#7015) ``                               |
| [`0b24658e`](https://github.com/nix-community/home-manager/commit/0b24658ec09908e5a6515cacc54f29d589c8423b) | `` halloy: add themes option (#7043) ``                                                 |
| [`58795314`](https://github.com/nix-community/home-manager/commit/587953146298b13e897b827181967ff2298fb63c) | `` wayprompt: tweak example (#7040) ``                                                  |
| [`fb061f55`](https://github.com/nix-community/home-manager/commit/fb061f555f821fe4fb49f8f6f2a0cc3d5728bd52) | `` misc: add news entries for March modules ``                                          |
| [`0083d901`](https://github.com/nix-community/home-manager/commit/0083d901a33696bf8d29966775bc420e302fb7ea) | `` misc: add news entries for April modules ``                                          |
| [`4a7311c2`](https://github.com/nix-community/home-manager/commit/4a7311c2353a1ae1292500e25b0e18866dd115aa) | `` misc: add news entries for May modules ``                                            |
| [`c74665ab`](https://github.com/nix-community/home-manager/commit/c74665abd6e4e37d3140e68885bc49a994ffa53c) | `` bacon: add prefs location to settings decription (#7030) ``                          |
| [`7a3f3e55`](https://github.com/nix-community/home-manager/commit/7a3f3e550737c3ed43f6abf33a560cb58537d21f) | `` misc: fix mozilla native messaging hosts ``                                          |
| [`a48fecda`](https://github.com/nix-community/home-manager/commit/a48fecda099e9324134f6dd88fe7e38f58d2d9d2) | `` files: add home.file.<name>.ignorelinks ``                                           |
| [`910292fe`](https://github.com/nix-community/home-manager/commit/910292fe342071f83d6906c7ca24864eba28676a) | `` halloy: add module (#7034) ``                                                        |
| [`ecb21624`](https://github.com/nix-community/home-manager/commit/ecb216242293f8a31c5426b40190700e5b3686fd) | `` numbat: add module ``                                                                |
| [`563e1b6c`](https://github.com/nix-community/home-manager/commit/563e1b6cb08256aa883526f5f3deb6970f390e58) | `` maintainers: add Aehmlo ``                                                           |
| [`5daf23a3`](https://github.com/nix-community/home-manager/commit/5daf23a38f53119803d1e329bf2eaa101563999c) | `` zellij: add themes option (#7031) ``                                                 |
| [`ff915842`](https://github.com/nix-community/home-manager/commit/ff915842e4a2e63c4c8c5c08c6870b9d5b3c3ee9) | `` Translate using Weblate (Catalan) ``                                                 |
| [`6991569c`](https://github.com/nix-community/home-manager/commit/6991569cb7cdde9891f52b43abe9916779df45b0) | `` flake.lock: Update ``                                                                |
| [`de496c9c`](https://github.com/nix-community/home-manager/commit/de496c9ccb705ed76c1f23c2cad13e8970c37f0b) | `` television: add support for channels (#7026) ``                                      |
| [`9ef92f1c`](https://github.com/nix-community/home-manager/commit/9ef92f1c6b77944198fd368ec805ced842352a1d) | `` waveterm: fix markdown in description ``                                             |
| [`13289f06`](https://github.com/nix-community/home-manager/commit/13289f06429700f3ecf8f5109ed8831839f09145) | `` services.autorandr: improve systemd unit description ``                              |
| [`1875b5a1`](https://github.com/nix-community/home-manager/commit/1875b5a1606a897d9285d80600c7ab566911c7bc) | `` services.autorandr: improve configurability ``                                       |
| [`555f88ad`](https://github.com/nix-community/home-manager/commit/555f88ad3452f1d2ce1560e7209b0b6af0c6033b) | `` services.autorandr: add package option ``                                            |
| [`4f442217`](https://github.com/nix-community/home-manager/commit/4f44221724ce074404fb0e569acdd6c456ed22d2) | `` services.autorandr: add lowlevl to maintainers ``                                    |
| [`b96c332d`](https://github.com/nix-community/home-manager/commit/b96c332dce9a1974ee046a4dcd5860a5f41009f5) | `` maintainers: add lowlevl ``                                                          |
| [`12e67385`](https://github.com/nix-community/home-manager/commit/12e67385964d9c9304daa81d0ad5ba3b01fdd35e) | `` docs: remove recommendation to wait for maintainers for news ``                      |
| [`6fd639db`](https://github.com/nix-community/home-manager/commit/6fd639dbe5183850b6c4a7fb47ae04c4808cb891) | `` docs: update news.md to highlight create-news-entry command ``                       |
| [`c4bd004d`](https://github.com/nix-community/home-manager/commit/c4bd004d9d8981837d958264b809f7edc93d9957) | `` flake.nix: expose create-news-entry as a package ``                                  |
| [`e95a7c5b`](https://github.com/nix-community/home-manager/commit/e95a7c5b6fa93304cd2fd78cf676c4f6d23c422c) | `` Revert "direnv: update nushell env conversion logic (#6999)" (#7014) ``              |
| [`b706037a`](https://github.com/nix-community/home-manager/commit/b706037a60acc727f1b5c037e84dc61a35ef1db1) | `` distrobox: make systemd unit optional (#7007) ``                                     |
| [`e9bd9568`](https://github.com/nix-community/home-manager/commit/e9bd9568db6b627155664090ea39a1b6ece0af47) | `` jujutsu: store configuration in $XDG_CONFIG_HOME for all platforms (#6994) ``        |
| [`f2b5bf55`](https://github.com/nix-community/home-manager/commit/f2b5bf55aa439a6c517adfcb9715a5a952020c5f) | `` direnv: update nushell env conversion logic (#6999) ``                               |
| [`3be7c80a`](https://github.com/nix-community/home-manager/commit/3be7c80a11b3b1c3c14d0061dfaa44f1c96673ff) | `` wayprompt: add news entry for linux (#7009) ``                                       |
| [`cbd8e8e9`](https://github.com/nix-community/home-manager/commit/cbd8e8e9a040db35d6a74a8f8903a32a2e47b8c5) | `` PR_TEMPLATE: update example for module maintainer (#7011) ``                         |
| [`8f723d61`](https://github.com/nix-community/home-manager/commit/8f723d613588e4a55e8838197741727e4dea4944) | `` lutris: fix runners not working due to wrong config name (#7008) ``                  |
| [`9e10d73c`](https://github.com/nix-community/home-manager/commit/9e10d73cea313708e9f9b98114963fbaac6ec99b) | `` onlyoffice: use pkgs.formats and use mkIf in config file generation (#7006) ``       |
| [`ce1ba0e9`](https://github.com/nix-community/home-manager/commit/ce1ba0e9f34df84e1e1d7c8ab3d4c948e81f0e20) | `` neovide: fix error when no settings are declared (#7005) ``                          |
| [`8d2ee399`](https://github.com/nix-community/home-manager/commit/8d2ee39915119dead6b794f7d2b63d6a1554941d) | `` waveterm: add module (#7004) ``                                                      |
| [`5d428b68`](https://github.com/nix-community/home-manager/commit/5d428b68dd56b98f023f5360002e3fe4b66a2b63) | `` docs: update filename of generated HTML manual (#7010) ``                            |
| [`a5159823`](https://github.com/nix-community/home-manager/commit/a51598236f23c89e59ee77eb8e0614358b0e896c) | `` lutris: add module (#6964) ``                                                        |
| [`3c59c513`](https://github.com/nix-community/home-manager/commit/3c59c5132b64e885faca381e713b579dcbddba75) | `` wayprompt: init module (#7002) ``                                                    |
| [`c84396bd`](https://github.com/nix-community/home-manager/commit/c84396bda0371cb42147c82ad051bebf8a158bd5) | `` rofi: modes optional (#7003) ``                                                      |
| [`cea975d4`](https://github.com/nix-community/home-manager/commit/cea975d46d08293eae3ad0d9f16207f1ce2dfc81) | `` rofi: modes option (#6115) ``                                                        |
| [`2ede089d`](https://github.com/nix-community/home-manager/commit/2ede089d11b68d7abfcb022c60cf71249504c3b0) | `` git: configure patdiff through [patdiff] git section (#6978) ``                      |
| [`50894120`](https://github.com/nix-community/home-manager/commit/50894120e8ac792a5d3046d23e4e4c4ef32cf09c) | `` modules/modules.nix: drop duplicate entry (#7000) ``                                 |
| [`ec71b516`](https://github.com/nix-community/home-manager/commit/ec71b5162848e6369bdf2be8d2f1dd41cded88e8) | `` sbt: Scoping credentials to ThisBuild (#6026) ``                                     |
| [`a8e2d08f`](https://github.com/nix-community/home-manager/commit/a8e2d08ffdc68123316b57cf2ad51244c7eca335) | `` alot: allow commas in maildir path (#6989) ``                                        |
| [`708074ae`](https://github.com/nix-community/home-manager/commit/708074ae6db9e0468e4f48477f856e8c2d059795) | `` treewide: Prevent IFD by default ``                                                  |
| [`ae442685`](https://github.com/nix-community/home-manager/commit/ae442685297517b5fcdd85787d95c3927e4aabf5) | `` prezto: Remove unnecessary import-from-derivation ``                                 |
| [`f3384e68`](https://github.com/nix-community/home-manager/commit/f3384e688da328fcec78c6a437566b40fd6f8a18) | `` tmpfiles: also remove files that need to be removed during activation (#6980) ``     |
| [`1d5fb9da`](https://github.com/nix-community/home-manager/commit/1d5fb9da1061e30012ee68675a489ac5780c1877) | `` flake.lock: Update (#6992) ``                                                        |
| [`5da6eafc`](https://github.com/nix-community/home-manager/commit/5da6eafceb2ea15b39de54d853cc224409e4c1a9) | `` treewide: remove unused code (#6985) ``                                              |
| [`76274a21`](https://github.com/nix-community/home-manager/commit/76274a2130db36a6754f0bf262daac63f2afbd1e) | `` tests/man: index.bt -> index.db ``                                                   |
| [`ba454389`](https://github.com/nix-community/home-manager/commit/ba45438996c3bc6c245af9833904c12836923b8d) | `` tests/darwinScrublist: add newsboat ``                                               |
| [`f78a171f`](https://github.com/nix-community/home-manager/commit/f78a171fe4e6a6e0ae5c33c5be8abe72e8a43eb3) | `` mako: use toKebabCase for option transformation ``                                   |
| [`327885ce`](https://github.com/nix-community/home-manager/commit/327885ceae1aecc9b966e9370eb4043d2c169b0c) | `` lib/deprecations: add mkSettingsRenamedOptionModules with transform parameter ``     |
| [`94d32062`](https://github.com/nix-community/home-manager/commit/94d32062ca42d8149cd77d2b3e3ec5c8c4103084) | `` lib/strings: add toCaseWithSeparator ``                                              |
| [`9cebc4cb`](https://github.com/nix-community/home-manager/commit/9cebc4cb8af0d4f71acadbb5f53bee1e406cec03) | `` lib/strings: add toKebabCase ``                                                      |
| [`e121442b`](https://github.com/nix-community/home-manager/commit/e121442b6583fdbfd968cca6fb7def58af0b6288) | `` lib/strings: add toSnakeCase ``                                                      |
| [`35535345`](https://github.com/nix-community/home-manager/commit/35535345be0be7dbae2e9b787c6cf790f8c893d5) | `` television: add shell integrations (#6983) ``                                        |
| [`60964ff8`](https://github.com/nix-community/home-manager/commit/60964ff845ec5965cde978377f3f73bcef84abe5) | `` mako: fix example config (#6987) ``                                                  |
| [`8a318641`](https://github.com/nix-community/home-manager/commit/8a318641ac13d3bc0a53651feaee9560f9b2d89a) | `` sway-easyfocus: add module (#6976) ``                                                |
| [`5f1f4725`](https://github.com/nix-community/home-manager/commit/5f1f472565ee59b5001ae5022bbb1a9a64239f91) | `` mako: use ini atom type (#6977) ``                                                   |
| [`1a1793f6`](https://github.com/nix-community/home-manager/commit/1a1793f6d940d22c6e49753548c5b6cb7dc5545d) | `` ghostty: fix config syntax file location on darwin (#6970) ``                        |
| [`8167af65`](https://github.com/nix-community/home-manager/commit/8167af657c0aa58fbe1fabfe7cce0520380c1bb3) | `` mako: fix criterias typo (#6968) ``                                                  |
| [`3a185176`](https://github.com/nix-community/home-manager/commit/3a185176e48206026b8c1e6dc3f3a37ffff4b9f7) | `` flake.lock: Update (#6969) ``                                                        |
| [`621986fe`](https://github.com/nix-community/home-manager/commit/621986fed37c5d0cb8df010ed8369694dc47c09b) | `` i3bar-river: add module (#6967) ``                                                   |
| [`64f7d5e6`](https://github.com/nix-community/home-manager/commit/64f7d5e6b94e2e66e3b344fe8e002c9da97a57b1) | `` wofi: allow path to style.css (#6966) ``                                             |
| [`d1bbab6b`](https://github.com/nix-community/home-manager/commit/d1bbab6b04d865d759505f33a5c6743bbb544074) | `` mako: refactor (#6948) ``                                                            |
| [`94f4c666`](https://github.com/nix-community/home-manager/commit/94f4c66660faa994676176d1d3d94618a796c39e) | `` tests/darwinScrublist: add more packages (#6965) ``                                  |
| [`75268f62`](https://github.com/nix-community/home-manager/commit/75268f62525920c4936404a056f37b91e299c97e) | `` tests: enable all firefox tests on darwin (plus derivations) (#6960) ``              |
| [`929f8ee8`](https://github.com/nix-community/home-manager/commit/929f8ee8362aec0a2bcbcbbd485e86e701496a73) | `` thunderbird: deprecate darwinSetupWarning option (#6531) ``                          |
| [`c0962eee`](https://github.com/nix-community/home-manager/commit/c0962eeeabfb8127713f859ec8a5f0e86dead0f2) | `` thunderbird: fix accounts being removed (#6959) ``                                   |
| [`123297c5`](https://github.com/nix-community/home-manager/commit/123297c57e77c692fae7e860e701823367afbec4) | `` onagre: add module (#6958) ``                                                        |