### PR TITLE
chore(flake/home-manager): `faeab325` -> `79dfd9aa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749657191,
-        "narHash": "sha256-QLilaHuhGxiwhgceDWESj9gFcKIdEp7+9lRqNGpN8S4=",
+        "lastModified": 1749821119,
+        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "faeab32528a9360e9577ff4082de2d35c6bbe1ce",
+        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`79dfd9aa`](https://github.com/nix-community/home-manager/commit/79dfd9aa295e53773aad45480b44c131da29f35b) | `` meli: move freeformat settings to example (#7259) ``                             |
| [`f1113939`](https://github.com/nix-community/home-manager/commit/f1113939873a62f185c18a51f4e45ae66686822b) | `` ashell: minor description improvements ``                                        |
| [`18f3a0d2`](https://github.com/nix-community/home-manager/commit/18f3a0d21c3739a242aafa17c04c5238bbab5a41) | `` opensnitch-ui: add package option (#7260) ``                                     |
| [`0215073a`](https://github.com/nix-community/home-manager/commit/0215073a704e9b8992d8e59761344d83d8c72e8b) | `` ashell: add module ``                                                            |
| [`dd12be86`](https://github.com/nix-community/home-manager/commit/dd12be8603041a26f56f8d0cc9199c6e88a7fb14) | `` maintainers: add justdeeevin ``                                                  |
| [`09859234`](https://github.com/nix-community/home-manager/commit/09859234f8a8fee31a1e2293f101504324578199) | `` zed-editor: don't add activation scripts if there is nothing to merge (#7254) `` |
| [`5ab15331`](https://github.com/nix-community/home-manager/commit/5ab15331c213350b2c6611454b5f7abb660568af) | `` targets/darwin: fix ShowDate default description (#7256) ``                      |