### PR TITLE
chore(flake/stylix): `a14e5257` -> `82323751`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750023464,
-        "narHash": "sha256-gBsstni5rgh1vt2SNThh51GNvxMDCjEBfpPksS0ig/c=",
+        "lastModified": 1750205637,
+        "narHash": "sha256-49wV81h1jnHJky1XNHfgwxNA0oCwSTLMz4hhrtWCM8A=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a14e525723c1c837b2ceacd8a37cba1f0b5e76c2",
+        "rev": "82323751bcd45579c8d3a5dd05531c3c2a78e347",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`82323751`](https://github.com/nix-community/stylix/commit/82323751bcd45579c8d3a5dd05531c3c2a78e347) | `` bemenu: add defaultText to fontSize (#1513) `` |