### PR TITLE
chore(flake/nixvim-flake): `7b94f41e` -> `6db5271b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1748564405,
-        "narHash": "sha256-uCmQLJmdg0gKWBs+vhNmS9RIPJW8/ddo6TvQ/a4gupc=",
+        "lastModified": 1748884506,
+        "narHash": "sha256-P/ldKE0SCGKH6pEVJoW2MJJo2dZCZe10d/h1ree66c0=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8b3a69cfea5ba2fa008c6c57ab79c99c513a349b",
+        "rev": "d063d0dd5e0b82d8be4dd4bc00b887ac1f92e4b2",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1748883373,
-        "narHash": "sha256-39Xiv/y6aVVohsttLpXCaA/NQQf7IhAxYlKN7RU2qb0=",
+        "lastModified": 1748915634,
+        "narHash": "sha256-0XW5BuYxt+ngrdgxT/BmQmf5XD0p1FIko97sP+dXgxM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "7b94f41e64515cad0c209d7d5ea485cbd8caaaef",
+        "rev": "6db5271b4664be9590e4de4504c7dc014d361d19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`6db5271b`](https://github.com/alesauce/nixvim-flake/commit/6db5271b4664be9590e4de4504c7dc014d361d19) | `` chore(flake/nixvim): 8b3a69cf -> d063d0dd `` |