### PR TITLE
chore(flake/nix-fast-build): `4ade860f` -> `214d9223`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -481,11 +481,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747563892,
-        "narHash": "sha256-FB7tItU9FO5bROIrSYQR3pTtIK0z7HtqBOaEiXh0sXU=",
+        "lastModified": 1747648711,
+        "narHash": "sha256-I1l/Mjry4wspuUBqIScXVg2Iy9ZdVKgGavV5FDCJ694=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4ade860f015131c12ab0317289ad9336c5e882c7",
+        "rev": "214d92233e3b125efaaa2c2931448ab6f5bccd61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`214d9223`](https://github.com/Mic92/nix-fast-build/commit/214d92233e3b125efaaa2c2931448ab6f5bccd61) | `` chore(deps): update nixpkgs digest to 949fb7f (#169) `` |
| [`330397c7`](https://github.com/Mic92/nix-fast-build/commit/330397c7e005ef1fbd420d89877ed34e12d4988a) | `` chore(deps): update nixpkgs digest to b7d438b (#168) `` |