### PR TITLE
chore(flake/stylix): `67a6479c` -> `1fc22894`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750688934,
-        "narHash": "sha256-nOWOzcB/U9QE8MZ5NV1eRwrsWnsqtcPA88v0SKwKmxA=",
+        "lastModified": 1750810405,
+        "narHash": "sha256-7Aa6jLbbltPVBCz34UXjIXkmrV1qq+6TYhJ37fErQhg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "67a6479c1aa95210a346a227743f074b82471432",
+        "rev": "1fc22894545f5adf915e245b3c3e92639fd70f64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                         |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`1fc22894`](https://github.com/nix-community/stylix/commit/1fc22894545f5adf915e245b3c3e92639fd70f64) | `` stylix: extract testbed modules to `autoload.nix` (#1520) `` |
| [`edcecc02`](https://github.com/nix-community/stylix/commit/edcecc02e6f113758f401b2248d739f28c063478) | `` doc: remove redundant option-location filtering (#1215) ``   |
| [`9194dd84`](https://github.com/nix-community/stylix/commit/9194dd84421fd4af904b1eeb77f3ab19f2f74b83) | `` waybar: use mkTarget (#1337) ``                              |
| [`79e816c2`](https://github.com/nix-community/stylix/commit/79e816c2e63df5024e28292fee0d92dc106ff66c) | `` doc: add missing module args (#1534) ``                      |