### PR TITLE
chore(flake/home-manager): `f5b12be8` -> `02077149`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748391243,
-        "narHash": "sha256-7sCuihzsTRZemtbTXaFUoGJUfuQErhKEcL9v7HKIo1k=",
+        "lastModified": 1748455938,
+        "narHash": "sha256-mQ/iNzPra2WtDQ+x2r5IadcWNr0m3uHvLMzJkXKAG/8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f5b12be834874f7661db4ced969a621ab2d57971",
+        "rev": "02077149e2921014511dac2729ae6dadb4ec50e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`02077149`](https://github.com/nix-community/home-manager/commit/02077149e2921014511dac2729ae6dadb4ec50e2) | `` flake.lock: Update (#7148) ``                |
| [`9bf9b1ae`](https://github.com/nix-community/home-manager/commit/9bf9b1ae000a8484f718bef93a381fe7752e98b5) | `` Translate using Weblate (Persian) (#7150) `` |