### PR TITLE
chore(flake/stylix): `29d00619` -> `5869510e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749236315,
-        "narHash": "sha256-Ndtdvwz8D4WOYHl5mj9d5F5iC8WPH6uPNF7RcU3QzmE=",
+        "lastModified": 1749398498,
+        "narHash": "sha256-Usx6sGnT/D8ZnWiZg+J1OY3dp4ZssMQiN1XeXcsL/cs=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "29d006198ee05143cca8b4b89f37025823da1bcc",
+        "rev": "5869510e48e64d916dc6905dc664a02b0f85f1bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                               |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`5869510e`](https://github.com/nix-community/stylix/commit/5869510e48e64d916dc6905dc664a02b0f85f1bd) | `` i3status-rust: apply background opacity (#1450) `` |
| [`b3e8f15f`](https://github.com/nix-community/stylix/commit/b3e8f15fe3b361f753a5f85587fd731d076ce821) | `` blender: prevent IFD (#1467) ``                    |