### PR TITLE
chore(flake/tinted-schemes): `868192c3` -> `ce495e39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1748893361,
-        "narHash": "sha256-qoGSoKZcRnzj/zRzeVKRp56PFFiGd3KEpq9yoJPmtu4=",
+        "lastModified": 1748962240,
+        "narHash": "sha256-Uc1lVoiKPCe5ldUnhjMsgyqZVx6V33sJ5LsnIEDPQSg=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "868192c34b56634130bef42020c5d2e5e6e3f39c",
+        "rev": "ce495e390337be0526678f820e0ca411daab957e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                           |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ce495e39`](https://github.com/tinted-theming/schemes/commit/ce495e390337be0526678f820e0ca411daab957e) | `` Fix various typos and name mismatches (#60) `` |