### PR TITLE
chore(flake/home-manager): `7c355048` -> `86402a17`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750614446,
-        "narHash": "sha256-6WH0aRFay79r775RuTqUcnoZNm6A4uHxU1sbcNIk63s=",
+        "lastModified": 1750713626,
+        "narHash": "sha256-uM+hqdMxp+H53d8R7EHn2yY+nLNGgg59pdipIgCZ5yY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7c35504839f915abec86a96435b881ead7eb6a2b",
+        "rev": "86402a17b6c67b07c5536354da5d56c14196de46",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                       |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`86402a17`](https://github.com/nix-community/home-manager/commit/86402a17b6c67b07c5536354da5d56c14196de46) | `` treewide: flatten single file modules ``                                   |
| [`bda9deb7`](https://github.com/nix-community/home-manager/commit/bda9deb791b29454d49f8f5c35198e2b23f7751a) | `` modules: allow root level nix files ``                                     |
| [`f5098b07`](https://github.com/nix-community/home-manager/commit/f5098b074051d1ae0e919adf434a60fc3f23347b) | `` programs/hyprpanel: init (#7303) ``                                        |
| [`873c5b2d`](https://github.com/nix-community/home-manager/commit/873c5b2dc5c9387bf67e59a12abc4de12a4b8697) | `` way-displays: use `mkOptionDefault` in `systemd.variables` (#7306) ``      |
| [`05b8c950`](https://github.com/nix-community/home-manager/commit/05b8c9506452349d8be854ac46e5a7630fa7917d) | `` ci: home-manager switch test aginst codebase ``                            |
| [`4a8f993c`](https://github.com/nix-community/home-manager/commit/4a8f993c45fcd2edf75d64ee4532cb9aca41566c) | `` home-manager: fix broken path reference ``                                 |
| [`4c9e99e8`](https://github.com/nix-community/home-manager/commit/4c9e99e8e8e36bcdfa9cdb102e45e4dc95aa5c5b) | `` ci: disable home-manager install tests on darwin ``                        |
| [`41a5f0a9`](https://github.com/nix-community/home-manager/commit/41a5f0a98a4970f27ff23914927aec33da949f2a) | `` tests/nix-gc: reorganize darwin and linux ``                               |
| [`7a64c023`](https://github.com/nix-community/home-manager/commit/7a64c0234077290079e5457691afb6cb543d45a0) | `` tests/imapnotify: reorganize darwin and linux ``                           |
| [`5618e7a7`](https://github.com/nix-community/home-manager/commit/5618e7a748706dbe4f23ef11ec303070af7b5ea0) | `` tests/home-manager-auto-expire: reorganize darwin and linux ``             |
| [`d2b2c72a`](https://github.com/nix-community/home-manager/commit/d2b2c72add6796fe95a9eb95690286cb0ab5fab3) | `` tests/espanso: reorganize darwin and linux ``                              |
| [`c283a23e`](https://github.com/nix-community/home-manager/commit/c283a23ef6c23366837a754ba3c30d45826424c1) | `` tests/emacs: reorganize darwin and linux ``                                |
| [`e9bde769`](https://github.com/nix-community/home-manager/commit/e9bde7692e7a0b6c87ea36200c3d196759959c31) | `` tests/git-sync: reorganize darwin and linux ``                             |
| [`2c4f8cb7`](https://github.com/nix-community/home-manager/commit/2c4f8cb7d6c1958d1afbd30276a3389947be4e59) | `` tests/yubikey-agent: reorganize darwin and linux ``                        |
| [`bbad45b7`](https://github.com/nix-community/home-manager/commit/bbad45b7ea7152f540faa531bafaf98a73b00463) | `` tests/jellyfin-mpv-shim: fix tests ``                                      |
| [`06c1392c`](https://github.com/nix-community/home-manager/commit/06c1392ca886553e9df1c7a927e5972261cf98f8) | `` tests: implement auto importing for modules ``                             |
| [`4fca600c`](https://github.com/nix-community/home-manager/commit/4fca600cb1db1d10bed39f67702c443f119117c1) | `` treewide: implement auto importing for modules ``                          |
| [`fefeb0e9`](https://github.com/nix-community/home-manager/commit/fefeb0e928d1ec528f54e73892a7c069425d5041) | `` tests/redshift-gammastep: check file exists first ``                       |
| [`520fc4b5`](https://github.com/nix-community/home-manager/commit/520fc4b50af1b365014c3748c126d3f52edb2f3b) | `` k9s: fix config files not generated correctly & improve options (#7262) `` |
| [`6fa01d52`](https://github.com/nix-community/home-manager/commit/6fa01d524bc5b0e77e6702dd37cf453247438480) | `` labwc: do not manage file when in default value(#7240) ``                  |
| [`2fbd694f`](https://github.com/nix-community/home-manager/commit/2fbd694fec4a53d0358ab9b1f5f0483fbb876286) | `` labwc: Fix pipemenu(#7236) and icon in menu generation ``                  |
| [`3bd64613`](https://github.com/nix-community/home-manager/commit/3bd646138a9c71f244a9293dde6f59ae1c6875ab) | `` nushell: Make sure the plugins are not garbage-collected (#7295) ``        |