### PR TITLE
chore(flake/nixvim-flake): `6ce01dac` -> `3e7cfc85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -485,11 +485,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749197268,
-        "narHash": "sha256-5EeSsqvXR9FBXl6OITDq+JCdpPuNYXdT/0xCV7dLi9w=",
+        "lastModified": 1749427739,
+        "narHash": "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "dcf6612bf5d7e804453a567a99a5a8c7b71abe70",
+        "rev": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1749556391,
-        "narHash": "sha256-eYb/3sTUnc5BdUECM1RaO2WYUIDRMx9Y6L2FOiH2nRY=",
+        "lastModified": 1749606848,
+        "narHash": "sha256-QpTjPIa3TNnxZ+jzricJMDJQaqYZtiozaAX9lVAO2WA=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "6ce01dac79401cd4c2447f65b8551827f3c36c22",
+        "rev": "3e7cfc85b0f5754f8e7932fc349d77600f7a14d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`3e7cfc85`](https://github.com/alesauce/nixvim-flake/commit/3e7cfc85b0f5754f8e7932fc349d77600f7a14d2) | `` chore(flake/nix-fast-build): dcf6612b -> b1dae483 `` |