### PR TITLE
chore(flake/home-manager): `79dfd9aa` -> `c5f34515`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749821119,
-        "narHash": "sha256-X3WAS322EsebI4ohJcXhKpiyG1v+7wE4VOiXy1pxM/c=",
+        "lastModified": 1749944797,
+        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "79dfd9aa295e53773aad45480b44c131da29f35b",
+        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                              |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c5f34515`](https://github.com/nix-community/home-manager/commit/c5f345153397f62170c18ded1ae1f0875201d49a) | `` atuin: fix docs url (#7252) ``    |
| [`8fabeb9c`](https://github.com/nix-community/home-manager/commit/8fabeb9c142a303e02270c3a3a0d8e00af9d0dfe) | `` fix meli eval warning  (#7267) `` |