### PR TITLE
chore(flake/stylix): `69b3dd05` -> `614c12c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747769259,
-        "narHash": "sha256-UGfeK8/iUZVWDOYdEpbcbt0liTRIDNNepVzKzWPp6Zc=",
+        "lastModified": 1747865103,
+        "narHash": "sha256-2RLLb9x++l1KGDPo6U2E7aGWZx51eBYq4NJ9fv/kyNI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "69b3dd05e6b64c71a10fb749b5ac4d7c8e40f720",
+        "rev": "614c12c5db0da406fd232cb9b0e82aec304a854e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`614c12c5`](https://github.com/nix-community/stylix/commit/614c12c5db0da406fd232cb9b0e82aec304a854e) | `` ci: fix tag for label merge conflicts (#1344) ``                      |
| [`46caa412`](https://github.com/nix-community/stylix/commit/46caa4122c4eacafba8e38f4b9344dd149064a10) | `` ci: add workflow to label merge conflicts (#1269) ``                  |
| [`c32026ea`](https://github.com/nix-community/stylix/commit/c32026eab2b314c4599fe4a4f6070229d2d7a5f5) | `` mpv: use mkTarget (#1334) ``                                          |
| [`4ce349da`](https://github.com/nix-community/stylix/commit/4ce349da56e075f7e3456b48731cbbf5ae8b1eb8) | `` alacritty: fix mkTarget usage (#1332) ``                              |
| [`7c66eda8`](https://github.com/nix-community/stylix/commit/7c66eda89ec8eabcdd8f21790224e2971c6f9063) | `` treewide: partially apply mkTarget ``                                 |
| [`c4fa6844`](https://github.com/nix-community/stylix/commit/c4fa684471d9230f4ca4d4543f02e8ac4c5f749b) | `` stylix: add mkTarget function ``                                      |
| [`2b176d49`](https://github.com/nix-community/stylix/commit/2b176d49defb6793eb475809de10097ea6d84b41) | `` discord: use new enable option for testbed ``                         |
| [`a2236aa2`](https://github.com/nix-community/stylix/commit/a2236aa2906a5c9a1029345adb4f14e099f5972a) | `` stylix: use a cheaper module eval for the `enable` option ``          |
| [`dfcab747`](https://github.com/nix-community/stylix/commit/dfcab7476d36cd71d3cd3778ec842a625c5a1e84) | `` stylix: revert improval of how discord testbed is disabled (#1291) `` |
| [`5113479d`](https://github.com/nix-community/stylix/commit/5113479d69e6881ae142bf05084d05adddc27111) | `` stylix: improve how discord testbed is disabled (#1291) ``            |
| [`4830942f`](https://github.com/nix-community/stylix/commit/4830942fa2a475c2be5d45ca1267fa77036bf9a6) | `` treewide: remove unnecessary builtins prefix (#1322) ``               |
| [`94010d21`](https://github.com/nix-community/stylix/commit/94010d21184a13efbb8571b3c19878adc0f3f93a) | `` stylix: add testbed enable option ``                                  |
| [`f891cf74`](https://github.com/nix-community/stylix/commit/f891cf742fb262b946705c4ec9ab3b6521ea140d) | `` stylix: refactor textbed.nix autoload ``                              |
| [`1f4de333`](https://github.com/nix-community/stylix/commit/1f4de333d7b2485cdf62e9f6c7d7ef65784fb2cf) | `` stylix: use `concatMap` in testbeds.nix ``                            |
| [`10e04b24`](https://github.com/nix-community/stylix/commit/10e04b24916317e27b22259b2526d862c49bcac6) | `` stylix: use `concatMapStringSep` in testbed.nix ``                    |