### PR TITLE
chore(flake/nixvim-flake): `58155832` -> `506b15f7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nuschtosSearch": "nuschtosSearch"
       },
       "locked": {
-        "lastModified": 1746749676,
-        "narHash": "sha256-782lJpCRuehoNvvyj5OJLuM3g01T1zXWEBEdZcvuiZc=",
+        "lastModified": 1746822201,
+        "narHash": "sha256-XAt4FgViCT9kcSkODQUcbQ8JejjjbTGcMVGIP+7o7YE=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "a6eda59091bfb984dde882ae7faad0f48ee8e216",
+        "rev": "1b1e43a36e4f701fb2fc870c322373579936f739",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1746755361,
-        "narHash": "sha256-S6DgQ5n6zFx1ZtSt0bAbtMYqW+hoTcScY43ZGJotNy0=",
+        "lastModified": 1746841510,
+        "narHash": "sha256-AYOgQsQGAHiMrIgRgYxV51DRq8lpKQIF+xbAy20zTQk=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "581558329da17d02d821629712793ee57238ff1f",
+        "rev": "506b15f760fb8d314937c6acdf1ba90096c786d5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`506b15f7`](https://github.com/alesauce/nixvim-flake/commit/506b15f760fb8d314937c6acdf1ba90096c786d5) | `` chore(flake/nixvim): a6eda590 -> 1b1e43a3 `` |