### PR TITLE
chore(flake/nixvim-flake): `dbfbb5d6` -> `a24f1277`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -485,11 +485,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1749427739,
-        "narHash": "sha256-Nm0oMqFNRnJsiZYeNChmefmjeVCOzngikpSQhgs7iXI=",
+        "lastModified": 1750933613,
+        "narHash": "sha256-UtBpLFPpQfKrnzxsESKroXzRB2rHdXEifVrtRUYHWng=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "b1dae483ab7d4139a6297e02b6de9e5d30e43d48",
+        "rev": "8f9623efceac21f432fdd83abbd3ab979ea8a39a",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1750902837,
-        "narHash": "sha256-+z4wzGUfVaKSYSeMmjX3ErOh0X4/9CpJgtI/FniR9GA=",
+        "lastModified": 1750989312,
+        "narHash": "sha256-ivypk6LX2IQHFaYsaCAPbrbUvDZJltqxnM21aJCDYZI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "dbfbb5d6bb53eb7f01f9168a351536d894a65029",
+        "rev": "a24f1277d6a1b59c325265a961c6138479608e68",
         "type": "github"
       },
       "original": {
@@ -896,11 +896,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749194973,
-        "narHash": "sha256-eEy8cuS0mZ2j/r/FE0/LYBSBcIs/MKOIVakwHVuqTfk=",
+        "lastModified": 1750931469,
+        "narHash": "sha256-0IEdQB1nS+uViQw4k3VGUXntjkDp7aAlqcxdewb/hAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "a05be418a1af1198ca0f63facb13c985db4cb3c5",
+        "rev": "ac8e6f32e11e9c7f153823abc3ab007f2a65d3e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`a24f1277`](https://github.com/alesauce/nixvim-flake/commit/a24f1277d6a1b59c325265a961c6138479608e68) | `` chore(flake/nix-fast-build): b1dae483 -> 8f9623ef `` |