### PR TITLE
chore(flake/darwin): `e0a7c377` -> `a9939228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748130652,
-        "narHash": "sha256-lHwMkKdqE2nUw8+DynnmZlVwd4e0tyNp0KjwfExgXz0=",
+        "lastModified": 1748149228,
+        "narHash": "sha256-mmonYFesFo42UUS49Hd0bcbVJRWX/aHBCDYUkkvylf4=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "e0a7c37735338d5155d70cf46e24b4b0db42a612",
+        "rev": "a9939228f661df370c4094fe85f683e45d761dbe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                               |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`0d3dcc55`](https://github.com/nix-darwin/nix-darwin/commit/0d3dcc55f3fef8ed1eb5afd976c6cc07f35071c3) | `` ci: enable merge queue ``                          |
| [`cd6a8a79`](https://github.com/nix-darwin/nix-darwin/commit/cd6a8a796d6d6479f425b56c601b189860e664fe) | `` config/system-path: restructure to mirror NixOS `` |