### PR TITLE
chore(flake/stylix): `77a8b265` -> `a14e5257`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1749905587,
-        "narHash": "sha256-sZpQM+InPCYwJQiTxs/PCCupwbYNaSCFi2Hvpl1/pOo=",
+        "lastModified": 1750023464,
+        "narHash": "sha256-gBsstni5rgh1vt2SNThh51GNvxMDCjEBfpPksS0ig/c=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "77a8b26520f48305f3b1bacffaa8740dde8afa2a",
+        "rev": "a14e525723c1c837b2ceacd8a37cba1f0b5e76c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`a14e5257`](https://github.com/nix-community/stylix/commit/a14e525723c1c837b2ceacd8a37cba1f0b5e76c2) | `` neovide: guard neovim config (#1495) ``                  |
| [`d9a4000d`](https://github.com/nix-community/stylix/commit/d9a4000d909c774b534881afa572302a4449a7a7) | `` doc: add link to `PULL_REQUEST_TEMPLATE.md` (#1504) ``   |
| [`092a602e`](https://github.com/nix-community/stylix/commit/092a602e5275e7395c34b9b83598419cc259e46e) | `` stylix: simplify mkTarget's argument trimming (#1505) `` |
| [`ad592a0e`](https://github.com/nix-community/stylix/commit/ad592a0e99386474a1826f3d90aeaff97848182c) | `` wezterm: use mkTarget (#1472) ``                         |