### PR TITLE
chore(flake/home-manager): `86b95fc1` -> `68cc9eeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749062139,
-        "narHash": "sha256-gGGLujmeWU+ZjFzfMvFMI0hp9xONsSbm88187wJr82Q=",
+        "lastModified": 1749160002,
+        "narHash": "sha256-IM3xKjsKxhu7Y1WdgTltrLKiOJS8nW7D4SUDEMNr7CI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86b95fc1ed2b9b04a451a08ccf13d78fb421859c",
+        "rev": "68cc9eeb3875ae9682c04629f20738e1e79d72aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`68cc9eeb`](https://github.com/nix-community/home-manager/commit/68cc9eeb3875ae9682c04629f20738e1e79d72aa) | `` jellyfin-mpv-shim: merge settings with existing config file ``   |
| [`7707ebb0`](https://github.com/nix-community/home-manager/commit/7707ebb05c6a021e730fdefdb41c2b7e8133251d) | `` jellyfin-mpv-shim: make sure the config file is read properly `` |
| [`09b0a4b0`](https://github.com/nix-community/home-manager/commit/09b0a4b0da86c12a57976028bbda3897137c9528) | `` dconf: revert: dconf: Provide dconf (#7215) ``                   |
| [`13a45ede`](https://github.com/nix-community/home-manager/commit/13a45ede6c17b5e923dfc18a40a3f646436f4809) | `` aichat: fix config example (#7212) ``                            |