### PR TITLE
chore(flake/nix-fast-build): `225e65c9` -> `14b4478b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1747737904,
-        "narHash": "sha256-lOouOgusUU3x97wClX8+WdbzpneMiRTdCqDSxGc/RlU=",
+        "lastModified": 1747946189,
+        "narHash": "sha256-FCOmNZeEH028WyC4/JHml1j07niqtacaoRtLWrZWhZc=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "225e65c9ea45cf675341fe032acea9436a5f9d22",
+        "rev": "14b4478bf841a53a8d57efa7b0cf849c91f2cddb",
         "type": "github"
       },
       "original": {
@@ -874,11 +874,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747469671,
-        "narHash": "sha256-bo1ptiFoNqm6m1B2iAhJmWCBmqveLVvxom6xKmtuzjg=",
+        "lastModified": 1747912973,
+        "narHash": "sha256-XgxghfND8TDypxsMTPU2GQdtBEsHTEc3qWE6RVEk8O0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ab0378b61b0d85e73a8ab05d5c6029b5bd58c9fb",
+        "rev": "020cb423808365fa3f10ff4cb8c0a25df35065a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`14b4478b`](https://github.com/Mic92/nix-fast-build/commit/14b4478bf841a53a8d57efa7b0cf849c91f2cddb) | `` chore(deps): update nixpkgs digest to ebcc1d6 (#171) ``     |
| [`70391676`](https://github.com/Mic92/nix-fast-build/commit/7039167675dddba74e4ebbdfd430d1b42adaeb2c) | `` chore(deps): update treefmt-nix digest to 020cb42 (#172) `` |