### PR TITLE
chore(flake/darwin): `44a7d0e6` -> `fa6120c3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748352827,
-        "narHash": "sha256-sNUUP6qxGkK9hXgJ+p362dtWLgnIWwOCmiq72LAWtYo=",
+        "lastModified": 1749012745,
+        "narHash": "sha256-Cax/k9ZRPKqTz18vZtmqGR45pHRXM+sDvEVd4V/3NrU=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "44a7d0e687a87b73facfe94fba78d323a6686a90",
+        "rev": "fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                    |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`f6b29e4a`](https://github.com/nix-darwin/nix-darwin/commit/f6b29e4af88c74b2f19101a5693ea3f2983e326b) | `` defaults: support `AppleKeyboardUIMode = 2` for newer macOS versions `` |
| [`b07a4c8b`](https://github.com/nix-darwin/nix-darwin/commit/b07a4c8be5aea8db66d4ee1754766d8b9c0aa06c) | `` Fix ShellCheck issue in `nixPath` check ``                              |