### PR TITLE
chore(flake/stylix): `1fdbf01e` -> `e38a646e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748276618,
-        "narHash": "sha256-reC7nvUfJMaIYJb5pVOuTFbOfj/L9eo21drj+9EbrkE=",
+        "lastModified": 1748376235,
+        "narHash": "sha256-LIQnskjlVHTJC5dW4xoWlMCtrKeWOPW7/8HYd8IruLA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1fdbf01ebe4b7838aa3d95334325ce8445625332",
+        "rev": "e38a646e5cd3d000c8fffb14632f3bb8a45dd042",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                            |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`e38a646e`](https://github.com/nix-community/stylix/commit/e38a646e5cd3d000c8fffb14632f3bb8a45dd042) | `` bemenu: fix undefined variable error (#1390) `` |
| [`dedf5de5`](https://github.com/nix-community/stylix/commit/dedf5de5792af6c16560f9cc8864be73ae535251) | `` doc: enable `hash-files` ``                     |
| [`19e48021`](https://github.com/nix-community/stylix/commit/19e48021e36d86004e1b3b04cf9e305ab67e8017) | `` doc: add redirect for 'Standalone Nixvim' ``    |
| [`9f94e353`](https://github.com/nix-community/stylix/commit/9f94e353734a3ceb2a7573a84eb92d37c325e9e3) | `` doc: add JavaScript redirects ``                |
| [`97468930`](https://github.com/nix-community/stylix/commit/9746893051f7dbf3b51aeb955fa132b9e84ace1a) | `` flake: add 'biome' to treefmt for javascript `` |