### PR TITLE
chore(flake/git-hooks): `dcf50727` -> `fa466640`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1746537231,
+        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`58205361`](https://github.com/cachix/git-hooks.nix/commit/58205361d8c85cab059ffeea4d8c44c2387e5301) | `` fix(trufflehog): `--show-top-level` -> `--show-toplevel` `` |