### PR TITLE
chore(flake/stylix): `27721407` -> `100b9680`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750527172,
-        "narHash": "sha256-ATl7gK98w27JaXzidK48YlG4o+mtfvyHu9zKuadE6j0=",
+        "lastModified": 1750562714,
+        "narHash": "sha256-GEQdMsWrij7y1UjuONVZYWLBo1OPIt709KcyCxcDfxU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "27721407de0615e927c84f7c23277628e1d12b67",
+        "rev": "100b968012804d6526c5f48a32c30680916bc474",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                               |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`100b9680`](https://github.com/nix-community/stylix/commit/100b968012804d6526c5f48a32c30680916bc474) | `` doc: ensure `config` is not used in option docs ``                 |
| [`e1ae98f9`](https://github.com/nix-community/stylix/commit/e1ae98f979fb5360ec025277e19ea82719a37d5a) | `` doc: ensure `pkgs` is not used in option docs ``                   |
| [`07af242a`](https://github.com/nix-community/stylix/commit/07af242a44ebaa889fac856b18e525f0a0f9ab1f) | `` doc: replace `inputs` input with `self` ``                         |
| [`bdf092d1`](https://github.com/nix-community/stylix/commit/bdf092d169f59224a3ec4683187981db8d0d346a) | `` doc: use minimal module evals ``                                   |
| [`84f02caa`](https://github.com/nix-community/stylix/commit/84f02caad30191c6b1f8e0e6934bd4f08a2dc848) | `` stylix: set defaultText in font size options ``                    |
| [`ab2f48fc`](https://github.com/nix-community/stylix/commit/ab2f48fc3a878be1cfd9dadc188fa03a56d8fc6e) | `` stylix: only read `autoEnable` in `mkEnableWallpaper`'s example `` |