### PR TITLE
chore(flake/nix-fast-build): `3806eebc` -> `88139228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746558933,
-        "narHash": "sha256-u3mukbWpWZE62nQaO1ot7CsWnFpWiThZBlUU4RhW1Q0=",
+        "lastModified": 1746647091,
+        "narHash": "sha256-oFa9a/tJlg96XqPLpe473gIqbQkPHrr2tbdB/GCS0SU=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "3806eebcc7c7c9329577ebead0880f287ebfc405",
+        "rev": "8813922864147f81f1b0d3644f8df6cf24d0d651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`88139228`](https://github.com/Mic92/nix-fast-build/commit/8813922864147f81f1b0d3644f8df6cf24d0d651) | `` chore(deps): update nixpkgs digest to c254c79 (#143) `` |
| [`011c7684`](https://github.com/Mic92/nix-fast-build/commit/011c7684932e9fc89b4251039ec2ed31ab57e518) | `` chore(deps): update nixpkgs digest to 40a6f04 (#142) `` |