### PR TITLE
chore(flake/home-manager): `5675a968` -> `6abf2794`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748737919,
-        "narHash": "sha256-5kvBbLYdp+n7Ftanjcs6Nv+UO6sBhelp6MIGJ9nWmjQ=",
+        "lastModified": 1748811839,
+        "narHash": "sha256-MDl6vpEK18ZfPHfoeOa9dGRdwVWNfmCCGazt72nHw+U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5675a9686851d9626560052a032c4e14e533c1fa",
+        "rev": "6abf27943bbb09a0f9d443df45ec70b07a6cbe20",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`6abf2794`](https://github.com/nix-community/home-manager/commit/6abf27943bbb09a0f9d443df45ec70b07a6cbe20) | `` ci: set a more useful update PR body `` |
| [`9882f43f`](https://github.com/nix-community/home-manager/commit/9882f43f9b870367105b9e4954e1f09c014e5c4d) | `` ci: switch to a GitHub App ``           |