### PR TITLE
chore(flake/nixvim-flake): `d62d98bf` -> `5c14e6ff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -299,11 +299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742649964,
-        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "lastModified": 1746537231,
+        "narHash": "sha256-Wb2xeSyOsCoTCTj7LOoD6cdKLEROyFAArnYoS+noCWo=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
+        "rev": "fa466640195d38ec97cf0493d6d6882bc4d14969",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1746496156,
-        "narHash": "sha256-pUYKGwA1d3gNx4oQvCIlzDpT2HB2GikbyUv8t9/bZD4=",
+        "lastModified": 1746582634,
+        "narHash": "sha256-2p0/o7wbB4166BoNd/56hNDn8V0iC6MiMpfbThxdVo8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "d62d98bfe7660f806938c53f37d6c34e8e1596c9",
+        "rev": "5c14e6ff5b831d513c2058ae7b6f3b01ab0357a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                            |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`5c14e6ff`](https://github.com/alesauce/nixvim-flake/commit/5c14e6ff5b831d513c2058ae7b6f3b01ab0357a8) | `` chore(flake/git-hooks): dcf50727 -> fa466640 `` |