### PR TITLE
chore(flake/home-manager): `c7fdb7e9` -> `34a13086`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748830238,
-        "narHash": "sha256-EB+LzYHK0D5aqxZiYoPeoZoOzSAs8eqBDxm3R+6wMKU=",
+        "lastModified": 1748979197,
+        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c7fdb7e90bff1a51b79c1eed458fb39e6649a82a",
+        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                          |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
| [`34a13086`](https://github.com/nix-community/home-manager/commit/34a13086148cbb3ae65a79f753eb451ce5cac3d3) | `` doc: add a missing subcommand (#7199) ``                      |
| [`bb846c03`](https://github.com/nix-community/home-manager/commit/bb846c031be68a96466b683be32704ef6e07b159) | `` dwm-status: run with --quiet (#7144) ``                       |
| [`593b0c66`](https://github.com/nix-community/home-manager/commit/593b0c667d93404972ad8459ffdfc4f5af465d53) | `` doc: fix instructions for enabling flakes in NixOS (#7189) `` |
| [`cb809ec1`](https://github.com/nix-community/home-manager/commit/cb809ec1ff15cf3237c6592af9bbc7e4d983e98c) | `` fzf: prefer `source` for Zsh integration (#7191) ``           |
| [`5adc1a51`](https://github.com/nix-community/home-manager/commit/5adc1a51a2fa8efec9d4eaa4f7df97908cded00d) | `` ci: use flake lock for tests ``                               |
| [`c3297d77`](https://github.com/nix-community/home-manager/commit/c3297d772174eaffe5601822010c18e2f127e2eb) | `` tests: create `no-big` and `ifd` test outputs. ``             |
| [`2ef52bca`](https://github.com/nix-community/home-manager/commit/2ef52bcab55dfbf4b7c2b23add43f549c9351bb7) | `` tests: pass enableLegacyIfd arg ``                            |