### PR TITLE
chore(flake/nix-fast-build): `97af644c` -> `1e462e81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1746735896,
-        "narHash": "sha256-qGxApA74EbiKyd0ThqsAH+ELr5AbjJVmWzJZ5TUXfhU=",
+        "lastModified": 1746833729,
+        "narHash": "sha256-Fcag3XPLQ6ZMa0nHicrf3XCwhKbfPcmWz/8Jpw54cks=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "97af644c6941b8013fddddd719429beb8aac7c5e",
+        "rev": "1e462e81133f0d9137079f89845485ada5b15f3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`1e462e81`](https://github.com/Mic92/nix-fast-build/commit/1e462e81133f0d9137079f89845485ada5b15f3e) | `` chore(deps): update nixpkgs digest to 0f1c18b (#147) `` |
| [`30b0e648`](https://github.com/Mic92/nix-fast-build/commit/30b0e64851dbb8e0d94ea1a93080a613dac8630b) | `` chore(deps): update nixpkgs digest to d06b53b (#146) `` |