### PR TITLE
chore(flake/stylix): `a6eff346` -> `c700d41b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750884081,
-        "narHash": "sha256-YVh5IuhJJiX5eQmCsQZ/jKx2viwYbrm47E+Y1ecHSMs=",
+        "lastModified": 1750950678,
+        "narHash": "sha256-ZNSjRDpaR/sAtrZNPO6RpGkHKdMb1oc1lkQN+6ZBvyU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "a6eff346d8e346b5a8e7eb3f8f7c4b36c9597a3c",
+        "rev": "c700d41bb8ee32baed490c8128c1077b2b27183b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                         |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`c700d41b`](https://github.com/nix-community/stylix/commit/c700d41bb8ee32baed490c8128c1077b2b27183b) | `` stylix: allow mkTarget's configuration arguments to receive paths (#1523) `` |
| [`0f93e586`](https://github.com/nix-community/stylix/commit/0f93e58628596297711954ba5ba6d3a3ef9cf3dd) | `` flake: infer default.nix import path (#1544) ``                              |
| [`32b2c1c8`](https://github.com/nix-community/stylix/commit/32b2c1c85df463c7cf45bc99dd8825e9e22080cc) | `` firefox: simplify inherit formatting ``                                      |
| [`59d500f8`](https://github.com/nix-community/stylix/commit/59d500f8644047aaed2af9675d00a62c86f880bb) | `` firefox: simplify derivation declaration ``                                  |