### PR TITLE
chore(flake/darwin): `19346808` -> `72c88d59`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194393,
-        "narHash": "sha256-vt6hM9DNywnXXuW1qPDLzECmbDcmxhh58wpb0EEQjAo=",
+        "lastModified": 1749739639,
+        "narHash": "sha256-oubMGIrW/vBdX+xw47LEcxrqYqZUdLYPE8xrLDKoBE8=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "19346808c445f23b08652971be198b9df6c33edc",
+        "rev": "72c88d5928196159e3a0d03e67b25d8044546ca6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                               |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`63c31af3`](https://github.com/nix-darwin/nix-darwin/commit/63c31af37a79bd2847243e679fa5bff2537bffcd) | `` etc: add known hashes for zprofile and zshrc in macOS 26 beta 1 `` |
| [`7c284a65`](https://github.com/nix-darwin/nix-darwin/commit/7c284a650484c90cf928779d77d9faa3f173522e) | `` Avoid confusing users with future deprecations ``                  |