### PR TITLE
chore(flake/nix-fast-build): `5f5ff111` -> `33f16171`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1748081099,
-        "narHash": "sha256-yk2H78SmFgSSxEHzBWFtIgwZrE57wQODUMUvTou6scQ=",
+        "lastModified": 1748218016,
+        "narHash": "sha256-bLUSxxMSuuqeJDCSYplmgVuzjUkDl+ueokIlOENY49E=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "5f5ff111255393c6ff3bca40fbd627f039aa8eb8",
+        "rev": "33f161715e8a49bbae65a1a384b19b0a9fcf5317",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`33f16171`](https://github.com/Mic92/nix-fast-build/commit/33f161715e8a49bbae65a1a384b19b0a9fcf5317) | `` chore(deps): lock file maintenance (#176) `` |