### PR TITLE
chore(flake/home-manager): `29dda415` -> `6c2eb1e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747763032,
-        "narHash": "sha256-9j3oCbemeH7bTVXJ3pDWxOptbxDx2SdK1jY2AHpjQiw=",
+        "lastModified": 1747834438,
+        "narHash": "sha256-AHJt79W8wADzur2htCx1U8FtEk4XjvrHb9/3iDfNedI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "29dda415f5b2178278283856c6f9f7b48a2a4353",
+        "rev": "6c2eb1e24cd0e76d88bdd633ef4c50d6286586e0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                 |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`6c2eb1e2`](https://github.com/nix-community/home-manager/commit/6c2eb1e24cd0e76d88bdd633ef4c50d6286586e0) | `` flake.lock: Update (#7101) ``                                        |
| [`2468b2d3`](https://github.com/nix-community/home-manager/commit/2468b2d35512d093aeb04972a1d8c20a0735793f) | `` files: show colliding files at bottom in checkLinkTargets (#5495) `` |