### PR TITLE
chore(flake/stylix): `3ca2c447` -> `82d9424f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1748887638,
-        "narHash": "sha256-AExfT8rMb6Ya37Gm3dimm+e4eeLGzya55JS6VWb3nfQ=",
+        "lastModified": 1748970111,
+        "narHash": "sha256-PmdrezN87CNzqTPnlC+YpLS7bZ0naeaD5d2eBFivXdY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "3ca2c4478a1e984d2007c57467c6986bcdcb2629",
+        "rev": "82d9424fffa709e162364c1397f816d232e6e1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                           |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`82d9424f`](https://github.com/nix-community/stylix/commit/82d9424fffa709e162364c1397f816d232e6e1d1) | `` doc: init server; `nix run .#docs` (#1328) ``                  |
| [`8d829119`](https://github.com/nix-community/stylix/commit/8d829119c5df4ad8064554547f198ea0630905b2) | `` wayprompt: drop '-hex' suffix on single color value (#1449) `` |
| [`d28012b0`](https://github.com/nix-community/stylix/commit/d28012b098421e741b7489493d8d5371d5911a7a) | `` wayfire: capitalize humanName value (#1451) ``                 |
| [`aa5e3c03`](https://github.com/nix-community/stylix/commit/aa5e3c03330b8daec5c249d5d58ee970a1afed86) | `` treewide: use mkTarget (batch 3) (#1371) ``                    |
| [`ced2af06`](https://github.com/nix-community/stylix/commit/ced2af06228bdc3de98a68cc7baec4ca0dc6f0ed) | `` ci: use ubuntu-24.04 for update-flake (#1444) ``               |