### PR TITLE
chore(flake/stylix): `82323751` -> `8c1421ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750205637,
-        "narHash": "sha256-49wV81h1jnHJky1XNHfgwxNA0oCwSTLMz4hhrtWCM8A=",
+        "lastModified": 1750369088,
+        "narHash": "sha256-njtrVYrl+4I3ikgAoKLyQ+5MZ1BKwazAiEpLq2efwrE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "82323751bcd45579c8d3a5dd05531c3c2a78e347",
+        "rev": "8c1421ae02475a874f2a09cc4a7ad6de63fbc9e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`8c1421ae`](https://github.com/nix-community/stylix/commit/8c1421ae02475a874f2a09cc4a7ad6de63fbc9e8) | `` stylix: honour recent docs to doc renames (#1493) ``  |
| [`2b231cdc`](https://github.com/nix-community/stylix/commit/2b231cdc9b0537f57be8260463d7e96fe22138ed) | `` treewide: use config in literalExpressions (#1517) `` |