### PR TITLE
chore(flake/stylix): `b69e9b76` -> `64b9f2c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748621009,
-        "narHash": "sha256-X7SqoEEHVsR01GwL9WBs3tuSXdit7YdeBdIHrl+MlZQ=",
+        "lastModified": 1748717073,
+        "narHash": "sha256-Yxo8A7BgNpRXTrB359LyfQ0NjJuiaLIS6sTTUCulEX0=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "b69e9b761ee682b722e2c9ce46637e767b50f6dc",
+        "rev": "64b9f2c2df31bb87bdd2360a2feb58c817b4d16c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                      |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`64b9f2c2`](https://github.com/nix-community/stylix/commit/64b9f2c2df31bb87bdd2360a2feb58c817b4d16c) | `` stylix: yamlint ignore truthy for workflows (#1116) ``    |
| [`093087e9`](https://github.com/nix-community/stylix/commit/093087e969e2ecfe1175dbf3cbc5c8624fde1c1e) | `` stylix: add imports to mkTarget (#1363) ``                |
| [`99130f41`](https://github.com/nix-community/stylix/commit/99130f414dc51bb8fd3980efc9005ca6596e123b) | `` stylix: minor meta.nix cleanup ``                         |
| [`03748a36`](https://github.com/nix-community/stylix/commit/03748a36d5926bfd4bc084e8ba579d7a9c91922b) | `` stylix: drop unnecessary use of `self` in meta.nix ``     |
| [`23e3013b`](https://github.com/nix-community/stylix/commit/23e3013b6257c8fc9556f5e3a25047f30bcd8fdc) | `` stylix: drop unnecessary use of `self` in droid ``        |
| [`9cb8a57e`](https://github.com/nix-community/stylix/commit/9cb8a57eac918273319d771981874bf5a025fb7f) | `` stylix: drop unnecessary use of `self` in darwin ``       |
| [`5fa31498`](https://github.com/nix-community/stylix/commit/5fa31498d281f6863d4a316fba3db3d1b847f77a) | `` stylix: drop unnecessary use of `self` in home-manager `` |
| [`950483a5`](https://github.com/nix-community/stylix/commit/950483a5d09d5ae9bbb8ff38942471b1f1535cfd) | `` stylix: drop unnecessary use of `self` in nixos ``        |
| [`9fb268f3`](https://github.com/nix-community/stylix/commit/9fb268f3a601d1799fa6a41d04964dacab16ce6f) | `` stylix: drop unnecessary use of `self` in autoload.nix `` |
| [`91755e0f`](https://github.com/nix-community/stylix/commit/91755e0f1c9bdc52b338b1db64d0814294371c0d) | `` stylix: drop unnecessary use of `self` in testbed ``      |
| [`eaa38e05`](https://github.com/nix-community/stylix/commit/eaa38e0591497565b097f740512bd7bbe00280e7) | `` doc: drop unnecessary use of `self` ``                    |
| [`b1a152c6`](https://github.com/nix-community/stylix/commit/b1a152c6390f3ba27670e7d1dd92d9a9b4654364) | `` flake: drop unnecessary use of `self` ``                  |