### PR TITLE
chore(flake/nixvim-flake): `5c14e6ff` -> `bac02adf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746387720,
-        "narHash": "sha256-x8k0DKiQYRNaf9Hg+di+WCKxb76zJVWSjKOlPiuc22o=",
+        "lastModified": 1746650585,
+        "narHash": "sha256-9WZtcSn1/UkYK4UNXkcLCnVR7aIVI83VweqVlCf06OA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "7d18194a22325f212e17eb876d9c00afcc434113",
+        "rev": "6597afe2097ba07fdf515a541a2a02a7e06768cd",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1746582634,
-        "narHash": "sha256-2p0/o7wbB4166BoNd/56hNDn8V0iC6MiMpfbThxdVo8=",
+        "lastModified": 1746668978,
+        "narHash": "sha256-CBcD/i63kS7F/lNv3mdSUAqCPtRWCRgp6dlh7lvsGjQ=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5c14e6ff5b831d513c2058ae7b6f3b01ab0357a8",
+        "rev": "bac02adf3c511ce7eaa20fae706ca745913cde10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`bac02adf`](https://github.com/alesauce/nixvim-flake/commit/bac02adf3c511ce7eaa20fae706ca745913cde10) | `` chore(flake/nixvim): 7d18194a -> 6597afe2 `` |