### PR TITLE
chore(flake/darwin): `f88be002` -> `b6fff20c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747138802,
-        "narHash": "sha256-Ou4zV3OskaDKlkuiM2VT+1w/xceXoZ5RRM4ZuW7n5+I=",
+        "lastModified": 1747297701,
+        "narHash": "sha256-R8mFJL3lREsJNDqPHbsn03imKoH2ocpzgT2kKWsWYBM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "f88be00227161a1e9369a1d199f452dd5d720feb",
+        "rev": "b6fff20c692d684d250a39453ed1853dd44c96ab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                               |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`d693997a`](https://github.com/nix-darwin/nix-darwin/commit/d693997a324d92253772ebfc7fe5d48f3633861a) | `` defaults: update docs for `AppleInterfaceStyle` `` |
| [`f2753a4c`](https://github.com/nix-darwin/nix-darwin/commit/f2753a4ca62332923affe1182e1d4bbdef8a3837) | `` _1password{,-gui}: fix `package` not being used `` |