### PR TITLE
chore(flake/home-manager): `2835e8ba` -> `1df816c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749400020,
-        "narHash": "sha256-0nTmHO8AYgRYk5v6zw5oZ3x9nh+feb+Isn7WNe318M0=",
+        "lastModified": 1749499854,
+        "narHash": "sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2835e8ba0ad99ba86d4a5e497a962ec9fa35e48f",
+        "rev": "1df816c407d3a5090c8496c9b00170af7891f021",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                         |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`1df816c4`](https://github.com/nix-community/home-manager/commit/1df816c407d3a5090c8496c9b00170af7891f021) | `` fix: ensure newline after vim.cmd[[source...]] in neovim init.lua (#7219) `` |
| [`74d196c9`](https://github.com/nix-community/home-manager/commit/74d196c9943a67908d1883f61154e594d03863e5) | `` papis: allow libraries to not to be defined (#7204) ``                       |
| [`35e1f5a7`](https://github.com/nix-community/home-manager/commit/35e1f5a7c29f2b05e8f53177f6b5c71108c5f4c3) | `` mc: add midnight commander module (#7225) ``                                 |
| [`eee14095`](https://github.com/nix-community/home-manager/commit/eee140958aa1171183fad3dc8dc3f0cda6af6460) | `` home-manager: fix integration tests ``                                       |