### PR TITLE
chore(flake/stylix): `838df8b8` -> `b69e9b76`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748563993,
-        "narHash": "sha256-BX7xKAzDh2d6Rn1SwYnhJwpMdyGNVehrBjIQ9lymySE=",
+        "lastModified": 1748621009,
+        "narHash": "sha256-X7SqoEEHVsR01GwL9WBs3tuSXdit7YdeBdIHrl+MlZQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "838df8b8ad7d993d4de4af144f57bca0d5d1329a",
+        "rev": "b69e9b761ee682b722e2c9ce46637e767b50f6dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b69e9b76`](https://github.com/nix-community/stylix/commit/b69e9b761ee682b722e2c9ce46637e767b50f6dc) | `` yazi: Change deprecated "manager" to new name "mgr" (#1424) `` |
| [`0512b0f6`](https://github.com/nix-community/stylix/commit/0512b0f685ab2ac0586c897460c247f49670460b) | `` ci: fix backport conditions (#1420) ``                         |