### PR TITLE
chore(flake/home-manager): `c5f34515` -> `66523b0e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749944797,
-        "narHash": "sha256-1l6ZW+2+LDQhYgE4fo2KsM2Ms3lY3ZXv0n6uKka2yMk=",
+        "lastModified": 1750033262,
+        "narHash": "sha256-TcFN78w6kPspxpbPsxW/8vQ1GAtY8Y3mjBaC+oB8jo4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c5f345153397f62170c18ded1ae1f0875201d49a",
+        "rev": "66523b0efe93ce5b0ba96dcddcda15d36673c1f0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`66523b0e`](https://github.com/nix-community/home-manager/commit/66523b0efe93ce5b0ba96dcddcda15d36673c1f0) | `` thunderbird: support declaration of calendars (#5484) ``     |
| [`cef3e0ad`](https://github.com/nix-community/home-manager/commit/cef3e0adc0b671062c2f911b46d9aacfd7235816) | `` maintainers: update aguirre-matteo email (#7279) ``          |
| [`83030f0e`](https://github.com/nix-community/home-manager/commit/83030f0e4a82a1f39f13fc057e3510938841c761) | `` ci: labeler issues permission (#7278) ``                     |
| [`676e40a2`](https://github.com/nix-community/home-manager/commit/676e40a2464783e05146ab5cb196a68230dffc45) | `` sketchybar: inherit meta in finalPackage (#7276) ``          |
| [`30b6daf8`](https://github.com/nix-community/home-manager/commit/30b6daf8723429190e56bc2f296837578c41aca8) | `` kakoune: implement a final package option (#7275) ``         |
| [`04672588`](https://github.com/nix-community/home-manager/commit/04672588c61aebd18c0d0ada66dd7bb4d8edab0d) | `` way-displays: support stateful configuration file (#7138) `` |
| [`dceefa87`](https://github.com/nix-community/home-manager/commit/dceefa87dc19661186f2c519dce6a9670a1d1b36) | `` ncspot: make package nullable ``                             |
| [`6e36b1be`](https://github.com/nix-community/home-manager/commit/6e36b1be0b477547967178422d6b6aedf8efb79b) | `` ncspot: adopt ``                                             |