### PR TITLE
chore(flake/tinted-schemes): `8c00a361` -> `9aa38a41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1747207144,
-        "narHash": "sha256-pHfbM7mF2mF1beycGAmA+7Jt+vmJ2reU7BvRfKURyaY=",
+        "lastModified": 1748086520,
+        "narHash": "sha256-x0FyEwweWuV2a9j+29BKrYWqxJNmyDEzsx8YMdSKTbk=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "8c00a361a99b6d356db9572240053a3f8716ea68",
+        "rev": "9aa38a41f02e46e37e60b42d0719efb8454a40b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                               |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`9aa38a41`](https://github.com/tinted-theming/schemes/commit/9aa38a41f02e46e37e60b42d0719efb8454a40b2) | `` Fix mountain base16 theme (#57) `` |