### PR TITLE
chore(flake/nix-index-database): `424a4005` -> `78cd697a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749960154,
-        "narHash": "sha256-EWlr9MZDd+GoGtZB4QsDzaLyaDQPGnRY03MFp6u2wSg=",
+        "lastModified": 1750565152,
+        "narHash": "sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "424a40050cdc5f494ec45e46462d288f08c64475",
+        "rev": "78cd697acc2e492b4e92822a4913ffad279c20e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`78cd697a`](https://github.com/nix-community/nix-index-database/commit/78cd697acc2e492b4e92822a4913ffad279c20e6) | `` update generated.nix to release 2025-06-22-034530 `` |
| [`9954ee6d`](https://github.com/nix-community/nix-index-database/commit/9954ee6dbec38983b888fa20dba7c770d44838bb) | `` flake.lock: Update ``                                |