### PR TITLE
chore(flake/stylix): `c700d41b` -> `3a09d3f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1750950678,
-        "narHash": "sha256-ZNSjRDpaR/sAtrZNPO6RpGkHKdMb1oc1lkQN+6ZBvyU=",
+        "lastModified": 1751145558,
+        "narHash": "sha256-OPlbpH64jzIspYqvJB96tnN9V9HBlAxROS5ijQwtN70=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c700d41bb8ee32baed490c8128c1077b2b27183b",
+        "rev": "3a09d3f5cb940fa4142a2f3415b508a8be92b721",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                  |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3a09d3f5`](https://github.com/nix-community/stylix/commit/3a09d3f5cb940fa4142a2f3415b508a8be92b721) | `` rofi: fix attribute 'size' missing (#1553) ``         |
| [`8c4b2ebf`](https://github.com/nix-community/stylix/commit/8c4b2ebfb83010e5b345cba4afcbe499603f6861) | `` ci: commit as stylix-automation in updates (#1547) `` |
| [`713f8dae`](https://github.com/nix-community/stylix/commit/713f8dae3127a0faeb1d343ed8da67677121ee29) | `` rofi: use mkTarget (#1550) ``                         |