### PR TITLE
chore(flake/nix-fast-build): `a132dbcf` -> `f59908e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747118174,
-        "narHash": "sha256-FfamGaHSmd5qDPK42qN25pvch1Y7kWGzSi0lNs2VjpY=",
+        "lastModified": 1747265771,
+        "narHash": "sha256-XCJuEIQ3gC3UZYNEZBh6q6fdpm+5AqusSGEPUdWZkwo=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "a132dbcf4d172216df12e971308a7e78b29f71f7",
+        "rev": "f59908e2b7a9e04579dace6b5728957f5dfbd058",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f59908e2`](https://github.com/Mic92/nix-fast-build/commit/f59908e2b7a9e04579dace6b5728957f5dfbd058) | `` chore(deps): update nixpkgs digest to b112281 (#156) `` |
| [`689861d6`](https://github.com/Mic92/nix-fast-build/commit/689861d60a91614c1010bb6b5b006c18f115a9dd) | `` chore(deps): update nixpkgs digest to 3a00b4e (#155) `` |