### PR TITLE
chore(flake/darwin): `6cb36e83` -> `d642c985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746708654,
-        "narHash": "sha256-GeC99gu5H6+AjBXsn5dOhP4/ApuioGCBkufdmEIWPRs=",
+        "lastModified": 1747069642,
+        "narHash": "sha256-a4TdGi/Ju8P3r5OIecNfM3LH3kccMY0dIo+EwiyphmM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "6cb36e8327421c61e5a3bbd08ed63491b616364a",
+        "rev": "d642c9856003ed37ce34dab618abf37e3ade1061",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                             |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
| [`84644435`](https://github.com/nix-darwin/nix-darwin/commit/846444354b4ce9ea20db88c89a38fb7da7ecb087) | `` services/buildkite-agents: support multi-tags `` |