### PR TITLE
chore(flake/nix-index-database): `40a6e15e` -> `424a4005`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749355504,
-        "narHash": "sha256-L17CdJMD+/FCBOHjREQLXbe2VUnc3rjffenBbu2Kwpc=",
+        "lastModified": 1749960154,
+        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "40a6e15e44b11fbf8f2b1df9d64dbfc117625e94",
+        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`424a4005`](https://github.com/nix-community/nix-index-database/commit/424a40050cdc5f494ec45e46462d288f08c64475) | `` update generated.nix to release 2025-06-15-034405 `` |
| [`0ce41b9d`](https://github.com/nix-community/nix-index-database/commit/0ce41b9dacc40bf4909012e46b2d8803a1feae1d) | `` flake.lock: Update ``                                |