### PR TITLE
chore(flake/darwin): `0d71cbf8` -> `1dd19f19`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750325256,
-        "narHash": "sha256-vvlxGz/waqJ3TGqM/iqXbnEc7/R1qnEXmaBiPaQ1RE0=",
+        "lastModified": 1750618568,
+        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "0d71cbf88d63e938b37b85b3bf8b238bcf7b39b9",
+        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                               |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`f2457a22`](https://github.com/nix-darwin/nix-darwin/commit/f2457a22c8cce48c2f8ede0935037c4d2cf8de39) | `` systems.defaults.alf: deprecate ``                                 |
| [`caa59bf5`](https://github.com/nix-darwin/nix-darwin/commit/caa59bf50a430d2ba18ff4d428c267561b686072) | `` networking.applicationFirewall: init ``                            |
| [`f67a4856`](https://github.com/nix-darwin/nix-darwin/commit/f67a4856c36e64b1f3884f6f59dce0ba0ca9dddd) | `` Update homebrew module documentation and examples ``               |
| [`30845bee`](https://github.com/nix-darwin/nix-darwin/commit/30845beee0448bea77a7b8770ea9e6d17ca205d8) | `` nix.nixPath: Do not use environment.darwinConfig if set to null `` |
| [`e2361f44`](https://github.com/nix-darwin/nix-darwin/commit/e2361f44961f8a9cc7bf3c00e5c2d472b7a7b93c) | `` homebrew: allow setting greedy for all casks by default ``         |