### PR TITLE
chore(flake/stylix): `34b59308` -> `1fdbf01e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748028561,
-        "narHash": "sha256-IgtJU6n9vR3nBUdcXrc7K9E+Y/G/4P6hFifGRr1tXMU=",
+        "lastModified": 1748276618,
+        "narHash": "sha256-reC7nvUfJMaIYJb5pVOuTFbOfj/L9eo21drj+9EbrkE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "34b5930894d8315401d93bd8a9a6635e1cd28eff",
+        "rev": "1fdbf01ebe4b7838aa3d95334325ce8445625332",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                   |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`d66135de`](https://github.com/nix-community/stylix/commit/d66135deb39da600a4dcd7c686e9225eb531ec5a) | `` flake: add ruff formatter (#1389) ``                   |
| [`aa70426f`](https://github.com/nix-community/stylix/commit/aa70426f8f4373da2f454de3e27b565241960599) | `` console: improve color consistency (#1388) ``          |
| [`225b2ddb`](https://github.com/nix-community/stylix/commit/225b2ddbbaa4ae3c2076c1bd1616fefd35e11670) | `` doc: explain testbed options (#1383) ``                |
| [`e22f96de`](https://github.com/nix-community/stylix/commit/e22f96de3f57b1ab1a393607bc08c003925f68fc) | ``  doc: update documentation to reflect #1083 (#1329) `` |
| [`17398c4f`](https://github.com/nix-community/stylix/commit/17398c4fce431ddda8027b00634393e803576d05) | `` treewide: name default testbeds ``                     |
| [`2b7ff59d`](https://github.com/nix-community/stylix/commit/2b7ff59d813d5b243eae5981ca3a598d65c1a352) | `` stylix: reduce testbed names ``                        |