### PR TITLE
chore(flake/nix-index-database): `2860bee6` -> `40a6e15e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748751003,
-        "narHash": "sha256-i4GZdKAK97S0ZMU3w4fqgEJr0cVywzqjugt2qZPrScs=",
+        "lastModified": 1749355504,
+        "narHash": "sha256-L17CdJMD+/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "2860bee699248d828c2ed9097a1cd82c2f991b43",
+        "rev": "40a6e15e44b11fbf8f2b1df9d64dbfc117625e94",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`40a6e15e`](https://github.com/nix-community/nix-index-database/commit/40a6e15e44b11fbf8f2b1df9d64dbfc117625e94) | `` update generated.nix to release 2025-06-08-034427 `` |
| [`b5ce0fe6`](https://github.com/nix-community/nix-index-database/commit/b5ce0fe6af9af80e622974a8003ea275d5348522) | `` flake.lock: Update ``                                |