### PR TITLE
chore(flake/nixvim-flake): `2f847e89` -> `a64c168d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -581,11 +581,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1749761870,
-        "narHash": "sha256-y+rCuxTylur4k2MbL8cJwOR3pHIamCxp8xG9Vuhwvgw=",
+        "lastModified": 1749924512,
+        "narHash": "sha256-IYv0yEFh86c+UnkcjrUAV0UeIE+9vMEeXDIF+YRlooc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "18d838e88945b554d059db5f1fff1daed4b7bf8f",
+        "rev": "e114d442b14f3a299307ca9b0f0eab20e821f419",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1749865841,
-        "narHash": "sha256-DfLv4VF01jP556TRhGF3GoCmFIyKyg3BaOA8oWJSgcs=",
+        "lastModified": 1749952986,
+        "narHash": "sha256-rq2fBD51xx4OY7QurQ6CFkRzUu6Cp5Lwjd1rxE9gxI8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "2f847e89d04d01285e9974e5e6a3ed5ea5a0f3fe",
+        "rev": "a64c168d0d17b09d50b6c55c68d702811cdf7307",
         "type": "github"
       },
       "original": {
@@ -658,11 +658,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749531675,
-        "narHash": "sha256-UB8Mc88rW9frjpJ1Fj2ro7f07Gg8dX3uVXvMXnFR4CE=",
+        "lastModified": 1749730855,
+        "narHash": "sha256-L3x2nSlFkXkM6tQPLJP3oCBMIsRifhIDPMQQdHO5xWo=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "4029d450d0266909ee52775849b7da54e79b328e",
+        "rev": "8dfe5879dd009ff4742b668d9c699bc4b9761742",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`a64c168d`](https://github.com/alesauce/nixvim-flake/commit/a64c168d0d17b09d50b6c55c68d702811cdf7307) | `` chore(flake/nixvim): 18d838e8 -> e114d442 `` |