### PR TITLE
chore(flake/nix-fast-build): `f59908e2` -> `7dce68d3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747265771,
-        "narHash": "sha256-XCJuEIQ3gC3UZYNEZBh6q6fdpm+5AqusSGEPUdWZkwo=",
+        "lastModified": 1747332914,
+        "narHash": "sha256-EEPt1S1y0skS5VSlivTyNEEBo9X7DiPpHdjbmA2K7kI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "f59908e2b7a9e04579dace6b5728957f5dfbd058",
+        "rev": "7dce68d3adc8821db75018ff96acc876fd07c697",
         "type": "github"
       },
       "original": {
@@ -894,11 +894,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746989248,
-        "narHash": "sha256-uoQ21EWsAhyskNo8QxrTVZGjG/dV4x5NM1oSgrmNDJY=",
+        "lastModified": 1747299117,
+        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "708ec80ca82e2bbafa93402ccb66a35ff87900c5",
+        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`7dce68d3`](https://github.com/Mic92/nix-fast-build/commit/7dce68d3adc8821db75018ff96acc876fd07c697) | `` chore(deps): update nixpkgs digest to e06158e (#159) ``     |
| [`c8177029`](https://github.com/Mic92/nix-fast-build/commit/c81770298382b911f7f14db37b0c3e82848ab330) | `` chore(deps): update treefmt-nix digest to e758f27 (#158) `` |
| [`a8da457b`](https://github.com/Mic92/nix-fast-build/commit/a8da457b09d902dcfd681c82c710b8259abdea0c) | `` chore(deps): update nixpkgs digest to 3ad376e (#157) ``     |