### PR TITLE
chore(flake/stylix): `e7fa0e5c` -> `34393859`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749670558,
-        "narHash": "sha256-luB+SFNy+etZK3PVznJSLps1DPYsGya6o/67Emcrtb0=",
+        "lastModified": 1749767991,
+        "narHash": "sha256-tgKABKKmQMEU6Mlsi5fJ37AgWCQVnf8bQUd2Pv9x/sk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "e7fa0e5cc2336b6b25310d5e49c149f14fdbc1bb",
+        "rev": "343938594e57483635d6fb34d90c227e8dd46072",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`34393859`](https://github.com/nix-community/stylix/commit/343938594e57483635d6fb34d90c227e8dd46072) | `` doc: remove redundant documentation dummy values (#1318) ``                  |
| [`9724654e`](https://github.com/nix-community/stylix/commit/9724654e8d8ac2e48205efa33497ec1bc9540e62) | `` yazi: update tabs theming style (#1480) ``                                   |
| [`58b1de7e`](https://github.com/nix-community/stylix/commit/58b1de7ebf6e133f12bac249901fe701ad17f3f1) | `` stylix: refactor `base16Scheme` and `lib.stylix.colors` assertion (#1446) `` |
| [`75411fe2`](https://github.com/nix-community/stylix/commit/75411fe2b90f67bfb4a2ad9cc3b1379758b64dbb) | `` swaylock: use mkTarget (#1481) ``                                            |
| [`dcf0f177`](https://github.com/nix-community/stylix/commit/dcf0f17712d0b07648b24f79b26b8728e2af25c2) | `` vscode: use mkTarget (#1477) ``                                              |
| [`5b74d930`](https://github.com/nix-community/stylix/commit/5b74d930209bdafc186695a7c22da251f05ab790) | `` k9s: apply upstream breaking changes (#1382) ``                              |
| [`1a471ee9`](https://github.com/nix-community/stylix/commit/1a471ee95e1c7a69f15ce75b5f6b1fe9ede9a778) | `` neovim: combine Neovim, Neovide, NixVim, nvf, and Vim (#1377) ``             |
| [`e9eb2308`](https://github.com/nix-community/stylix/commit/e9eb2308ff5b2cec8ff608edf707fef9c5f8909b) | `` i3bar-river: init (#1415) ``                                                 |
| [`744385ee`](https://github.com/nix-community/stylix/commit/744385eedf233d53c0701e3845c826b70016a8b7) | `` mkTarget: allow _${arg} ``                                                   |
| [`5d1ed786`](https://github.com/nix-community/stylix/commit/5d1ed786ff997aafd9021f8de5cef4b21d9e408c) | `` deadnix: ignore bindings starting with _ ``                                  |