### PR TITLE
chore(flake/home-manager): `02077149` -> `8a4b3826`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748455938,
-        "narHash": "sha256-mQ/iNzPra2WtDQ+x2r5IadcWNr0m3uHvLMzJkXKAG/8=",
+        "lastModified": 1748563990,
+        "narHash": "sha256-q3Hz7g7TncnU2A01GxFFWPCrVWscrHr5cBIJw6BYmgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "02077149e2921014511dac2729ae6dadb4ec50e2",
+        "rev": "8a4b38262755fce39551e1182af1621a06ddde35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                               |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`8a4b3826`](https://github.com/nix-community/home-manager/commit/8a4b38262755fce39551e1182af1621a06ddde35) | `` kodi: make type for settings less restrictive (#5277) ``                           |
| [`2f4db1cd`](https://github.com/nix-community/home-manager/commit/2f4db1cd5be0afaa0a2ec8fa5da6460f0ebdbc11) | `` yambar: add systemd service (#5469) ``                                             |
| [`da282034`](https://github.com/nix-community/home-manager/commit/da282034f4d30e787b8a10722431e8b650a907ef) | `` darwinScrublist: update (#7157) ``                                                 |
| [`95c988cf`](https://github.com/nix-community/home-manager/commit/95c988cf08e9a5a8fe7cc275d5e3f24e9e87bd51) | `` xsession: add xdg-desktop-autostart to requires of hm-graphical-session (#7108) `` |
| [`85a27991`](https://github.com/nix-community/home-manager/commit/85a27991d5d9c980e33179b2fc7f0eb4f7262db0) | `` fish: add binds option (#7121) ``                                                  |
| [`13ed57aa`](https://github.com/nix-community/home-manager/commit/13ed57aaa679253d7989db21f4581ae85b2167fa) | `` meli: adding the meli email client (#7111) ``                                      |
| [`7d2fcc86`](https://github.com/nix-community/home-manager/commit/7d2fcc864eb10139258a020611b67111df54a604) | `` pywal: make kitty config appear at start to not override user vals ``              |
| [`ad88262f`](https://github.com/nix-community/home-manager/commit/ad88262f06e903e6643e760dfeaee01d492c4662) | `` kitty: make extraConfig obey mkOrder ``                                            |
| [`115344f3`](https://github.com/nix-community/home-manager/commit/115344f32b56ae9581386bf0ab9e3df7adc92a82) | `` chromium: allow nullable package (#7149) ``                                        |