### PR TITLE
chore(flake/darwin): `33220d47` -> `e0a7c377`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748004251,
-        "narHash": "sha256-XodjkVWTth3A2JpBqGBkdLD9kkWn94rnv98l3xwKukg=",
+        "lastModified": 1748130652,
+        "narHash": "sha256-lHwMkKdqE2nUw8+DynnmZlVwd4e0tyNp0KjwfExgXz0=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "33220d4791784e4dd4739edd3f6c028020082f91",
+        "rev": "e0a7c37735338d5155d70cf46e24b4b0db42a612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                               |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------- |
| [`5374405a`](https://github.com/nix-darwin/nix-darwin/commit/5374405a015f02e866bd4a9bbc551d07d7d3a0c2) | `` config/terminfo: init module ``    |
| [`7347f725`](https://github.com/nix-darwin/nix-darwin/commit/7347f7250726dba3557ae6d367f5773a0036ed3f) | `` programs/arqbackup: init module `` |