### PR TITLE
chore(flake/nix-fast-build): `7dce68d3` -> `51d2cb88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747332914,
-        "narHash": "sha256-EEPt1S1y0skS5VSlivTyNEEBo9X7DiPpHdjbmA2K7kI=",
+        "lastModified": 1747509878,
+        "narHash": "sha256-e32LtD8AZepEWUunTv7IpVoNaMWq1tcNoM3SLTM8Nlg=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "7dce68d3adc8821db75018ff96acc876fd07c697",
+        "rev": "51d2cb882dde63b270f37579479afb69b5e64391",
         "type": "github"
       },
       "original": {
@@ -894,11 +894,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747299117,
-        "narHash": "sha256-JGjCVbxS+9t3tZ2IlPQ7sdqSM4c+KmIJOXVJPfWmVOU=",
+        "lastModified": 1747469671,
+        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e758f27436367c23bcd63cd973fa5e39254b530e",
+        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`51d2cb88`](https://github.com/Mic92/nix-fast-build/commit/51d2cb882dde63b270f37579479afb69b5e64391) | `` chore(deps): update nixpkgs digest to 6315e9c (#166) ``     |
| [`765c14ec`](https://github.com/Mic92/nix-fast-build/commit/765c14ec198730fd1b0648078da6d6dfe9e11d51) | `` chore(deps): update treefmt-nix digest to ab0378b (#165) `` |
| [`0abf70ed`](https://github.com/Mic92/nix-fast-build/commit/0abf70edf43d59b8388a34c1e9c89a74568c486d) | `` chore(deps): update nixpkgs digest to e067fb8 (#164) ``     |
| [`145221c7`](https://github.com/Mic92/nix-fast-build/commit/145221c7d655a46c0d772a5050d16021fe9d7576) | `` chore(deps): update nixpkgs digest to b965e4c (#163) ``     |
| [`529e4e49`](https://github.com/Mic92/nix-fast-build/commit/529e4e494621ef5efc440d615aa2145a58e51800) | `` chore(deps): update treefmt-nix digest to 42dd928 (#162) `` |
| [`2aba5540`](https://github.com/Mic92/nix-fast-build/commit/2aba5540a17e424a321505770b44f0c3fcb6eb37) | `` chore(deps): update nixpkgs digest to adfa8b0 (#160) ``     |