### PR TITLE
chore(flake/nix-fast-build): `dcf6612b` -> `b1dae483`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -459,11 +459,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1749197268,
-        "narHash": "sha256-5EeSsqvXR9FBXl6OITDq+JCdpPuNYXdT/0xCV7dLi9w=",
+        "lastModified": 1749427739,
+        "narHash": "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "dcf6612bf5d7e804453a567a99a5a8c7b71abe70",
+        "rev": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`b1dae483`](https://github.com/Mic92/nix-fast-build/commit/b1dae483ab7d4139a6297e02b6de9e5d30e43d48) | `` chore(deps): lock file maintenance (#184) ``                |
| [`eb8c7bc1`](https://github.com/Mic92/nix-fast-build/commit/eb8c7bc1619c4e6b232173893e95cb5957e43e85) | `` chore(deps): update flake-parts digest to 9305fe4 (#183) `` |