### PR TITLE
chore(flake/stylix): `614c12c5` -> `f99fe598`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747865103,
-        "narHash": "sha256-2RLLb9x++l1KGDPo6U2E7aGWZx51eBYq4NJ9fv/kyNI=",
+        "lastModified": 1747952198,
+        "narHash": "sha256-GjxRPffuLQQx1G701fzgom+bKxCEJD9fbq44x4gl/n8=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "614c12c5db0da406fd232cb9b0e82aec304a854e",
+        "rev": "f99fe598a68831debbf096e289296c7c7178c21f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                   |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`f99fe598`](https://github.com/nix-community/stylix/commit/f99fe598a68831debbf096e289296c7c7178c21f) | `` foot: fix font size (#1360) ``                                         |
| [`3e447578`](https://github.com/nix-community/stylix/commit/3e447578effb29574adf26f74d5a9466f977c5ca) | `` doc: give consistant input version and follows instructions (#1271) `` |
| [`e16d94d8`](https://github.com/nix-community/stylix/commit/e16d94d8685f5b1025def349f3dcb06b6cf5a6d5) | `` ci: prefix labels with type (#1256) ``                                 |
| [`f9a6a599`](https://github.com/nix-community/stylix/commit/f9a6a599d7212980c97e93701e50a7002d08802f) | `` hyprland: fix hyprpaper enable condition (#1355) ``                    |
| [`c1ef1efd`](https://github.com/nix-community/stylix/commit/c1ef1efd8fe5d263f3e9ebf34b64c377f27ebe06) | `` qutebrowser: simplify dark mode setting (#1352) ``                     |
| [`6f67462b`](https://github.com/nix-community/stylix/commit/6f67462b01bb8d37749f4c0c0cb77b6799054808) | `` forge: use mkTarget ``                                                 |
| [`59c782eb`](https://github.com/nix-community/stylix/commit/59c782eb99aa14cc5f21263ffe4f4974aaee2fea) | `` console: use mkTarget ``                                               |
| [`7b2e482d`](https://github.com/nix-community/stylix/commit/7b2e482da7d32a9f092a67c8a669a4092406cc62) | `` cava: use mkTarget ``                                                  |
| [`3d5c02f8`](https://github.com/nix-community/stylix/commit/3d5c02f843384aa647c52d7532eb9ca18a2299c5) | `` bat: use mkTarget ``                                                   |
| [`f4a4b269`](https://github.com/nix-community/stylix/commit/f4a4b2690c1bd8dfab734f533df9a668f9c7f027) | `` avizo: use mkTarget ``                                                 |
| [`e0e61f8c`](https://github.com/nix-community/stylix/commit/e0e61f8c97a4b124646b596e64e6d0454f1fa771) | `` cavalier: use mkTarget ``                                              |
| [`68518231`](https://github.com/nix-community/stylix/commit/68518231f323a3a47d07a087c7a9711d2fa655d0) | `` zed: use mkTarget ``                                                   |
| [`019d9f11`](https://github.com/nix-community/stylix/commit/019d9f11b3e23b9814de65633d00763af0aea23f) | `` zellij: use mkTarget ``                                                |
| [`fea4b0ea`](https://github.com/nix-community/stylix/commit/fea4b0ea5870f3826987cdd266a61894a27cf54e) | `` xresources: use mkTarget ``                                            |
| [`33c517c8`](https://github.com/nix-community/stylix/commit/33c517c8ec646135a9b88a009b60d76582cb74d1) | `` xfce: use mkTarget ``                                                  |
| [`e31bca3e`](https://github.com/nix-community/stylix/commit/e31bca3ee1295cb7fdddef01332eeeaea1e9d6b6) | `` bspwm: use mkTarget ``                                                 |
| [`230705d5`](https://github.com/nix-community/stylix/commit/230705d5fb6c308402579b17e0261e9f15de6f46) | `` gnome: don't apply hm on darwin (#1316) ``                             |
| [`043a43a0`](https://github.com/nix-community/stylix/commit/043a43a0f97edd200e5fd8023b588812574747d1) | `` ci: used maintained conflicts action (#1348) ``                        |
| [`02f3d004`](https://github.com/nix-community/stylix/commit/02f3d00467af0f4269d6ee1c80a28cfd15757b4a) | `` foliate: use mkTarget ``                                               |
| [`18211a9f`](https://github.com/nix-community/stylix/commit/18211a9f417e7cf08dcda2f350000278ddae1794) | `` fish: use mkTarget ``                                                  |
| [`af114357`](https://github.com/nix-community/stylix/commit/af114357237b03f5c2979ac170224b3c979650f9) | `` lazygit: use mkTarget ``                                               |
| [`89edd2f3`](https://github.com/nix-community/stylix/commit/89edd2f3c0b6e921aebf3ebe02fbc73a057345f5) | `` foot: use mkTarget ``                                                  |
| [`910dc0dc`](https://github.com/nix-community/stylix/commit/910dc0dc3e9792ca9fe143fed318b59ac7857f9c) | `` btop: use mkTarget ``                                                  |
| [`81cb57a3`](https://github.com/nix-community/stylix/commit/81cb57a350da029d168535afd0342e8625ea6a2a) | `` hyprlock: use mkTraget ``                                              |
| [`26efa4fc`](https://github.com/nix-community/stylix/commit/26efa4fca0ecc163697c388b2975138e9bb01053) | `` helix: use mkTarget ``                                                 |
| [`24d1438d`](https://github.com/nix-community/stylix/commit/24d1438df48064b9c258429339cac2fbe62723c4) | `` halloy: use mkTarget ``                                                |
| [`cde06bed`](https://github.com/nix-community/stylix/commit/cde06bed949235cae1d22ac02ec2cf415c619dd1) | `` gitui: use mkTarget ``                                                 |
| [`085767cc`](https://github.com/nix-community/stylix/commit/085767cc84bea0742dd21c339f006fe7a8773266) | `` gedit: use mkTarget ``                                                 |
| [`e73f4c08`](https://github.com/nix-community/stylix/commit/e73f4c08322acf31bec1bb15d5ef3d0c13eb6be9) | `` chromium: use mkTarget ``                                              |