### PR TITLE
chore(flake/home-manager): `68cc9eeb` -> `2d7d65f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749160002,
-        "narHash": "sha256-IM3xKjsKxhu7Y1WdgTltrLKiOJS8nW7D4SUDEMNr7CI=",
+        "lastModified": 1749243446,
+        "narHash": "sha256-P1gumhZN5N9q+39ndePHYrtwOwY1cGx+VoXGl+vTm7A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "68cc9eeb3875ae9682c04629f20738e1e79d72aa",
+        "rev": "2d7d65f65b61fdfce23278e59ca266ddd0ef0a36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`2d7d65f6`](https://github.com/nix-community/home-manager/commit/2d7d65f65b61fdfce23278e59ca266ddd0ef0a36) | `` fish: fix the binds.*.erase option (#7186) ``                               |
| [`1d595a5b`](https://github.com/nix-community/home-manager/commit/1d595a5b64fb887dd67dd98866af30b1a37b0f7a) | `` zed-editor: allow for nullable package (#7220) ``                           |
| [`96482a53`](https://github.com/nix-community/home-manager/commit/96482a538e6103579d254b139759d0536177370b) | `` keychain: warn about deprecated options (#7196) ``                          |
| [`c18a7679`](https://github.com/nix-community/home-manager/commit/c18a767948ebe573502b564f88fadec448009b88) | `` zed-editor: userKeymaps default to empty array (#7222) ``                   |
| [`812b43b4`](https://github.com/nix-community/home-manager/commit/812b43b45d4807e072b261cd00f35c911c3cbef0) | `` tests/thefuck: explicit stubbing ``                                         |
| [`b2483b45`](https://github.com/nix-community/home-manager/commit/b2483b45e6ac37ec81192e9ab979ac3b669ae8e9) | `` flake.lock: Update ``                                                       |
| [`76e9c6e1`](https://github.com/nix-community/home-manager/commit/76e9c6e14aabba36368bc1c0680c80f018451e43) | `` lib/default.nix: remove inefficient second copy (#7221) ``                  |
| [`91287a0e`](https://github.com/nix-community/home-manager/commit/91287a0e9d42570754487b7e38c6697e15a9aab2) | `` nixgl: remove alias (#7218) ``                                              |
| [`355c7d09`](https://github.com/nix-community/home-manager/commit/355c7d09ede3335b6642cf1736de3df0d4fdd136) | `` chawan: fix example for settings (#7210) ``                                 |
| [`bbb31d83`](https://github.com/nix-community/home-manager/commit/bbb31d835230720c7a5bc085412776c61dabc7bc) | `` ludusavi: fix import (#7205) ``                                             |
| [`0ee810c8`](https://github.com/nix-community/home-manager/commit/0ee810c839ee73b2d3973f5683f9a3bf8d430e8a) | `` zed-editor: respect user interactivity with settings and keymaps (#6993) `` |
| [`de8463dd`](https://github.com/nix-community/home-manager/commit/de8463dd3ef259502b937fac37fadd6adc252bfe) | `` zsh: add plugins.*.completions paths to fpath (#7197) ``                    |