### PR TITLE
chore(flake/home-manager): `b65126fa` -> `5675a968`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748651212,
-        "narHash": "sha256-blV7kzaDgqRoynZ8qtao/fkWkGZ15YM7i3d1qeopiqc=",
+        "lastModified": 1748737919,
+        "narHash": "sha256-5kvBbLYdp+n7Ftanjcs6Nv+UO6sBhelp6MIGJ9nWmjQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b65126fa71e744c53fbae44d90139d3069711ac4",
+        "rev": "5675a9686851d9626560052a032c4e14e533c1fa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`5675a968`](https://github.com/nix-community/home-manager/commit/5675a9686851d9626560052a032c4e14e533c1fa) | `` home-cursor: sway depend on cfg.size instead of gtk.cursorTheme.size (#7176) `` |
| [`60e46243`](https://github.com/nix-community/home-manager/commit/60e4624302d956fe94d3f7d96a560d14d70591b9) | `` news: re-add dropped news entries (#7173) ``                                    |
| [`6587238e`](https://github.com/nix-community/home-manager/commit/6587238e406dcb64cd74a7f17b9d3e2461908519) | `` lib: remove 22.11 deprecations ``                                               |
| [`cc8896c3`](https://github.com/nix-community/home-manager/commit/cc8896c32130182c9d6633fd4dea16b096073f1f) | `` ci: remove literalExpression step ``                                            |
| [`765ceb93`](https://github.com/nix-community/home-manager/commit/765ceb93d1b75401b9b85da00a36c58864a3fb27) | `` lib: remove literalExpression and literalDocBook logic ``                       |
| [`7ccda857`](https://github.com/nix-community/home-manager/commit/7ccda8574fc76a3e1361ae482a301a1d883a90f3) | `` ci: labels dedupe and reorganize ``                                             |
| [`5118087a`](https://github.com/nix-community/home-manager/commit/5118087a159f448e2a569f03282eac7ceeb75793) | `` ci: sort label categories ``                                                    |
| [`b6bd7c62`](https://github.com/nix-community/home-manager/commit/b6bd7c629fcb34aec25781478fa7a228f59ebbfd) | `` ci: add more modules to labeler ``                                              |
| [`6d09fd37`](https://github.com/nix-community/home-manager/commit/6d09fd37a7d4110251c1c03cb09fbf6321fbe10d) | `` ci: alternative fix for backport if condition (#7169) ``                        |