### PR TITLE
chore(flake/nix-fast-build): `9b271cb4` -> `3806eebc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746470700,
-        "narHash": "sha256-azv9tuIs1tkkdvgNr/2m4i2ZbkeXHdbVNZCam6QT/uA=",
+        "lastModified": 1746558933,
+        "narHash": "sha256-u3mukbWpWZE62nQaO1ot7CsWnFpWiThZBlUU4RhW1Q0=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9b271cb42c591a5e031f64d5869fb0212a075bed",
+        "rev": "3806eebcc7c7c9329577ebead0880f287ebfc405",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3806eebc`](https://github.com/Mic92/nix-fast-build/commit/3806eebcc7c7c9329577ebead0880f287ebfc405) | `` chore(deps): update nixpkgs digest to e7072d1 (#141) `` |
| [`b64c5b0c`](https://github.com/Mic92/nix-fast-build/commit/b64c5b0c5416f5d7824119326a22ada9d565d068) | `` chore(deps): update nixpkgs digest to 5a837cb (#140) `` |