### PR TITLE
chore(flake/nixpkgs): `3e3afe51` -> `ee930f97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1749794982,
+        "narHash": "sha256-Kh9K4taXbVuaLC0IL+9HcfvxsSUx8dPB5s5weJcc9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "ee930f9755f58096ac6e8ca94a1887e0534e2d81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
| [`a1ec5c89`](https://github.com/NixOS/nixpkgs/commit/a1ec5c891cde1e9803f5532429afc247755e7981) | `` stopmotion: 0.8.7 -> 0.9.0 ``                                                                                   |
| [`cf85edf6`](https://github.com/NixOS/nixpkgs/commit/cf85edf636a0bb764c2774d162e7941ef6720506) | `` dprint-plugins.dprint-plugin-typescript: 0.95.5 -> 0.95.7 ``                                                    |
| [`5fa650c8`](https://github.com/NixOS/nixpkgs/commit/5fa650c8014849d67c1f7eccb3c50f24b253d329) | `` alist: mark as insecure ``                                                                                      |
| [`18cd9132`](https://github.com/NixOS/nixpkgs/commit/18cd9132b09da3fc7c508a1663a5671a53088fa2) | `` nixosTests.sway: skip nagbar test on aarch64-linux for now ``                                                   |
| [`ecc4bf8a`](https://github.com/NixOS/nixpkgs/commit/ecc4bf8acb597ba2aa61d5e68d6bbb8989131095) | `` xnconvert: init at 1.105.0 ``                                                                                   |
| [`32dd5359`](https://github.com/NixOS/nixpkgs/commit/32dd53594cbfefa1b2ec6aa1124461d8568eab74) | `` maintainers: add aldenparker ``                                                                                 |
| [`3eead8e7`](https://github.com/NixOS/nixpkgs/commit/3eead8e782add3f11e9469ac370cd96b904c5dbb) | `` python3Packages.mechanize: add patch for python 3.13 ``                                                         |
| [`faf06d7a`](https://github.com/NixOS/nixpkgs/commit/faf06d7ae4c5656b20adbb373b83109239b4ce0d) | `` komikku: 1.77.0 -> 1.79.1 ``                                                                                    |
| [`31c4ef4d`](https://github.com/NixOS/nixpkgs/commit/31c4ef4d034b41942145105b8ad3bdf06629db80) | `` python3Packages.pytouchline-extended: 0.4.5 -> 0.4.6 ``                                                         |
| [`dba1c836`](https://github.com/NixOS/nixpkgs/commit/dba1c836ad45a1c5cb5a19c2b688bc7af5c5a7d9) | `` phel: 0.17.0 -> 0.18.0 ``                                                                                       |
| [`8e20e430`](https://github.com/NixOS/nixpkgs/commit/8e20e430ec5ec73197f89eb3b96e190d2b523ad8) | `` python3Packages.mdutils: 1.6.0 -> 1.7.0 ``                                                                      |
| [`a17ccfb3`](https://github.com/NixOS/nixpkgs/commit/a17ccfb33a66489ad1ce3267592968cbe8afee12) | `` python3Packages.pyopencl: 2025.2.2 -> 2025.2.3 ``                                                               |
| [`832623d7`](https://github.com/NixOS/nixpkgs/commit/832623d70aa69532eddbf206e091e6b75a4cdf5d) | `` mcuboot-imgtool: 2.1.0 -> 2.2.0 ``                                                                              |
| [`6c8044e2`](https://github.com/NixOS/nixpkgs/commit/6c8044e2551da463696df034520050e7bd1a56f1) | `` python3Packages.islpy: 2025.2.2 -> 2025.2.3 ``                                                                  |
| [`07128f77`](https://github.com/NixOS/nixpkgs/commit/07128f7700040bd2e2573f816da0306d870a584e) | `` nsis: pass version to scons ``                                                                                  |
| [`23d58e6f`](https://github.com/NixOS/nixpkgs/commit/23d58e6f4fd5f4d87c914869936e2b958d513c29) | `` xbursttools: drop ``                                                                                            |
| [`1a5cd33d`](https://github.com/NixOS/nixpkgs/commit/1a5cd33d1639d3122bdf17f4e42dce933d60fe36) | `` github-mcp-server: 0.4.0 -> 0.5.0 ``                                                                            |
| [`73e72ea6`](https://github.com/NixOS/nixpkgs/commit/73e72ea6c3ed55f3d12cdff57093eeb68c5a18e5) | `` rescrobbled: 0.7.2 -> 0.8.0 ``                                                                                  |
| [`799dcdfb`](https://github.com/NixOS/nixpkgs/commit/799dcdfb3ef047d034b4af49d85046b2d75f2c76) | `` redpanda-client: 25.1.3 -> 25.1.5 ``                                                                            |
| [`420f7652`](https://github.com/NixOS/nixpkgs/commit/420f7652c00a730baa8562ecadd7bc1663a17596) | `` liblognorm: Refactor package definitions ``                                                                     |
| [`ab22ffac`](https://github.com/NixOS/nixpkgs/commit/ab22ffacbd93e90f1674c3eb043588f6fa516c72) | `` scaleway-cli: 2.39.0 -> 2.40.0 ``                                                                               |
| [`473b3728`](https://github.com/NixOS/nixpkgs/commit/473b3728846bb34727bbc73cefd192e2f21ce470) | `` wdt: 1.27.1612021-unstable-2024-12-06 -> 1.27.1612021-unstable-2025-06-05 ``                                    |
| [`4935f5f0`](https://github.com/NixOS/nixpkgs/commit/4935f5f09bfecfc9d8fab1aeb1a2a9b2ca9487ed) | `` nixos-rebuild-ng: silence reexec messages ``                                                                    |
| [`b63e89de`](https://github.com/NixOS/nixpkgs/commit/b63e89de4fb7fda9a45bc624d31e964dd4923df5) | `` xdg-ninja: 0.2.0.2-unstable-2025-03-09 -> 0.2.0.2-unstable-2025-06-07 ``                                        |
| [`13b78b02`](https://github.com/NixOS/nixpkgs/commit/13b78b02c3ff8c2642fee3b75dba8721b02ddf10) | `` home-assistant-custom-components.tuya_local: 2025.4.0 -> 2025.6.0 ``                                            |
| [`ceaeb4a2`](https://github.com/NixOS/nixpkgs/commit/ceaeb4a25cafc5e4ecd5055f68da3bb564b777b9) | `` python3Packages.tinytuya: 1.16.1 -> 1.17.1 ``                                                                   |
| [`b2ea6fa0`](https://github.com/NixOS/nixpkgs/commit/b2ea6fa066c62e37e20f2afc1905fc0447883ee2) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.4 -> 4.5.5 ``                                 |
| [`f9cc4d00`](https://github.com/NixOS/nixpkgs/commit/f9cc4d00c6dc740ea9471bfd2fa8f890a9e45e07) | `` home-assistant-custom-components.volvo_cars: 1.5.3 -> 1.5.4 ``                                                  |
| [`8d201601`](https://github.com/NixOS/nixpkgs/commit/8d20160183655330c5cf1a9d4354b404e0c0c195) | `` home-assistant-custom-components.versatile_thermostat: 7.3.1 -> 7.3.2 ``                                        |
| [`de301e57`](https://github.com/NixOS/nixpkgs/commit/de301e574445f1c37d42ee045cf6e56030ad45a1) | `` home-assistant-custom-components.sun2: 3.3.5 -> 3.4.0b0 ``                                                      |
| [`5786f76d`](https://github.com/NixOS/nixpkgs/commit/5786f76d7aa7965d2f173f202eb58d5424238529) | `` home-assistant-custom-components.solax_modbus: 2025.04.4 -> 2025.06.1 ``                                        |
| [`fae47311`](https://github.com/NixOS/nixpkgs/commit/fae473110339cbc94e597025ee48a6533a75be3e) | `` home-assistant-custom-components.midea_ac_lan: 0.6.7 -> 0.6.8 ``                                                |
| [`2d479eba`](https://github.com/NixOS/nixpkgs/commit/2d479eba456781215a3877bc1419ac6a5f347db3) | `` home-assistant-custom-components.samsungtv-smart: 0.13.5 -> 0.13.6 ``                                           |
| [`10939d74`](https://github.com/NixOS/nixpkgs/commit/10939d74ff926f311ee29079726fb907e17bc56b) | `` python3Packages.midea-local: 6.2.0 -> 6.3.0 ``                                                                  |
| [`ad185729`](https://github.com/NixOS/nixpkgs/commit/ad18572929db3f7db791a5ea4a088175ff23d22d) | `` home-assistant-custom-components.oref_alert: 2.21.1 -> 2.22.1 ``                                                |
| [`17c7ae90`](https://github.com/NixOS/nixpkgs/commit/17c7ae9020facf6811e49b3798175524af26dcb8) | `` home-assistant-custom-components.emporia_vue: 0.10.2-pre -> 0.11.1 ``                                           |
| [`ba758a91`](https://github.com/NixOS/nixpkgs/commit/ba758a9143745663085ed8e7409c1b60091b83d4) | `` home-assistant-custom-components.daikin_onecta: 4.2.6 -> 4.2.8 ``                                               |
| [`ec0c4ee2`](https://github.com/NixOS/nixpkgs/commit/ec0c4ee24c2ae0855e731242d6ac8542599f0ae3) | `` home-assistant-custom-components.alarmo: 1.10.8 -> 1.10.9 ``                                                    |
| [`3051f1b3`](https://github.com/NixOS/nixpkgs/commit/3051f1b3adcdc4a56489bd31d504a0d0ade80499) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.246 -> 0.13.251 ``                       |
| [`b288524c`](https://github.com/NixOS/nixpkgs/commit/b288524c024bbf51e9b11ae948162b5e267002e8) | `` python313Packages.homeassistant-stubs: 2025.5.3 -> 2025.6.0 ``                                                  |
| [`b0e0211c`](https://github.com/NixOS/nixpkgs/commit/b0e0211c614b6f09115361181e56bc394063817e) | `` home-assistant-custom-components.frigate: disable more tests ``                                                 |
| [`36b76b41`](https://github.com/NixOS/nixpkgs/commit/36b76b41414c391e78b63cd3f07377984cd437d7) | `` ci/nixpkgs-vet.sh: fix passing arguments ``                                                                     |
| [`249109c6`](https://github.com/NixOS/nixpkgs/commit/249109c6fc83cf45dae06d9c5429218dd5d0ce44) | `` jx: 3.11.81 -> 3.11.97 ``                                                                                       |
| [`e3ed3553`](https://github.com/NixOS/nixpkgs/commit/e3ed3553ec023d4b09dd4efdbe37b48412c11aba) | `` libretro.flycast: 0-unstable-2025-06-01 -> 0-unstable-2025-06-06 ``                                             |
| [`d74a6d72`](https://github.com/NixOS/nixpkgs/commit/d74a6d724692ea817e6161e4cae871bf23b7aec2) | `` zashboard: 1.93.0 -> 1.94.0 ``                                                                                  |
| [`5f9c974e`](https://github.com/NixOS/nixpkgs/commit/5f9c974e5bd00b443c71da01069f4f9723d7b1f0) | `` python313Packages.python-openstackclient: ignore tests which failed because of the openstacksdk 4.6.0 update `` |
| [`81acf558`](https://github.com/NixOS/nixpkgs/commit/81acf55879bc811516a4e79434e5a206f33feea3) | `` python3Packages.llm-gemini: 0.21 -> 0.22 ``                                                                     |
| [`b81760fd`](https://github.com/NixOS/nixpkgs/commit/b81760fd04781d0dff2c47ec76290b24dabcddd3) | `` blackfire: 2.28.24 -> 2.28.26 ``                                                                                |
| [`6a3064bb`](https://github.com/NixOS/nixpkgs/commit/6a3064bb518c0bf8d8581d216ebb60cb1f7dc2ed) | `` sillytavern: init at 1.13.0 ``                                                                                  |
| [`d50e8abe`](https://github.com/NixOS/nixpkgs/commit/d50e8abe7eac8bcb0e8c0bc5177906c77d845424) | `` nixos/zrepl: Improve tests (#416118) ``                                                                         |
| [`599ee121`](https://github.com/NixOS/nixpkgs/commit/599ee1216210b91f1bfb4c180375b12ef02d2725) | `` linkerd_edge: 25.5.4 -> 25.6.1 ``                                                                               |
| [`ee0d8172`](https://github.com/NixOS/nixpkgs/commit/ee0d81725c74319a84266a24d7b1d0bd2925418a) | `` microsoft-edge: add maintainer bricklou ``                                                                      |
| [`6fc56469`](https://github.com/NixOS/nixpkgs/commit/6fc564691d6d43729b9e67b45bb4d88b47a01b7c) | `` maintainers: add bricklou ``                                                                                    |
| [`aeac5ac6`](https://github.com/NixOS/nixpkgs/commit/aeac5ac60cfbc842689ad9ab8b70ec89889a0666) | `` maintainers: update c4thebomb -> c4patino and add gpg key ``                                                    |
| [`82e60e51`](https://github.com/NixOS/nixpkgs/commit/82e60e51ddf69c3b126dfa929ee8e4ef6f70e23a) | `` xcpc: 20070122 -> 0.52.1 ``                                                                                     |
| [`096771ab`](https://github.com/NixOS/nixpkgs/commit/096771ab625f4c31f43ae88fae180e7bbff314c4) | `` brave: `--replace` -> `--replace-fail` ``                                                                       |
| [`36fd2b5d`](https://github.com/NixOS/nixpkgs/commit/36fd2b5d8a28661bd9ca4fffebf7ef1ef718af67) | `` brave: fix paths in secondary .desktop file ``                                                                  |
| [`23aaa2a7`](https://github.com/NixOS/nixpkgs/commit/23aaa2a7dc761f0041d6bbbc837175e3f751ac79) | `` uwsm: 0.21.6 -> 0.21.8 ``                                                                                       |
| [`6fa85aa6`](https://github.com/NixOS/nixpkgs/commit/6fa85aa6836994f0ac3e0be4690f43ddea33115d) | `` Revert "linux-builder: remove DNS hack for libslirp" ``                                                         |
| [`8e086587`](https://github.com/NixOS/nixpkgs/commit/8e086587b900d592c3425c67975f3f5ab612ccc1) | `` librewolf-unwrapped: 139.0.1-1 -> 139.0.4-1 ``                                                                  |
| [`62200186`](https://github.com/NixOS/nixpkgs/commit/622001860a98363d5fc59e5ad15c8aba291691c7) | `` ethercat: 1.6.4 -> 1.6.5 ``                                                                                     |
| [`b628f70b`](https://github.com/NixOS/nixpkgs/commit/b628f70bd797fb93438c04411fa82a13d13248d9) | `` gokapi: 2.0.0 -> 2.0.1 ``                                                                                       |
| [`a015ccdf`](https://github.com/NixOS/nixpkgs/commit/a015ccdfde0bac07cd7111393ea567e1ab607eb5) | `` meerk40t: 0.9.7030 -> 0.9.7051 (#416168) ``                                                                     |
| [`858d781d`](https://github.com/NixOS/nixpkgs/commit/858d781d0c34709a7ab53ccc70dd519ad873baa6) | `` python3Packages.pyezviz: remove ``                                                                              |
| [`350a4564`](https://github.com/NixOS/nixpkgs/commit/350a45641bf4f76e23fe8ccfc2294bc8533e34bb) | `` home-assistant: 2025.5.3 -> 2025.6.0 ``                                                                         |
| [`f213053b`](https://github.com/NixOS/nixpkgs/commit/f213053b9f69740629c95e13fa6df3fc7c44d3e2) | `` home-assistant.intents: 2025.5.7 -> 2025.6.10 ``                                                                |
| [`12fc99d5`](https://github.com/NixOS/nixpkgs/commit/12fc99d5a8bc22822a7b6b667a5f6141c6c1d53d) | `` python3Packages.wsdot: init at 0.0.1 ``                                                                         |
| [`22baf4d2`](https://github.com/NixOS/nixpkgs/commit/22baf4d2c5e01a870b84a30ae6c4c7def699fb1c) | `` python3Packages.pysmarlaapi: init at 0.8.2 ``                                                                   |
| [`3a80aea1`](https://github.com/NixOS/nixpkgs/commit/3a80aea1328b74b9b053b6c172a047999eee343e) | `` python3Packages.pysignalr: init at 1.3.0 ``                                                                     |
| [`6f197b1a`](https://github.com/NixOS/nixpkgs/commit/6f197b1a79c5f21ffe2baa32e7ecaf09a853a256) | `` python3Packages.zha: 0.0.57 -> 0.0.59 ``                                                                        |
| [`e3e88df2`](https://github.com/NixOS/nixpkgs/commit/e3e88df2c5ef33889c9709020dd064f547cc8a1c) | `` python3Packages.zigpy-deconz: 0.24.2 -> 0.25.0 ``                                                               |
| [`05922686`](https://github.com/NixOS/nixpkgs/commit/05922686bddeece08296bd36847dd11e7c816948) | `` python3Packages.zha-quirks: 0.0.137 -> 0.0.138 ``                                                               |
| [`77a05a09`](https://github.com/NixOS/nixpkgs/commit/77a05a091d75e1cdd988376ecae6070a14b41ddd) | `` python3Packages.zigpy: 0.79.0 -> 0.80.1 ``                                                                      |
| [`0b2a0583`](https://github.com/NixOS/nixpkgs/commit/0b2a05836c9b117cf5bab35002be2b3f6b9c0f3f) | `` python3Packages.uiprotect: 7.6.0 -> 7.11.0 (#410623) ``                                                         |
| [`8758318e`](https://github.com/NixOS/nixpkgs/commit/8758318e00fec40518571f4dfda7eb3cd86c0a3d) | `` python3Packages.teslemetry-stream: 0.7.7 -> 0.7.9 ``                                                            |
| [`052cf61c`](https://github.com/NixOS/nixpkgs/commit/052cf61cc5ab996e215ff09986b150f01aaabcd7) | `` python3Packages.switchbot-api: 2.3.1 -> 2.4.0 ``                                                                |
| [`c9972bf3`](https://github.com/NixOS/nixpkgs/commit/c9972bf34edc846e720e02031046fbf9c395357f) | `` python313Packages.python-tado: 0.18.14 -> 0.18.15 ``                                                            |
| [`2c9af3b9`](https://github.com/NixOS/nixpkgs/commit/2c9af3b93605c140bd6389a8be430eed796ee0e7) | `` python313Packages.python-linkplay: 0.2.10 -> 0.2.11 ``                                                          |
| [`734814e4`](https://github.com/NixOS/nixpkgs/commit/734814e4c6f665b1e22dbdf61e26fa248d759cb1) | `` python313Packages.pysmartthings: 3.2.3 -> 3.2.4 ``                                                              |
| [`6c389678`](https://github.com/NixOS/nixpkgs/commit/6c389678c575446b1a7db22258e99807c5408d9e) | `` python313Packages.pyswitchbot: 0.62.2 -> 0.65.0 (#410297) ``                                                    |
| [`7a34be6a`](https://github.com/NixOS/nixpkgs/commit/7a34be6aa43d2b62075dbfdb9d7a36e9ddc86235) | `` python313Packages.pymiele: 0.4.3 -> 0.5.2 ``                                                                    |
| [`892445e7`](https://github.com/NixOS/nixpkgs/commit/892445e7a7e24120626590039851a535fc0245d3) | `` python3Packages.pydrawise: 2025.3.0 -> 2025.6.0 ``                                                              |
| [`96f47f33`](https://github.com/NixOS/nixpkgs/commit/96f47f3309f0c3db9e00729bd2242fbbd6dfcf3c) | `` python313Packages.pypck: 0.8.5 -> 0.8.6 (#401804) ``                                                            |
| [`38c6500e`](https://github.com/NixOS/nixpkgs/commit/38c6500e13bf9aeb5afe43d1edeb6b01b156ec35) | `` python313Packages.pyatmo: 9.0.0 -> 9.2.1 (#408883) ``                                                           |
| [`5eed43d9`](https://github.com/NixOS/nixpkgs/commit/5eed43d9a265fa9c9acbbc3f7839159983580c91) | `` python3Packages.py-synologydsm-api: 2.7.2 -> 2.7.3 ``                                                           |
| [`2d3a349b`](https://github.com/NixOS/nixpkgs/commit/2d3a349b7a4480afbb05f4ea5f1ccfd58a859799) | `` python3Packages.mcstatus: 11.1.1 -> 12.0.1 (#406269) ``                                                         |
| [`fb43cbdb`](https://github.com/NixOS/nixpkgs/commit/fb43cbdb6db3e0dd5363b804a8c42dba57dcc30a) | `` python3Packages.lektricowifi: 0.0.43 -> 0.1 ``                                                                  |
| [`385226f5`](https://github.com/NixOS/nixpkgs/commit/385226f56e44b02e5ffe7f8190f1db2cad704599) | `` python3Packages.homematicip: 2.0.1.1 -> 2.0.4 (#407427) ``                                                      |
| [`bfb5f44c`](https://github.com/NixOS/nixpkgs/commit/bfb5f44c305b648940032b4e867ee6304f9c9383) | `` python3Packages.hdate: 1.1.0 -> 1.1.1 ``                                                                        |
| [`3897d295`](https://github.com/NixOS/nixpkgs/commit/3897d295efb3bd8dd99774bb4ecfd1f58311fb89) | `` python313Packages.hass-nabucasa: 0.96.0 -> 0.101.0 ``                                                           |
| [`5ac88b83`](https://github.com/NixOS/nixpkgs/commit/5ac88b837ae3b6b4a86468f766f4727c94c12b06) | `` python3Packages.go2rtc-client: 0.1.2 -> 0.2.1 ``                                                                |
| [`93644436`](https://github.com/NixOS/nixpkgs/commit/936444360e9cc6e7f384a4114ee27fd998bc1e46) | `` python313Packages.habluetooth: 3.48.2 -> 3.49.0 (#413814) ``                                                    |
| [`e9c46581`](https://github.com/NixOS/nixpkgs/commit/e9c4658106693d3ced6fc53d70fe78513f83cfbb) | `` python3Packages.habiticalib: 0.3.7 -> 0.4.0 (#409714) ``                                                        |
| [`2e3768e4`](https://github.com/NixOS/nixpkgs/commit/2e3768e4e8011ede5f0195032297eb5d70b358ea) | `` python3Packages.env-canada: 0.10.2 -> 0.11.2 ``                                                                 |
| [`f1e80d2c`](https://github.com/NixOS/nixpkgs/commit/f1e80d2c8d225d12fd4c0921c5ad36b57cf5dd88) | `` python313Packages.deebot-client: 13.2.1 -> 13.3.0 ``                                                            |
| [`19246681`](https://github.com/NixOS/nixpkgs/commit/192466811d809c0f86c745d610e7ca7ad45378cb) | `` python3Packages.bluetooth-auto-recovery: 1.5.1 -> 1.5.2 ``                                                      |
| [`5f55217f`](https://github.com/NixOS/nixpkgs/commit/5f55217f34c3c5be0958b6fb130785fbfb2ab4ec) | `` python3Packages.apsystems-ez1: 2.6.0 -> 2.7.0 ``                                                                |
| [`3dbb8838`](https://github.com/NixOS/nixpkgs/commit/3dbb883877f4c83f622bbd6a1f5e9d727f2bdae7) | `` python312Packages.datapoint: 0.9.9 -> 0.12.1 ``                                                                 |
| [`f6b34528`](https://github.com/NixOS/nixpkgs/commit/f6b34528ac2c933aee1a61bfa14e69c458bbb1e8) | `` python3Packages.aioesphomeapi: 30.2.0 -> 32.2.1 (#405130) ``                                                    |
| [`1ae214f8`](https://github.com/NixOS/nixpkgs/commit/1ae214f8b09003652df63f2a0431e0e77d67a90a) | `` check-meta: fix 'hasNoMaintainers' ``                                                                           |
| [`959cf4ce`](https://github.com/NixOS/nixpkgs/commit/959cf4ce561c1c742ffd47595fbbad93fcede1f7) | `` streamripper: fix build ``                                                                                      |
| [`25145eec`](https://github.com/NixOS/nixpkgs/commit/25145eecee2536c26adf5efc98f91b7c104fe05c) | `` python3Packages.craft-store: 3.2.1 -> 3.2.2 ``                                                                  |
| [`95b70cce`](https://github.com/NixOS/nixpkgs/commit/95b70cce0b78d52ddf697523930f74a6c1c63834) | `` drone-cli: 1.8.0 -> 1.9.0 ``                                                                                    |
| [`8c443ed0`](https://github.com/NixOS/nixpkgs/commit/8c443ed0ed1324062078621a6d2995b01c0d8eb2) | `` stalwart-mail: 0.12.2 -> 0.12.4 ``                                                                              |
| [`c88e955e`](https://github.com/NixOS/nixpkgs/commit/c88e955e02353faf082aae2d7b235e93aabe9836) | `` fan2go: 0.9.0 -> 0.10.0 ``                                                                                      |
| [`320a9cbe`](https://github.com/NixOS/nixpkgs/commit/320a9cbeb3912cbedf775132274ba7cd731b347d) | `` go-licence-detector: 0.7.0 -> 0.8.0 ``                                                                          |
| [`3018ad22`](https://github.com/NixOS/nixpkgs/commit/3018ad225428ad20d98584114443ea1853a02ddf) | `` helmfile: 1.1.1 -> 1.1.2 ``                                                                                     |
| [`ba8c1145`](https://github.com/NixOS/nixpkgs/commit/ba8c11452c49cc36255e06273432bc8cb2e75065) | `` vengi-tools: 0.0.37 -> 0.0.38 ``                                                                                |