### PR TITLE
chore(flake/home-manager): `080e8b48` -> `76d0c31f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750973805,
-        "narHash": "sha256-BZXgag7I0rnL/HMHAsBz3tQrfKAibpY2vovexl2lS+Y=",
+        "lastModified": 1751146119,
+        "narHash": "sha256-gvjG95TCnUVJkvQvLMlnC4NqiqFyBdJk3o8/RwuHeaU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "080e8b48b0318b38143d5865de9334f46d51fce3",
+        "rev": "76d0c31fce2aa0c71409de953e2f9113acd5b656",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                     |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`76d0c31f`](https://github.com/nix-community/home-manager/commit/76d0c31fce2aa0c71409de953e2f9113acd5b656) | `` formatter: add deadnix (#7331) ``                                        |
| [`da077f20`](https://github.com/nix-community/home-manager/commit/da077f20db88a173629624a30380658840d377b3) | `` fix(service/gpg-agent): ensure SSH_AUTH_SOCK is set on Darwin (#7117) `` |