### PR TITLE
chore(flake/stylix): `f8833c5e` -> `69b3dd05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747675820,
-        "narHash": "sha256-Z8o3Tu/FN4GOtZl4WNY0Gcp/Uzuz06ILkRy0oPVteM0=",
+        "lastModified": 1747769259,
+        "narHash": "sha256-UGfeK8/iUZVWDOYdEpbcbt0liTRIDNNepVzKzWPp6Zc=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f8833c5e0c64287cd51a27e6061a88f4225b6b70",
+        "rev": "69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`69b3dd05`](https://github.com/nix-community/stylix/commit/69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720) | `` stylix: bump release to 25.11 (#1317) ``                        |
| [`c7feebc3`](https://github.com/nix-community/stylix/commit/c7feebc34ab7374cadea1a5da7ee3393ee692d68) | `` qutebrowser: remove lib.mkDefault option declaration (#1227) `` |
| [`43a652de`](https://github.com/nix-community/stylix/commit/43a652de771aabd206ad9ce137171d0da0966198) | `` alacritty: fix bright-yellow usage, adopt (#1280) ``            |
| [`fb9c2205`](https://github.com/nix-community/stylix/commit/fb9c22056faa95f35749f116c49c5c202ceb159c) | `` doc: move to doc directory (#1272) ``                           |