### PR TITLE
chore(flake/home-manager): `427c9604` -> `faeab325`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749526396,
-        "narHash": "sha256-UL9F76abAk87llXOrcQRjhd5OaOclUd6MIltsqcUZmo=",
+        "lastModified": 1749657191,
+        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "427c96044f11a5da50faf6adaf38c9fa47e6d044",
+        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`faeab325`](https://github.com/nix-community/home-manager/commit/faeab32528a9360e9577ff4082de2d35c6bbe1ce) | `` ci: fix bars labeler (#7253) ``            |
| [`02040b77`](https://github.com/nix-community/home-manager/commit/02040b7777f65342b96c7f826a5c6aef95585057) | `` flake.lock: Update (#7251) ``              |
| [`450f06ec`](https://github.com/nix-community/home-manager/commit/450f06ec3cd0d86f67db58a7245db8848773e895) | `` meli: support include statement (#7248) `` |