### PR TITLE
chore(flake/home-manager): `34a13086` -> `86b95fc1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748979197,
-        "narHash": "sha256-mKYwYcO9RmA2AcAFIXGDBOw5iv/fbjw6adWvMbnfIuk=",
+        "lastModified": 1749062139,
+        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "34a13086148cbb3ae65a79f753eb451ce5cac3d3",
+        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`86b95fc1`](https://github.com/nix-community/home-manager/commit/86b95fc1ed2b9b04a451a08ccf13d78fb421859c) | `` aichat: init (#7207) ``                                      |
| [`ffab96a8`](https://github.com/nix-community/home-manager/commit/ffab96a8b4a523c4b5e2645ee09e95a75cbdbfab) | `` qutebrowser: null package support (#7203) ``                 |
| [`3830a21a`](https://github.com/nix-community/home-manager/commit/3830a21aa2313239b582e4e4ac97f0b25243cb7a) | `` xdg.desktopEntries: Update outdated links in docs (#7201) `` |