### PR TITLE
chore(flake/stylix): `f99fe598` -> `34b59308`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1747952198,
-        "narHash": "sha256-GjxRPffuLQQx1G701fzgom+bKxCEJD9fbq44x4gl/n8=",
+        "lastModified": 1748028561,
+        "narHash": "sha256-IgtJU6n9vR3nBUdcXrc7K9E+Y/G/4P6hFifGRr1tXMU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f99fe598a68831debbf096e289296c7c7178c21f",
+        "rev": "34b5930894d8315401d93bd8a9a6635e1cd28eff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                    |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`34b59308`](https://github.com/nix-community/stylix/commit/34b5930894d8315401d93bd8a9a6635e1cd28eff) | `` doc: recommend 25.05 as stable version (#1320) ``       |
| [`6b2bc896`](https://github.com/nix-community/stylix/commit/6b2bc89659213d90929642e4439289694309e8b6) | `` stylix: allow for overlays to access options (#1372) `` |
| [`e4fde51c`](https://github.com/nix-community/stylix/commit/e4fde51c6e56b9cd65850694c847a47f0d6c6026) | `` tofi: add missing lib module argument (#1370) ``        |
| [`7ffb31da`](https://github.com/nix-community/stylix/commit/7ffb31da698511030f17ddc94c92c59be1a30b2c) | `` treewide: use mkTarget (batch 2) (#1362) ``             |
| [`8dd18dd3`](https://github.com/nix-community/stylix/commit/8dd18dd3955548fe299d7ba337e464bc28dd1448) | `` hyprlock: fix setting background ``                     |
| [`86cfc446`](https://github.com/nix-community/stylix/commit/86cfc446a5f4352c28ae81ae71303a1746cd2d85) | `` hyprlock: add MrSom3body as maintainer ``               |