### PR TITLE
chore(flake/home-manager): `6c2eb1e2` -> `a8685705`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747834438,
-        "narHash": "sha256-AHJt79W8wADzur2htCx1U8FtEk4XjvrHb9/3iDfNedI=",
+        "lastModified": 1747955385,
+        "narHash": "sha256-AKoBFaEGN02tGvBlkwVIDOGXouHvrTTfOUcvBDGxkxQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6c2eb1e24cd0e76d88bdd633ef4c50d6286586e0",
+        "rev": "a868570581f0dbdef7e33c8c9bb34b735dfcbacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`a8685705`](https://github.com/nix-community/home-manager/commit/a868570581f0dbdef7e33c8c9bb34b735dfcbacf) | `` news: fix timestamp (#7109) ``                                               |
| [`f9186c64`](https://github.com/nix-community/home-manager/commit/f9186c64fcc6ee5f0114547acf9e814c806a640b) | `` Revert "fontconfig: Fix missing default fontconfig files (#7045)" (#7103) `` |
| [`a69ebd97`](https://github.com/nix-community/home-manager/commit/a69ebd97025969679de9f930958accbe39b4c705) | `` direnv: Fix `default` syntax for nushell integration (#7081) ``              |