### PR TITLE
chore(flake/darwin): `b6fff20c` -> `b9b927dd`

### DIFF
--- a/core/darwin.nix
+++ b/core/darwin.nix
@@ -49,5 +49,6 @@
   system = {
     stateVersion = 4;
     defaults.SoftwareUpdate.AutomaticallyInstallMacOSUpdates = true;
+    primaryUser = "alesauce";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -603,11 +603,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1747436826,
-        "narHash": "sha256-uLyPKU5V9hRO6lsHkrMg2f+N6o7cIG+XiO7PXNOJyFk=",
+        "lastModified": 1747607161,
+        "narHash": "sha256-73mz+f6XlVsRxLbjQeCrgW7mZnUihoPoHDa+GIg2j/o=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ffdeb40a505c6f7d2dfd9bcae6358e4e97bb0d2e",
+        "rev": "563fdaeef95599e584fcff2e8f8d6f72011ffb99",
         "type": "github"
       },
       "original": {
@@ -630,11 +630,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1747533418,
-        "narHash": "sha256-KLQQUvn7nWnrJNs0jr85bzFvSD1x1qkK/s/ZBo4F0lc=",
+        "lastModified": 1747619737,
+        "narHash": "sha256-9emDcKctwfA8C0zYDdqdlgD/yDYiGvm1N6hkLkb1Qy8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "84d1564deb9e63edd5a08cbdf1a4c39145256591",
+        "rev": "7c86dbdb2f15fe3079deb1cbd874e2ba53e84e7e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747297701,
-        "narHash": "sha256-R8mFJL3lREsJNDqPHbsn03imKoH2ocpzgT2kKWsWYBM=",
+        "lastModified": 1747521943,
+        "narHash": "sha256-GMAJcB8oB9cC+TbYTE7QDfw9fwHZyloxUWnUpHnQRko=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "b6fff20c692d684d250a39453ed1853dd44c96ab",
+        "rev": "b9b927dd1f24094b271e8ec5277a672dc4fc860d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747563892,
-        "narHash": "sha256-FB7tItU9FO5bROIrSYQR3pTtIK0z7HtqBOaEiXh0sXU=",
+        "lastModified": 1747648711,
+        "narHash": "sha256-I1l/Mjry4wspuUBqIScXVg2Iy9ZdVKgGavV5FDCJ694=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4ade860f015131c12ab0317289ad9336c5e882c7",
+        "rev": "214d92233e3b125efaaa2c2931448ab6f5bccd61",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "fromYaml": "fromYaml"
       },
       "locked": {
-        "lastModified": 1745523430,
-        "narHash": "sha256-EAYWV+kXbwsH+8G/8UtmcunDeKwLwSOyfcmzZUkWE/c=",
+        "lastModified": 1746562888,
+        "narHash": "sha256-YgNJQyB5dQiwavdDFBMNKk1wyS77AtdgDk/VtU6wEaI=",
         "owner": "SenchoPens",
         "repo": "base16.nix",
-        "rev": "58bfe2553d937d8af0564f79d5b950afbef69717",
+        "rev": "806a1777a5db2a1ef9d5d6f493ef2381047f2b89",
         "type": "github"
       },
       "original": {
@@ -194,7 +194,6 @@
       "inputs": {
         "nixpkgs-lib": [
           "stylix",
-          "nur",
           "nixpkgs"
         ]
       },
@@ -215,27 +214,6 @@
     "flake-utils": {
       "inputs": {
         "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": [
-          "stylix",
-          "systems"
-        ]
       },
       "locked": {
         "lastModified": 1731533236,
@@ -406,16 +384,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1732369855,
-        "narHash": "sha256-JhUWbcYPjHO3Xs3x9/Z9RuqXbcp5yhPluGjwsdE2GMg=",
+        "lastModified": 1744584021,
+        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "dadd58f630eeea41d645ee225a63f719390829dc",
+        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "47.2",
+        "ref": "48.1",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -645,7 +623,10 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
+        "flake-parts": [
+          "stylix",
+          "flake-parts"
+        ],
         "nixpkgs": [
           "stylix",
           "nixpkgs"
@@ -712,7 +693,7 @@
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_2",
+        "flake-parts": "flake-parts_3",
         "git-hooks": "git-hooks_3",
         "gnome-shell": "gnome-shell",
         "home-manager": [
@@ -730,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1746307762,
-        "narHash": "sha256-Ss8FaZEOpZgQiH3Z/LkSokxsIfrpy+jdlq4PxCRLwJ0=",
+        "lastModified": 1747675820,
+        "narHash": "sha256-Z8o3Tu/FN4GOtZl4WNY0Gcp/Uzuz06ILkRy0oPVteM0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e51b3e64f90960a523ff39baa271f373cd60321a",
+        "rev": "f8833c5e0c64287cd51a27e6061a88f4225b6b70",
         "type": "github"
       },
       "original": {
@@ -808,17 +789,16 @@
     "tinted-kitty": {
       "flake": false,
       "locked": {
-        "lastModified": 1716423189,
-        "narHash": "sha256-2xF3sH7UIwegn+2gKzMpFi3pk5DlIlM18+vj17Uf82U=",
+        "lastModified": 1735730497,
+        "narHash": "sha256-4KtB+FiUzIeK/4aHCKce3V9HwRvYaxX+F1edUrfgzb8=",
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
+        "rev": "de6f888497f2c6b2279361bfc790f164bfd0f3fa",
         "type": "github"
       },
       "original": {
         "owner": "tinted-theming",
         "repo": "tinted-kitty",
-        "rev": "eb39e141db14baef052893285df9f266df041ff8",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -427,11 +427,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746204974,
-        "narHash": "sha256-Evu4H0/kzaQoCNLGQTp+JGTqkywzPx0IAo20Ci2zNck=",
+        "lastModified": 1747688838,
+        "narHash": "sha256-FZq4/3OtGV/cti9Vccsy2tGSUrxTO4hkDF9oeGRTen4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e8c62c651242fc685b10efc4a48ab777635fb7f",
+        "rev": "45c2985644b60ab64de2a2d93a4d132ecb87cf66",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -563,11 +563,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747327360,
-        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "lastModified": 1747542820,
+        "narHash": "sha256-GaOZntlJ6gPPbbkTLjbd8BMWaDYafhuuYRNrxCGnPJw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "rev": "292fa7d4f6519c074f0a50394dbbe69859bb6043",
         "type": "github"
       },
       "original": {

--- a/users/alesauce/core/atuin.nix
+++ b/users/alesauce/core/atuin.nix
@@ -17,7 +17,7 @@
 
   # Zsh-vi-mode overwrites the Ctrl-R keybinding for atuin, this loads atuin after zvm.
   # https://github.com/atuinsh/atuin/issues/1826
-  programs.zsh.initExtra = ''
+  programs.zsh.initContent = ''
     if [[ $options[zle] = on ]]; then
       zvm_after_init_commands+=(eval "$(${lib.getExe pkgs.atuin} init zsh)")
     fi

--- a/users/alesauce/core/zsh.nix
+++ b/users/alesauce/core/zsh.nix
@@ -22,7 +22,7 @@
       export LESSHISTFILE="${config.xdg.dataHome}/less_history"
       export CARGO_HOME="${config.xdg.cacheHome}/cargo"
     '';
-    initExtra = ''
+    initContent = ''
       source ${pkgs.zsh-vi-mode}/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh
 
       source ${pkgs.zsh-fast-syntax-highlighting}/share/zsh/site-functions/fast-syntax-highlighting.plugin.zsh

--- a/users/alesauce/dev/amzn.nix
+++ b/users/alesauce/dev/amzn.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  lib,
   ...
 }: {
   home = {
@@ -22,7 +23,7 @@
     };
   };
 
-  programs.zsh.initExtraBeforeCompInit = ''
+  programs.zsh.initContent = lib.mkOrder 550 ''
     fpath+=("${config.home.homeDirectory}/.zsh/completion")
     fpath+=("${config.home.homeDirectory}/.brazil_completion/zsh_completion")
   '';


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                              |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`24952f03`](https://github.com/nix-darwin/nix-darwin/commit/24952f03f90cc7fe3d935618d2332ff53b414191) | `` Update default.nix ``                                             |
| [`58f268e0`](https://github.com/nix-darwin/nix-darwin/commit/58f268e065cd556bbaed56dbd894c88ab703cd9b) | `` Update CHANGELOG ``                                               |
| [`a4cc5477`](https://github.com/nix-darwin/nix-darwin/commit/a4cc54778d91c1e9631aa510b304e9a369d4f7a7) | `` Update repo link ``                                               |
| [`b9e580c1`](https://github.com/nix-darwin/nix-darwin/commit/b9e580c1130307c3aee715956a11824c0d8cdc5e) | `` changelog: document user activation removal ``                    |
| [`a0e4dd2a`](https://github.com/nix-darwin/nix-darwin/commit/a0e4dd2af9de4c62319e5ffe5c225d8488e42024) | `` activation-scripts: move `createRun` after `checks` ``            |
| [`7e5c6f7e`](https://github.com/nix-darwin/nix-darwin/commit/7e5c6f7e2156dcece3c30d42d19ce482b8f2a4ff) | `` etc: merge `etcChecks` into `checks` ``                           |
| [`af62c4d1`](https://github.com/nix-darwin/nix-darwin/commit/af62c4d1763fd60a2fbd51df7ce56828e4fa309e) | `` checks: make `nixPath` check more helpful ``                      |
| [`051283a8`](https://github.com/nix-darwin/nix-darwin/commit/051283a8953d08a7c16de5304e8dba5c4418e02e) | `` {activation-scripts,activate-system}: purify environment again `` |
| [`516dbe1f`](https://github.com/nix-darwin/nix-darwin/commit/516dbe1fa40548945f18135875ed22228db4ce33) | `` darwin-rebuild: require running as `root` ``                      |
| [`40d2a159`](https://github.com/nix-darwin/nix-darwin/commit/40d2a159cc6fd4c171613c51f81232b78be0f9be) | `` tests: remove stray `activate-user` references ``                 |
| [`2ca29474`](https://github.com/nix-darwin/nix-darwin/commit/2ca294741f94d74c9d9bdc7171bda41f9f9c975b) | `` activation-scripts: get rid of user activation ``                 |
| [`0abf0126`](https://github.com/nix-darwin/nix-darwin/commit/0abf01266612d3dd72dbf79597282cf33ad721ca) | `` users: refuse to delete the primary user ``                       |
| [`bed70a84`](https://github.com/nix-darwin/nix-darwin/commit/bed70a84af8e4bc28e4050cded929505a030195a) | `` {environment,nix}: remove references to `$HOME` ``                |
| [`2892da83`](https://github.com/nix-darwin/nix-darwin/commit/2892da83ea941e24c5549639ce294971b55840de) | `` applications: use `system.primaryUser` for the legacy path ``     |
| [`f47b8062`](https://github.com/nix-darwin/nix-darwin/commit/f47b8062cbcd1b6867e42dfac27d8e91467b553e) | `` defaults: move `userDefaults` to system activation ``             |
| [`7877cba5`](https://github.com/nix-darwin/nix-darwin/commit/7877cba5f5f462067ccd5e9eda3562fe016852d7) | `` launchd: move `userLaunchd` to system activation ``               |
| [`c449918b`](https://github.com/nix-darwin/nix-darwin/commit/c449918bfbce4211ad2c39a793780b336a737c48) | `` homebrew: move to system activation ``                            |
| [`52ee8c57`](https://github.com/nix-darwin/nix-darwin/commit/52ee8c57c26a31588c61fe9507ec688248d011ca) | `` primary-user: init ``                                             |
| [`14737a96`](https://github.com/nix-darwin/nix-darwin/commit/14737a967691173be76e0c1a77167210b8c2d266) | `` defaults: add `com.apple.iCal` for managing Calendar.app ``       |