### PR TITLE
chore(flake/stylix): `a057acc1` -> `8456dfa7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749053445,
-        "narHash": "sha256-tf4MNRwJ5ikyg4+UfGuC1+GwMBQYh4dK4sdow1MEGVk=",
+        "lastModified": 1749165619,
+        "narHash": "sha256-E1KgTswgmzBGv+8WijQRghlyIP6k+LPzj9j8bq9BlLU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a057acc112856352e77d42ac4685134b2213a810",
+        "rev": "8456dfa7f60e6b4499b0498fc88e9b8b57d4d7d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`8456dfa7`](https://github.com/nix-community/stylix/commit/8456dfa7f60e6b4499b0498fc88e9b8b57d4d7d7) | `` ci: don't check repository_owner (#1436) ``           |
| [`937a154d`](https://github.com/nix-community/stylix/commit/937a154dc30ebcf6d2b74fe74c930dd892a127d9) | `` blender: move README into meta description (#1460) `` |