### PR TITLE
chore(flake/home-manager): `66523b0e` -> `0edffd08`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750033262,
-        "narHash": "sha256-TcFN78w6kPspxpbPsxW/8vQ1GAtY8Y3mjBaC+oB8jo4=",
+        "lastModified": 1750107071,
+        "narHash": "sha256-yfuHCO4m+gu3OBNGnP0/TL5W8nLXrC/EV1fs/+YcoL8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "66523b0efe93ce5b0ba96dcddcda15d36673c1f0",
+        "rev": "0edffd088e42fdc48598b37d88eb5345e2ca3937",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                   |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`0edffd08`](https://github.com/nix-community/home-manager/commit/0edffd088e42fdc48598b37d88eb5345e2ca3937) | `` firefox: allow separators in bookmarks (#7284) ``                      |
| [`1db3cb41`](https://github.com/nix-community/home-manager/commit/1db3cb415da14c81d8e0fdd3a5edeba82ad13a1f) | `` lib/strings: add PascalCase support for toCaseWithSeperator (#7282) `` |