### PR TITLE
chore(flake/home-manager): `86402a17` -> `ff31a467`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750713626,
-        "narHash": "sha256-uM+hqdMxp+H53d8R7EHn2yY+nLNGgg59pdipIgCZ5yY=",
+        "lastModified": 1750798083,
+        "narHash": "sha256-DTCCcp6WCFaYXWKFRA6fiI2zlvOLCf5Vwx8+/0R8Wc4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86402a17b6c67b07c5536354da5d56c14196de46",
+        "rev": "ff31a4677c1a8ae506aa7e003a3dba08cb203f82",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`ff31a467`](https://github.com/nix-community/home-manager/commit/ff31a4677c1a8ae506aa7e003a3dba08cb203f82) | `` fix(zed): support preexisting JSON5 settings (#7317) ``   |
| [`951f0b30`](https://github.com/nix-community/home-manager/commit/951f0b30c535a46817aa5ef4c66ddc4445f3e324) | `` ci: schedule release flake lock updates (#7325) ``        |
| [`d400c361`](https://github.com/nix-community/home-manager/commit/d400c361660526a199e1e56cc22f073c09c71d35) | `` tests/flake.lock: remove (#7324) ``                       |
| [`a4bac2b9`](https://github.com/nix-community/home-manager/commit/a4bac2b9ba2f9bd68032880da8ae6b44fbc46047) | `` helix: fix configuration file creation logic (#7319) ``   |
| [`d07e9cce`](https://github.com/nix-community/home-manager/commit/d07e9cceb4994ed64a22b9b36f8b76923e87ac38) | `` docs: add note about importing modules (#7315) ``         |
| [`c9d8158b`](https://github.com/nix-community/home-manager/commit/c9d8158bc56923013fa9a4346ba3e273f3b956b3) | `` tests/aerospace: test launchd agent ``                    |
| [`d33444e6`](https://github.com/nix-community/home-manager/commit/d33444e63a88f70feccd99971c442dc9d84faff1) | `` aerospace: Add launchd agent and enhance configuration `` |