### PR TITLE
chore(flake/home-manager): `1df816c4` -> `427c9604`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749499854,
-        "narHash": "sha256-V1BgwiX8NjbRreU6LC2EzmuqFSQAHhoSeNlYJyZ40NE=",
+        "lastModified": 1749526396,
+        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1df816c407d3a5090c8496c9b00170af7891f021",
+        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`427c9604`](https://github.com/nix-community/home-manager/commit/427c96044f11a5da50faf6adaf38c9fa47e6d044) | `` codex: init ``                                     |
| [`7e3d76e7`](https://github.com/nix-community/home-manager/commit/7e3d76e7f71c05d4c2190d94ae1c438f60f1136e) | `` maintainers: add delafthi ``                       |
| [`e9763eb1`](https://github.com/nix-community/home-manager/commit/e9763eb195c1e3d508892993cf112bd75d6fd712) | `` niriswitcher: add module (#7246) ``                |
| [`f26c378c`](https://github.com/nix-community/home-manager/commit/f26c378c3d0f9958d41b350f6dd12e2bd8f9602a) | `` Translations update from Hosted Weblate (#7244) `` |