### PR TITLE
chore(flake/nixpkgs): `62b852f6` -> `4faa5f53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748190013,
-        "narHash": "sha256-R5HJFflOfsP5FBtk+zE8FpL8uqE7n62jqOsADvVshhE=",
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "62b852f6c6742134ade1abdd2a21685fd617a291",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`642de212`](https://github.com/NixOS/nixpkgs/commit/642de212a6ec1d4e76f7cca957163bbeaef85e88) | `` maintainer/scripts/check-cherry-picks: fix calling from outside nixpkgs ``                 |
| [`d283c3b3`](https://github.com/NixOS/nixpkgs/commit/d283c3b36ff4ed09cc1b275b604bddc82693f075) | `` maintainer/scripts/check-cherry-picks: propagate git errors instead of passing silently `` |
| [`279f4ffc`](https://github.com/NixOS/nixpkgs/commit/279f4ffcc06ea833dcd834c8a6cf03c80746a2be) | `` projectm-sdl-cpp: 0-unstable-2025-03-17 -> 0-unstable-2025-05-20 ``                        |
| [`c839ac34`](https://github.com/NixOS/nixpkgs/commit/c839ac340b7890d9e617eeee7bd143d3d77ae0b6) | `` teams-for-linux: 2.0.13 -> 2.0.14 ``                                                       |
| [`0a397691`](https://github.com/NixOS/nixpkgs/commit/0a39769102627e8742c3e423a4e414fdb4bbea11) | `` lib.maintainers.nicoo: update GH account name ``                                           |
| [`a7485af7`](https://github.com/NixOS/nixpkgs/commit/a7485af7d504540d9c82ef3e9ac1da1c8f75280a) | `` nixos/telepathy: Remove GNOME remnants ``                                                  |
| [`cf6bb7f5`](https://github.com/NixOS/nixpkgs/commit/cf6bb7f51b70939ebc5ed26426817fa4521cca14) | `` anyrun: 0-unstable-2025-04-29 -> 0-unstable-2025-05-19 ``                                  |
| [`4fb8ed7d`](https://github.com/NixOS/nixpkgs/commit/4fb8ed7dfef13afa8efce195c5fd4460db5f8787) | `` doc/nrd: add example of multipage rendering ``                                             |
| [`fb1e54cf`](https://github.com/NixOS/nixpkgs/commit/fb1e54cf601f4c4c760950f6db517324f9a07a2b) | `` candy-icons: 0-unstable-2025-05-08 -> 0-unstable-2025-05-24 ``                             |
| [`688e14d2`](https://github.com/NixOS/nixpkgs/commit/688e14d21a38135270544bfdfcc793d25dea2802) | `` _cuda: introduce to organize CUDA package set backbone ``                                  |
| [`8fcff239`](https://github.com/NixOS/nixpkgs/commit/8fcff2390e3224e970291975cedcbd23f743c6da) | `` cudaPackages: doc fixup ``                                                                 |
| [`ead65813`](https://github.com/NixOS/nixpkgs/commit/ead65813623f92f8630811b1b3616877a727b1d9) | `` tree-wide: cudaPackages.flags updates ``                                                   |
| [`765529df`](https://github.com/NixOS/nixpkgs/commit/765529dfff5cb04cd8ebf9275c9bccc9473fcbb5) | `` cudaPackages.fixups -> pkgs.cudaFixups ``                                                  |
| [`c5dad288`](https://github.com/NixOS/nixpkgs/commit/c5dad2886a5623fc5e41054ab9ed9ff8e5f7ac91) | `` cudaPackages: switch to cudaLib ``                                                         |
| [`629ae4e4`](https://github.com/NixOS/nixpkgs/commit/629ae4e42c4764f1e56cd64746a3f19e28ff62a0) | `` cudaPackages: rewrite backendStdenv ``                                                     |
| [`0ac3a73b`](https://github.com/NixOS/nixpkgs/commit/0ac3a73b6a997ea5e05067577a17c613ecddcd7d) | `` cudaLib: init ``                                                                           |
| [`a018d736`](https://github.com/NixOS/nixpkgs/commit/a018d736978adf55e1b8f7bf79e736cd6d042573) | `` cudaPackages.driver_assistant: mark as unsupported ``                                      |
| [`646bebe3`](https://github.com/NixOS/nixpkgs/commit/646bebe3be8004e578842745136b8196f4f1fced) | `` cudaPackages: add cudaNamePrefix ``                                                        |
| [`e6936034`](https://github.com/NixOS/nixpkgs/commit/e69360347bcb06ed3946d63210269af3ffc88be3) | `` python312Packages.influxdb-client: 1.48.0 -> 1.49.0 ``                                     |
| [`9ba0040b`](https://github.com/NixOS/nixpkgs/commit/9ba0040bb5ee69c7a18293750d37775c9caf8054) | `` python312Packages.gcal-sync: 7.0.1 -> 7.1.0 ``                                             |
| [`6041b78d`](https://github.com/NixOS/nixpkgs/commit/6041b78d8b4572d184157465fe3d615f4a27cfea) | `` nixosTests.containers-imperative: Fix eval ``                                              |
| [`d09d8ce1`](https://github.com/NixOS/nixpkgs/commit/d09d8ce1954414fb11c21b82e18c1fa53f08f265) | `` nixosTests.login: Fix eval ``                                                              |
| [`c9f192da`](https://github.com/NixOS/nixpkgs/commit/c9f192da9242f66cd9314b90632682d0326afa93) | `` nixos/amdgpu: add overdrive and ppfeaturemask option (#411155) ``                          |
| [`f26bd9d6`](https://github.com/NixOS/nixpkgs/commit/f26bd9d630661a511ad75d35752db80947263ee7) | `` uutils-coreutils: Add myself as maintainer ``                                              |
| [`cae5c734`](https://github.com/NixOS/nixpkgs/commit/cae5c734ab30a439d645f21ffa1fb8c520dac88d) | `` nixpkgs-track: Add myself as maintainer ``                                                 |
| [`ca82b583`](https://github.com/NixOS/nixpkgs/commit/ca82b5839fe180898f30b9c4e5b92c1c1b38bed0) | `` snips-sh: Add myself as maintainer ``                                                      |
| [`010d46e6`](https://github.com/NixOS/nixpkgs/commit/010d46e615382388e5531ddd67220224ea6fb2f0) | `` watcher: Add myself as maintainer ``                                                       |
| [`0f506e0f`](https://github.com/NixOS/nixpkgs/commit/0f506e0fea24ff7cb7b32b12f34667e7ddfa1861) | `` python313Packages.aiolifx-themes: 0.6.10 -> 0.6.11 ``                                      |
| [`9b4ee851`](https://github.com/NixOS/nixpkgs/commit/9b4ee8516adc29c2dff478a0b223a92e8e84724f) | `` python312Packages.aiolifx: 1.1.4 -> 1.1.5 ``                                               |
| [`8ef41657`](https://github.com/NixOS/nixpkgs/commit/8ef41657bb0fcb3bfef309aca870b2568e5fbeca) | `` werf: 2.35.8 -> 2.36.3 ``                                                                  |
| [`3ade2e5c`](https://github.com/NixOS/nixpkgs/commit/3ade2e5c695a33f9e31782b0cf807227e4cbec97) | `` amp-cli: 0.0.1747886591-g90f24f -> 0.0.1748347293-g7a57b5 ``                               |
| [`6e75ca1f`](https://github.com/NixOS/nixpkgs/commit/6e75ca1faa4128a3538ca1639491dd0ce31b0567) | `` gnatprove: fix building with gcc-14.3 ``                                                   |
| [`c7f86ba1`](https://github.com/NixOS/nixpkgs/commit/c7f86ba1322f90ea747d652fac9daf0a31d7342d) | `` pgroll: 0.12.0 -> 0.13.0 ``                                                                |
| [`cce9ebb6`](https://github.com/NixOS/nixpkgs/commit/cce9ebb6e819a883d15e25dcbba25216933b1a0f) | `` glpi-agent: 1.11 -> 1.14 ``                                                                |
| [`6ce89676`](https://github.com/NixOS/nixpkgs/commit/6ce89676d08a75134af8196c12465aef811980bd) | `` trickest-cli: 2.0.2 -> 2.1.0 ``                                                            |
| [`32358e07`](https://github.com/NixOS/nixpkgs/commit/32358e07e987fddccf713402069c378cff6afc9d) | `` cargo-public-api: 0.47.0 -> 0.47.1 ``                                                      |
| [`95d28b01`](https://github.com/NixOS/nixpkgs/commit/95d28b0121533ee2f16e02b7144f61e12b769c67) | `` easytier: 2.2.4 -> 2.3.0 ``                                                                |
| [`0cf04bdc`](https://github.com/NixOS/nixpkgs/commit/0cf04bdcf56aa7ced9c678447b0c7225c19ead1d) | `` miniflux: 2.2.8 -> 2.2.9 ``                                                                |
| [`7df8c92c`](https://github.com/NixOS/nixpkgs/commit/7df8c92cbc7d5fb8310b22205203d7fbbda46e81) | `` parca-agent: 0.38.2 -> 0.39.0 ``                                                           |
| [`b937812e`](https://github.com/NixOS/nixpkgs/commit/b937812e01001dc4d458d852e23b503de28178e9) | `` parca-agent: add `nix-update-script` ``                                                    |
| [`bb3362bb`](https://github.com/NixOS/nixpkgs/commit/bb3362bb187687d0190ea50b82c02cfd499f866a) | `` python3Packages.tlds: 2025043000 -> 2025051700 ``                                          |
| [`db30a856`](https://github.com/NixOS/nixpkgs/commit/db30a8568994be3a9ba52947ede301756150281b) | `` solanum: 0-unstable-2025-05-11 -> 0-unstable-2025-05-21 ``                                 |
| [`46aea2e7`](https://github.com/NixOS/nixpkgs/commit/46aea2e76f85682940cad52fa2af06ae6f5df9cc) | `` Revert "mlt: 7.30.0 -> 7.32.0" ``                                                          |
| [`cbbe1798`](https://github.com/NixOS/nixpkgs/commit/cbbe1798f47986427ba1055e8c81f237803bb8e1) | `` vscode-extensions.betterthantomorrow.calva: 2.0.512 -> 2.0.516 ``                          |
| [`c33daf29`](https://github.com/NixOS/nixpkgs/commit/c33daf2918646310f722187afe29a41cec3a8b72) | `` justbuild: 1.5.1 -> 1.5.2 ``                                                               |
| [`59b5226d`](https://github.com/NixOS/nixpkgs/commit/59b5226dd3120d21cfb381fb53aed683035a4dbf) | `` python3Packages.primecountpy: 0.1.0 -> 0.1.1 ``                                            |
| [`adc43c75`](https://github.com/NixOS/nixpkgs/commit/adc43c75bb19be21b00b1175aaf04559fbfe12f0) | `` python3Packages.aiovodafone: 0.11.0 -> 1.0.0 ``                                            |
| [`eb8c0643`](https://github.com/NixOS/nixpkgs/commit/eb8c0643e91303bbcc799cf0578c46b713b9e1f4) | `` zoxide: Add myself as maintainer ``                                                        |
| [`397e3986`](https://github.com/NixOS/nixpkgs/commit/397e3986bfb48eb1168ff2352e72a8800da3f388) | `` msr-tools: 1.3 -> 1.3-unstable-2022-08-05 ``                                               |
| [`9fdef667`](https://github.com/NixOS/nixpkgs/commit/9fdef667f9d04bd3d82bb7593f01cc704328c92c) | `` python3Packages.preshed: 3.0.9 -> 3.0.10 ``                                                |
| [`3ee53d9e`](https://github.com/NixOS/nixpkgs/commit/3ee53d9edf2c88b7ba868baa84a31a385a166133) | `` vimPlugins.nvim-k8s-crd: init at 2025-05-26 ``                                             |
| [`a4a69667`](https://github.com/NixOS/nixpkgs/commit/a4a69667db06da9aaddbe95136cf9b4b13a76771) | `` rerun: 0.23.2 -> 0.23.3 ``                                                                 |
| [`53b62026`](https://github.com/NixOS/nixpkgs/commit/53b62026457bb90b671adbd7311aa1f87473213f) | `` gimp3: add to release-cuda ``                                                              |
| [`139df70d`](https://github.com/NixOS/nixpkgs/commit/139df70d8d052d82039ac41faa8c87a0b64ee143) | `` zoxide: 0.9.7 -> 0.9.8 ``                                                                  |
| [`be243e8c`](https://github.com/NixOS/nixpkgs/commit/be243e8cca0af54b926f83ebeea6b4fce0064b38) | `` watcher: 0.13.5 -> 0.13.6 ``                                                               |
| [`8c3d4830`](https://github.com/NixOS/nixpkgs/commit/8c3d48300dfb32be97ce161219e8a615170135ad) | `` snips-sh: 0.4.2 -> 0.5.0 ``                                                                |
| [`332e91d5`](https://github.com/NixOS/nixpkgs/commit/332e91d588a2214bd1018197f52fd00360018e87) | `` prettyping: 1.0.1 -> 1.1.0 ``                                                              |
| [`72c93a1a`](https://github.com/NixOS/nixpkgs/commit/72c93a1ab0ce962378caece59a6a7b63cbc6a00a) | `` netbird-ui: 0.44.0 -> 0.45.1 ``                                                            |
| [`06e51694`](https://github.com/NixOS/nixpkgs/commit/06e5169405846a9917c7974ce2f8fbe23144a3fa) | `` nuclei-templates: 10.2.1 -> 10.2.2 ``                                                      |
| [`71ac797e`](https://github.com/NixOS/nixpkgs/commit/71ac797e3ee471078ef609ac738dad8b83119016) | `` libretro.scummvm: 0-unstable-2025-04-05 -> 0-unstable-2025-05-23 ``                        |
| [`a2049762`](https://github.com/NixOS/nixpkgs/commit/a2049762f2c0fea4067a019178d030b3113b3d1b) | `` geany-with-vte: add note about inheriting meta ``                                          |
| [`571c5c02`](https://github.com/NixOS/nixpkgs/commit/571c5c020b721496d6a43c647578b07eb1b8d43c) | `` vscode-extensions.sonarsource.sonarlint-vscode: 4.22.0 -> 4.23.0 ``                        |
| [`8d782353`](https://github.com/NixOS/nixpkgs/commit/8d782353b0693306533d616256767354bb365351) | `` root: 6.34.08 -> 6.36.00 (#390706) ``                                                      |
| [`9aeaf31f`](https://github.com/NixOS/nixpkgs/commit/9aeaf31fce3c39059bb1115f2414fd87a225859b) | `` mitra: 4.2.1 -> 4.3.1 ``                                                                   |
| [`62b34d8a`](https://github.com/NixOS/nixpkgs/commit/62b34d8ae10963109ed1f1d3154fd71a323a2d00) | `` particle-cli: 3.35.10 -> 3.35.11 ``                                                        |
| [`406cdf59`](https://github.com/NixOS/nixpkgs/commit/406cdf59fd894754d80009cc480cfef02701f360) | `` probe-rs-tools: 0.28.0 -> 0.29.0 ``                                                        |
| [`7254412c`](https://github.com/NixOS/nixpkgs/commit/7254412c80a1dce0b074895c47ffea66da55ef13) | `` seaweedfs: 3.87 -> 3.88 ``                                                                 |
| [`3db849b8`](https://github.com/NixOS/nixpkgs/commit/3db849b8f9c56796ee9e06bdb7f8291c62d84a26) | `` stunnel: 5.74 -> 5.75 ``                                                                   |
| [`050ed018`](https://github.com/NixOS/nixpkgs/commit/050ed018742159cba6da6d7414701240917ec5ca) | `` ruqola: 2.5.0 -> 2.5.1 ``                                                                  |
| [`ff404d2d`](https://github.com/NixOS/nixpkgs/commit/ff404d2d68d41685973590919e8b65fac2693493) | `` vi-mongo: 0.1.27 -> 0.1.28 ``                                                              |
| [`b371fc9c`](https://github.com/NixOS/nixpkgs/commit/b371fc9cef3f330e015b74c944b3d81e0ff519be) | `` forecast: 0-unstable-2025-05-15 -> 0-unstable-2025-05-25 ``                                |
| [`55670934`](https://github.com/NixOS/nixpkgs/commit/556709346b108ca6f60e67141533808585694db4) | `` tgpt: 2.9.4 -> 2.10.0 ``                                                                   |
| [`406199ba`](https://github.com/NixOS/nixpkgs/commit/406199ba3e051ff74a09b920e05090abab95dbb7) | `` checkov: 3.2.432 -> 3.2.433 ``                                                             |
| [`e4244ad3`](https://github.com/NixOS/nixpkgs/commit/e4244ad358bcd57b2b14ad122dc7c28bf1eb5128) | `` checkov: 3.2.427 -> 3.2.432 ``                                                             |
| [`9eb380a4`](https://github.com/NixOS/nixpkgs/commit/9eb380a4cc4793f7481574c1f756e236856c1d49) | `` circt: 1.118.0 -> 1.119.0 ``                                                               |
| [`cc31b635`](https://github.com/NixOS/nixpkgs/commit/cc31b635a99fed0baf717b4e32a58c019af9ec71) | `` firefox-bin-unwrapped: 138.0.4 -> 139.0 ``                                                 |
| [`a91995a5`](https://github.com/NixOS/nixpkgs/commit/a91995a5a1f3da13d638a2a3454a6c79f90b5a14) | `` firefox-esr-128-unwrapped: 128.10.1esr -> 128.11.0esr ``                                   |
| [`83d02af8`](https://github.com/NixOS/nixpkgs/commit/83d02af8b35fd69b8bc795a6aea942b1c8ce7015) | `` firefox-unwrapped: 138.0.4 -> 139.0 ``                                                     |
| [`3587619b`](https://github.com/NixOS/nixpkgs/commit/3587619b1a188ba20cb94a71b27b2f9776c44128) | `` nix-eval-jobs: 2.28.1 -> 2.29.0 ``                                                         |
| [`9f8d45af`](https://github.com/NixOS/nixpkgs/commit/9f8d45af8c33a23e33c04772afaf0d23bb39fe96) | `` perses: init at 0.51.0-rc.0 ``                                                             |
| [`e98656cb`](https://github.com/NixOS/nixpkgs/commit/e98656cb48de4ce1adf4b58c0dda963765faea62) | `` ty: 0.0.1-alpha.6 -> 0.0.1-alpha.7 ``                                                      |
| [`1f3007ca`](https://github.com/NixOS/nixpkgs/commit/1f3007cac9d760abe706b268d9809ff4ce345d27) | `` supabase-cli: 2.23.1 -> 2.23.7 ``                                                          |
| [`68357544`](https://github.com/NixOS/nixpkgs/commit/68357544ec7f310dbfaa8bb822013bf980d95011) | `` python313Packages.dissect-volume: 3.13 -> 3.15 ``                                          |
| [`04024abd`](https://github.com/NixOS/nixpkgs/commit/04024abdda114d6c731b3eea245ef1f0c018dd4a) | `` python313Packages.dissect-jffs: 1.4 -> 1.5 ``                                              |
| [`8dbb549c`](https://github.com/NixOS/nixpkgs/commit/8dbb549c8b915534f25b74df5ce77390a70e06b9) | `` python313Packages.dissect-ole: 3.10 -> 3.11 ``                                             |
| [`a2541230`](https://github.com/NixOS/nixpkgs/commit/a25412306539e7ecefeb0dc81ca9c6e07b87636a) | `` flutter: optimize evaluation of appBuildDeps ``                                            |
| [`94817274`](https://github.com/NixOS/nixpkgs/commit/94817274d2208ef5356b2dc450c22fdf195f8501) | `` lib.fileset.difference: fix type docs ``                                                   |
| [`e2833ace`](https://github.com/NixOS/nixpkgs/commit/e2833acefc33729fa390610ed75dc0e9a85995c6) | `` Revert "stalwart-mail: use system jemalloc" (#411201) ``                                   |
| [`3afc9d7b`](https://github.com/NixOS/nixpkgs/commit/3afc9d7bb2c78472c90b87ac9964335de3f64c5f) | `` python313Packages.dissect-esedb: 3.15 -> 3.16 ``                                           |
| [`63a699bb`](https://github.com/NixOS/nixpkgs/commit/63a699bb88aaadd2da6b49e61ddd4cd34b8d2e6f) | `` python313Packages.dissect-volume: 3.13 -> 3.15 ``                                          |
| [`e7020c95`](https://github.com/NixOS/nixpkgs/commit/e7020c956f46eadd6c81225709ece83110df62e9) | `` python313Packages.dissect-sql: 3.10 -> 3.11 ``                                             |
| [`3470ccf9`](https://github.com/NixOS/nixpkgs/commit/3470ccf95969aa8762f75ea60c05d283d09689a2) | `` hawkeye: 6.0.3 -> 6.0.4 ``                                                                 |
| [`58d2510e`](https://github.com/NixOS/nixpkgs/commit/58d2510e00f1eeda5107ffede1e5699ee7569b39) | `` python313Packages.dissect-esedb: 3.15 -> 3.16 ``                                           |
| [`c3c28da4`](https://github.com/NixOS/nixpkgs/commit/c3c28da4cea4dac1a1d138ffc494f26da82d5e0f) | `` python313Packages.dissect-etl: disable failing tests ``                                    |
| [`1a08674e`](https://github.com/NixOS/nixpkgs/commit/1a08674e838d36c2ab1826c17e378ad7cbce3b97) | `` python313Packages.dissect-util: 3.19 -> 3.21 ``                                            |
| [`ff8c965f`](https://github.com/NixOS/nixpkgs/commit/ff8c965f83280d6b08c6788a351ad6491c3d7db2) | `` mani: 0.30.1 -> 0.31.0 ``                                                                  |
| [`b134f314`](https://github.com/NixOS/nixpkgs/commit/b134f3148fb2b457f547842f173e34767d4d969f) | `` nixos/postgrest: fix typo in name of configuration options (#411197) ``                    |