### PR TITLE
chore(flake/darwin): `fa6120c3` -> `19346808`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749012745,
-        "narHash": "sha256-Cax/k9ZRPKqTz18vZtmqGR45pHRXM+sDvEVd4V/3NrU=",
+        "lastModified": 1749194393,
+        "narHash": "sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "fa6120c32f10bd2aac9e8c9a6e71528a9d9d823b",
+        "rev": "19346808c445f23b08652971be198b9df6c33edc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                   |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`daf8e228`](https://github.com/nix-darwin/nix-darwin/commit/daf8e22831c197ee52db43aac266d5a8c3d20e38) | `` programs/direnv: add finalPackage readonly option ``   |
| [`fb27326b`](https://github.com/nix-darwin/nix-darwin/commit/fb27326bbcc9ee5cce20f6ea85662a8e855d2278) | `` programs/direnv: fix silent option ``                  |
| [`0e83fc6e`](https://github.com/nix-darwin/nix-darwin/commit/0e83fc6e76e08931f8f87881c0f0ffd0809aa155) | `` feat: add option programs.zsh.enableAutosuggestions `` |