### PR TITLE
chore(flake/home-manager): `6abf2794` -> `c7fdb7e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748811839,
-        "narHash": "sha256-MDl6vpEK18ZfPHfoeOa9dGRdwVWNfmCCGazt72nHw+U=",
+        "lastModified": 1748830238,
+        "narHash": "sha256-EB+LzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R+6wMKU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6abf27943bbb09a0f9d443df45ec70b07a6cbe20",
+        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`c7fdb7e9`](https://github.com/nix-community/home-manager/commit/c7fdb7e90bff1a51b79c1eed458fb39e6649a82a) | `` tests/mako: test extraConfig `` |
| [`6861cfa1`](https://github.com/nix-community/home-manager/commit/6861cfa165b7fbc6f5a0305cae7c5b3985de6886) | `` mako: remove criteria ``        |
| [`654b6865`](https://github.com/nix-community/home-manager/commit/654b686536e5405504299a93c6a330169c23372a) | `` mako: add extraConfig back ``   |