### PR TITLE
chore(flake/nixpkgs): `9e83b64f` -> `08f22084`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750134718,
-        "narHash": "sha256-v263g4GbxXv87hMXMCpjkIxd/viIF7p3JpJrwgKdNiI=",
+        "lastModified": 1750365781,
+        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e83b64f727c88a7711a2c463a7b16eedb69a84c",
+        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`08f22084`](https://github.com/NixOS/nixpkgs/commit/08f22084e6085d19bcfb4be30d1ca76ecb96fe54) | `` nvidia-optimus: blacklist "nvidia-uvm" (#396074) ``                                |
| [`2ac50aad`](https://github.com/NixOS/nixpkgs/commit/2ac50aadf3f005314942710c89e9e41e2622c1d0) | `` phpExtensions.xdebug: 3.4.3 -> 3.4.4 ``                                            |
| [`0bb4a5ea`](https://github.com/NixOS/nixpkgs/commit/0bb4a5ea7f3a2af15d37ae5f136a1ad2581b129c) | `` cpptrace: 0.8.3 -> 1.0.1 ``                                                        |
| [`d443e89d`](https://github.com/NixOS/nixpkgs/commit/d443e89d25ee30fc84c935907fff79d165530501) | `` libdwarf: 0.11.1 -> 2.0.0 ``                                                       |
| [`8d23acbc`](https://github.com/NixOS/nixpkgs/commit/8d23acbc950def0904b30fdd349fc79e6cb60135) | `` SDL_image: 1.2.12-unstable-2025-04-27 -> 1.2.12-unstable-2025-06-15 ``             |
| [`d5406b85`](https://github.com/NixOS/nixpkgs/commit/d5406b851a87342591b44e5681ed5be65f526f80) | `` linux_6_6: 6.6.93 -> 6.6.94 ``                                                     |
| [`e7bfb32f`](https://github.com/NixOS/nixpkgs/commit/e7bfb32fabc872d02e29456aa9225f823034a3a3) | `` linux_6_12: 6.12.33 -> 6.12.34 ``                                                  |
| [`06d87a36`](https://github.com/NixOS/nixpkgs/commit/06d87a365839cef8563e23e081e20816b84190c1) | `` linux_6_15: 6.15.2 -> 6.15.3 ``                                                    |
| [`1d03a031`](https://github.com/NixOS/nixpkgs/commit/1d03a031d0aa7e0e8b48075678f50cd3e31f1c1e) | `` qownnotes: 25.6.0 -> 25.6.2 ``                                                     |
| [`b88538e0`](https://github.com/NixOS/nixpkgs/commit/b88538e07142af7f0423af6efc05fe99a3f9834c) | `` maintainers: rename midirhee12 -> midischwarz12 ``                                 |
| [`af88182f`](https://github.com/NixOS/nixpkgs/commit/af88182f955607a601e55a5b311ff81b0eb822b6) | `` chatmcp: 0.0.62 -> 0.0.66 ``                                                       |
| [`4868c12f`](https://github.com/NixOS/nixpkgs/commit/4868c12f4002e4bea45ca255677b86cddf4cf744) | `` ocamlPackages.encore: 0.8 -> 0.8.1 (#414532) ``                                    |
| [`1f3536ec`](https://github.com/NixOS/nixpkgs/commit/1f3536ecbb08874d588faf1affec0660596341da) | `` home-assistant-custom-lovelace-modules.universal-remote-card: 4.5.5 -> 4.6.0 ``    |
| [`dc7662a0`](https://github.com/NixOS/nixpkgs/commit/dc7662a050d85e5f48c3ac4343f33a89d6cfc3dc) | `` snx-rs: clean up ``                                                                |
| [`3f200cf2`](https://github.com/NixOS/nixpkgs/commit/3f200cf2f5b2e4202b55f2e39f7c9c8bb847f41e) | `` Revert "kdePackages.extra-cmake-modules: propagate qdoc by default" ``             |
| [`7c7c950a`](https://github.com/NixOS/nixpkgs/commit/7c7c950a4b99dea1ffffcf1c4589e46fc9c211ef) | `` mitra: 4.4.0 -> 4.5.0 ``                                                           |
| [`55fd771b`](https://github.com/NixOS/nixpkgs/commit/55fd771b14ccdcd105263e73b3dbd791e18b16d1) | `` stylelint: 16.20.0 -> 16.21.0 ``                                                   |
| [`46a61447`](https://github.com/NixOS/nixpkgs/commit/46a614471942c868875724aca9a280804a439574) | `` mediawriter: 5.2.5 -> 5.2.6 ``                                                     |
| [`dc50b96e`](https://github.com/NixOS/nixpkgs/commit/dc50b96e8a4c0e2810dabe3b387cc9cb561068bc) | `` python3Packages.guestfs: build and use from pkgs.libguestfs ``                     |
| [`ce9550f2`](https://github.com/NixOS/nixpkgs/commit/ce9550f2e96981349534d1b25a3d306a42170341) | `` scalingo: 1.34.0 -> 1.35.0 ``                                                      |
| [`f9fcefd2`](https://github.com/NixOS/nixpkgs/commit/f9fcefd27ab42705d025d4435b6d7d6b84983a9b) | `` btrfs-assistant: 2.1.1 -> 2.2 ``                                                   |
| [`8d1484af`](https://github.com/NixOS/nixpkgs/commit/8d1484af41510e479f57921fd9eb65f8f7c99aae) | `` vimPlugins.blink-pairs: 0.2.0 -> 0.3.0 ``                                          |
| [`2cd4e1c0`](https://github.com/NixOS/nixpkgs/commit/2cd4e1c09a2bc5cdedf38dfe19c04d5bd8a58cb2) | `` claude-code: 1.0.24 -> 1.0.29 ``                                                   |
| [`082e0967`](https://github.com/NixOS/nixpkgs/commit/082e0967fc8b9cad006c01d3cb4e17b045bda7b0) | `` claude-code: add omarjatoi to maintainers ``                                       |
| [`d353bd94`](https://github.com/NixOS/nixpkgs/commit/d353bd94f7bbbb30206a33092607fbdba549ceb7) | `` maintainers: add omarjatoi ``                                                      |
| [`32a10669`](https://github.com/NixOS/nixpkgs/commit/32a1066961d14f6c79ab1222d95b344826e489e9) | `` bash-language-server: add meta.changelog and maintainer gepbird ``                 |
| [`5e3c0b8a`](https://github.com/NixOS/nixpkgs/commit/5e3c0b8ab39f8fb491ad4aa99e708cdc114040b9) | `` illuminanced: init at 1.0.2 ``                                                     |
| [`5130436b`](https://github.com/NixOS/nixpkgs/commit/5130436b3665386b7951e1b033f8d0f1f73a6445) | `` python312Packages.ossapi: init at 5.2.1 ``                                         |
| [`5e1e3599`](https://github.com/NixOS/nixpkgs/commit/5e1e35996b9056b48aeb583a35accdbf9d9c543e) | `` python312Packages.typing-utils: init at 0.1.0 ``                                   |
| [`bb94f544`](https://github.com/NixOS/nixpkgs/commit/bb94f544b050f58565e613a8174f230486149019) | `` python312Packages.osrparse: init at 7.0.1 ``                                       |
| [`cdb58599`](https://github.com/NixOS/nixpkgs/commit/cdb5859977c13d6f142e40cf4d17e4cce55fbf8d) | `` maintainers: add wulpine ``                                                        |
| [`32d89fb6`](https://github.com/NixOS/nixpkgs/commit/32d89fb6188c3bebf749a12a4fddcbd866179882) | `` bash-language-server: refactor ``                                                  |
| [`c38f7a25`](https://github.com/NixOS/nixpkgs/commit/c38f7a2581fa15b88b5b1be139721c8735a88506) | `` bash-language-server: remove unnecessary and non-deterministic files ``            |
| [`4454b79e`](https://github.com/NixOS/nixpkgs/commit/4454b79e369e4bbe6a926e0434bae94d78b49538) | `` python3Packages.vllm: relax setuptools ``                                          |
| [`6cfe9ec0`](https://github.com/NixOS/nixpkgs/commit/6cfe9ec0fbf123916154aad433a9813d4442408d) | `` kdePackages.extra-cmake-modules: don't pull in qdoc ``                             |
| [`3368cc4d`](https://github.com/NixOS/nixpkgs/commit/3368cc4d9b541fe362fc6b64b22e279a7badad1f) | `` ladybird: 0-unstable-2025-06-03 -> 0-unstable-2025-06-18 ``                        |
| [`0b88eab9`](https://github.com/NixOS/nixpkgs/commit/0b88eab9e67ac9e5366acacb4d1896db5bcf3caa) | `` aliases.nix: Correct "it's" usage  (#417768) ``                                    |
| [`3cdf7171`](https://github.com/NixOS/nixpkgs/commit/3cdf71710d7e0c5822a6d9ffb21f5aba12795955) | `` bash-language-server: 5.4.0 -> 5.6.0 ``                                            |
| [`e5e29a01`](https://github.com/NixOS/nixpkgs/commit/e5e29a0108882f38fc81602b4f054147fe155a74) | `` sing-box: 1.11.13 -> 1.11.14 ``                                                    |
| [`4f6c942f`](https://github.com/NixOS/nixpkgs/commit/4f6c942f7a68ee2c05832531d42370c6268e7ff1) | `` python3Packages.ray: 2.47.0 -> 2.47.1 ``                                           |
| [`1ae47c10`](https://github.com/NixOS/nixpkgs/commit/1ae47c10a5a85bca2d1d26a68534c9226860c93e) | `` google-chrome: 137.0.7151.103 -> 137.0.7151.119 ``                                 |
| [`8ab44fec`](https://github.com/NixOS/nixpkgs/commit/8ab44fec3709c629e54216b126ddc7dc8a28bc4d) | `` workflows/labels: fix pull_request event trigger ``                                |
| [`74b75681`](https://github.com/NixOS/nixpkgs/commit/74b75681ca33a6d2c9e4d64dfeacffeae08c4453) | `` python3Packages.apache-beam: skip failing tests ``                                 |
| [`e87d1a7d`](https://github.com/NixOS/nixpkgs/commit/e87d1a7dae254b55d93bc102590b69afb891955f) | `` minijail: install man pages ``                                                     |
| [`e2203100`](https://github.com/NixOS/nixpkgs/commit/e22031008817aa9236e719ea9ced95fe65a275b7) | `` pgcopydb: install man pages ``                                                     |
| [`904fd1ed`](https://github.com/NixOS/nixpkgs/commit/904fd1ed4831615d32d964b2072cf0e2557940d9) | `` batman-adv: 2025.1 -> 2025.2 ``                                                    |
| [`12311b4c`](https://github.com/NixOS/nixpkgs/commit/12311b4c34a830aad8139f32765e624aee8dec6f) | `` mpd-sima: install man page ``                                                      |
| [`cd7b9202`](https://github.com/NixOS/nixpkgs/commit/cd7b9202cade827c749e675c6db7122e908758cc) | `` androidStudioPackages.canary: 2025.1.2.4 -> 2025.1.2.5 ``                          |
| [`598d5c29`](https://github.com/NixOS/nixpkgs/commit/598d5c29f8b1bb7d094d9965ab25819c963e50a0) | `` llama-cpp: 5608 -> 5702 ``                                                         |
| [`23f44b10`](https://github.com/NixOS/nixpkgs/commit/23f44b10529ad53516b4403e03ebeb4780dfcc07) | `` python3Packages.apache-beam: relax numpy ``                                        |
| [`191706ad`](https://github.com/NixOS/nixpkgs/commit/191706ad58f6fac3b445cc5275fc78a88c5fc248) | `` sddm: wrap with strictDeps ``                                                      |
| [`a7a9c2ce`](https://github.com/NixOS/nixpkgs/commit/a7a9c2cefbc88c8d48e8a5b3d4f1b3f8c760f404) | `` keepassxc: remove blankparticle as maintainer ``                                   |
| [`c86b778c`](https://github.com/NixOS/nixpkgs/commit/c86b778c7af9731cfb6e01655d2726a446b626f5) | `` cockpit: add `pkgs.hostname` to the binary path for cockpit package ``             |
| [`2c04edb8`](https://github.com/NixOS/nixpkgs/commit/2c04edb83faf8e6c0beb0ae976b91f34564f66c1) | `` python3Packages.rlcard: fix build ``                                               |
| [`4085f84c`](https://github.com/NixOS/nixpkgs/commit/4085f84cc3c031aefd04d1ddd5c9c6912788a860) | `` lean4: 4.19.0 -> 4.20.0 ``                                                         |
| [`79d3915b`](https://github.com/NixOS/nixpkgs/commit/79d3915b72968f51056ca35f3b39b682dd47aa08) | `` python3Packages.garth: 0.5.15 -> 0.5.16 ``                                         |
| [`abc9b180`](https://github.com/NixOS/nixpkgs/commit/abc9b18038ae082c05ad2c0cbab1506fa2ec4d87) | `` deno: disable LTO on Linux and x86_64-darwin ``                                    |
| [`9ca2fccd`](https://github.com/NixOS/nixpkgs/commit/9ca2fccd22e3087dfe6c0f7966280931140cb3fd) | `` gotestsum: 1.12.2 -> 1.12.3 ``                                                     |
| [`5bb72e52`](https://github.com/NixOS/nixpkgs/commit/5bb72e52f30038a2410d7f632ca6929787d5ba6b) | `` librespeed-cli: 1.0.10 -> 1.0.12 ``                                                |
| [`24896f1d`](https://github.com/NixOS/nixpkgs/commit/24896f1dd15e3b8ac886db24e81b68bdad6287cc) | `` xwayland: 24.1.7 -> 24.1.8 ``                                                      |
| [`9ef039f3`](https://github.com/NixOS/nixpkgs/commit/9ef039f3edda7dffc905539891329a78e3c8c870) | `` juju: 3.6.6 -> 3.6.7 ``                                                            |
| [`ef05c5dd`](https://github.com/NixOS/nixpkgs/commit/ef05c5ddb936341f81e9d44c2458c32b7d11a6a4) | `` gamescope: 3.16.12 -> 3.16.14 ``                                                   |
| [`98702f22`](https://github.com/NixOS/nixpkgs/commit/98702f22b1209825a960d3366fdeb66b77cb0f8c) | `` python3Packages.mitmproxy: Fix broken build ``                                     |
| [`888f5236`](https://github.com/NixOS/nixpkgs/commit/888f523682c1e74f13366faad02f48d915d15339) | `` grimblast: 0.1-unstable-2025-05-18 -> 0.1-unstable-2025-06-14 ``                   |
| [`070af34b`](https://github.com/NixOS/nixpkgs/commit/070af34b83a802f9ec9ba7064dd381260b9f78fe) | `` ledger-live-desktop: 2.115.1 -> 2.117.0 ``                                         |
| [`b5aeb79d`](https://github.com/NixOS/nixpkgs/commit/b5aeb79d8aa8a28c3f58f6726f227169ee0a3da2) | `` python3Packages.django-mcp-server: fix pythonImportsCheck, removed unused input `` |
| [`91ff341b`](https://github.com/NixOS/nixpkgs/commit/91ff341b9b726c45f1295402fdb4a21158acd77a) | `` boxflat: 1.32.0 -> 1.32.1 ``                                                       |
| [`6bcb9f25`](https://github.com/NixOS/nixpkgs/commit/6bcb9f25f91cfa4331f24710f308633bba48cf90) | `` hydralauncher: 3.6.0 -> 3.6.1 ``                                                   |
| [`decbd775`](https://github.com/NixOS/nixpkgs/commit/decbd775ab53aff637e46c7a9ed2a03431e015b9) | `` vobcopy: 1.2.0 -> 1.2.1-unstable-2023-08-29; change upstream ``                    |
| [`54810608`](https://github.com/NixOS/nixpkgs/commit/548106087cc8f1590e29f3f90ae2ecb0d1b28895) | `` blst: add meta.changelog ``                                                        |
| [`5f59dd0f`](https://github.com/NixOS/nixpkgs/commit/5f59dd0f50202242a0fe55b38a88e220d189b4d5) | `` telepresence2: 2.22.6 -> 2.23.0 ``                                                 |
| [`87d14a11`](https://github.com/NixOS/nixpkgs/commit/87d14a110fd74088dfcb84548199eb8d8b96777d) | `` qir-runner: 0.8.1 -> 0.8.2 ``                                                      |
| [`54c77e4d`](https://github.com/NixOS/nixpkgs/commit/54c77e4dab347b53e51ec41530da8f443ad5dfa4) | `` kdePackages.dynamic-workspaces: init at 3.2 ``                                     |
| [`35255036`](https://github.com/NixOS/nixpkgs/commit/35255036415cfb1210c355c71f3a44b5ba126ee5) | `` python313Packages.python-olm: drop unused dependency future ``                     |
| [`eef3a0fe`](https://github.com/NixOS/nixpkgs/commit/eef3a0fe9a1efbb1ce2a748bbfd482e966491db5) | `` mesa: 25.1.3 -> 25.1.4 ``                                                          |
| [`c3a33a82`](https://github.com/NixOS/nixpkgs/commit/c3a33a8230a4571d7df94ca931079ff677c02614) | `` glab: 1.59.2 -> 1.60.2 ``                                                          |
| [`7ecea9d5`](https://github.com/NixOS/nixpkgs/commit/7ecea9d514f6cf12354ec32deb93624f9c088ac1) | `` python3Packages.django-prometheus: 2.3.1 -> 2.4.0 ``                               |
| [`8fbac5db`](https://github.com/NixOS/nixpkgs/commit/8fbac5dbdca98d9d80fa3e654213e0b575834f68) | `` clamav: 1.4.2 -> 1.4.3 ``                                                          |
| [`9944fed2`](https://github.com/NixOS/nixpkgs/commit/9944fed2501ba6e3bbfa1862d33f12b2f81927d2) | `` sage: pin python to 3.12 for getrandbits() compat ``                               |
| [`6731db5a`](https://github.com/NixOS/nixpkgs/commit/6731db5ab8f8847f2fbabc0dcc4a14e4d821f819) | `` hypercore: 11.8.3 -> 11.9.1 ``                                                     |
| [`bdd34c75`](https://github.com/NixOS/nixpkgs/commit/bdd34c75446441b9ca084707978026da6b8d49c1) | `` pantheon.elementary-bluetooth-daemon: 1.0.1 -> 1.1.0 ``                            |
| [`72b6b835`](https://github.com/NixOS/nixpkgs/commit/72b6b835bf059ae997264e89c12b61f54859c3ff) | `` ytdl-sub: 2025.06.01.post1 -> 2025.06.12 ``                                        |
| [`8bb8408a`](https://github.com/NixOS/nixpkgs/commit/8bb8408aa1c893214e6dadf11ddc477eb6cd97d7) | `` cowsql: fix build failure from libuv conflict ``                                   |
| [`6759ee9e`](https://github.com/NixOS/nixpkgs/commit/6759ee9e4ea02633976d25894acc127c6dce9f4b) | `` openvino: 2025.1.0 -> 2025.2.0 ``                                                  |
| [`d66efbca`](https://github.com/NixOS/nixpkgs/commit/d66efbca0acf014295439558f901fad3c33e37b2) | `` simplex-chat-desktop: 6.3.5 -> 6.3.6 ``                                            |
| [`70a3fad4`](https://github.com/NixOS/nixpkgs/commit/70a3fad452935c0e3b8663db12cb52eee6f57cef) | `` tailwindcss-language-server: 0.14.21 -> 0.14.22 ``                                 |
| [`2e3453d5`](https://github.com/NixOS/nixpkgs/commit/2e3453d5cc233072f39a20a829bb60d808b8169f) | `` python313Packages.htmlmin: fix build on python 3.13 ``                             |
| [`68f0571d`](https://github.com/NixOS/nixpkgs/commit/68f0571db912bc0566803d3ef1d63bd5c4d1aa54) | `` obs-do: 0.1.8 -> 0.1.9 ``                                                          |
| [`0ba99e94`](https://github.com/NixOS/nixpkgs/commit/0ba99e943ef6e532f59b9fd9379d5789bf204a5e) | `` blivet-gui: patch hardcoded binary paths ``                                        |
| [`d2bb43f6`](https://github.com/NixOS/nixpkgs/commit/d2bb43f6c969e3c8b4d49c19aca105360dc807d8) | `` immich: 1.134.0 -> 1.135.0 ``                                                      |
| [`4491bf34`](https://github.com/NixOS/nixpkgs/commit/4491bf34f00dd3244000282d0d8542530354617a) | `` autobrr: 1.62.0 -> 1.63.1 ``                                                       |
| [`e2afa5b3`](https://github.com/NixOS/nixpkgs/commit/e2afa5b3da3f0c9bb3e5dd478aa6b90586be556e) | `` zed-editor: 0.191.4 -> 0.191.5 ``                                                  |
| [`69fd01a5`](https://github.com/NixOS/nixpkgs/commit/69fd01a5079a223d78d1c76dd611490d3e741887) | `` mpvScripts.eisa01.smartskip: 0-unstable-2025-05-08 -> 0-unstable-2025-05-14 ``     |
| [`9c82463c`](https://github.com/NixOS/nixpkgs/commit/9c82463c2e1caeecf3680a27009bd7948ed1b28e) | `` lxgw-neoxihei: 1.217 -> 1.218 ``                                                   |
| [`39145a9f`](https://github.com/NixOS/nixpkgs/commit/39145a9f9fab62008b90312267785dfd0a2b5a5b) | `` fluxcd-operator: 0.22.0 -> 0.23.0 ``                                               |
| [`b1ff84ac`](https://github.com/NixOS/nixpkgs/commit/b1ff84ac9ca8b45b1182729eeecce37a0b4a8eaa) | `` flyctl: 0.3.140 -> 0.3.144 ``                                                      |
| [`d2024981`](https://github.com/NixOS/nixpkgs/commit/d20249818966ff80c7f5c249ac02bb202f7bfd2d) | `` gitversion: 5.12.0 -> 6.3.0 ``                                                     |
| [`9757c900`](https://github.com/NixOS/nixpkgs/commit/9757c9009e010aa6599f9709f5263dd76dad985e) | `` jinja-lsp: 0.1.86 -> 0.1.89 ``                                                     |