### PR TITLE
chore(flake/nix-fast-build): `88139228` -> `97af644c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746647091,
-        "narHash": "sha256-oFa9a/tJlg96XqPLpe473gIqbQkPHrr2tbdB/GCS0SU=",
+        "lastModified": 1746735896,
+        "narHash": "sha256-qGxApA74EbiKyd0ThqsAH+ELr5AbjJVmWzJZ5TUXfhU=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "8813922864147f81f1b0d3644f8df6cf24d0d651",
+        "rev": "97af644c6941b8013fddddd719429beb8aac7c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`97af644c`](https://github.com/Mic92/nix-fast-build/commit/97af644c6941b8013fddddd719429beb8aac7c5e) | `` chore(deps): update nixpkgs digest to 2cd2dec (#145) `` |
| [`38eecfc4`](https://github.com/Mic92/nix-fast-build/commit/38eecfc45d91aa1e00a740ab39bbd9d33ba5835a) | `` chore(deps): update nixpkgs digest to 1676224 (#144) `` |