### PR TITLE
chore(flake/nixvim-flake): `506b15f7` -> `4f49a513`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -507,11 +507,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1746470700,
-        "narHash": "sha256-azv9tuIs1tkkdvgNr/2m4i2ZbkeXHdbVNZCam6QT/uA=",
+        "lastModified": 1746887075,
+        "narHash": "sha256-44GrKkww1p4XOANN2WpXonMsnP8+SPi4wrvERWCSb7g=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9b271cb42c591a5e031f64d5869fb0212a075bed",
+        "rev": "a803b722190a857768b06b4a804aee53c26ee49b",
         "type": "github"
       },
       "original": {
@@ -629,11 +629,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1746841510,
-        "narHash": "sha256-AYOgQsQGAHiMrIgRgYxV51DRq8lpKQIF+xbAy20zTQk=",
+        "lastModified": 1746928559,
+        "narHash": "sha256-LkH8s9oeU23T71HhoxeTcZA4WgPTmPe74kCLFbFYMR4=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "506b15f760fb8d314937c6acdf1ba90096c786d5",
+        "rev": "4f49a5130e645edecebcbeb3990991c01638fe54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`4f49a513`](https://github.com/alesauce/nixvim-flake/commit/4f49a5130e645edecebcbeb3990991c01638fe54) | `` chore(flake/nix-fast-build): 9b271cb4 -> a803b722 `` |