### PR TITLE
chore(flake/nix-index-database): `78cd697a` -> `9c932ae6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750565152,
-        "narHash": "sha256-A6ZIoIgaPPkzIVxKuaxwEJicPOeTwC/MD9iuC3FVhDM=",
+        "lastModified": 1751170039,
+        "narHash": "sha256-3EKpUmyGmHYA/RuhZjINTZPU+OFWko0eDwazUOW64nw=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "78cd697acc2e492b4e92822a4913ffad279c20e6",
+        "rev": "9c932ae632d6b5150515e5749b198c175d8565db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`9c932ae6`](https://github.com/nix-community/nix-index-database/commit/9c932ae632d6b5150515e5749b198c175d8565db) | `` update generated.nix to release 2025-06-29-034928 `` |
| [`3adfb5f5`](https://github.com/nix-community/nix-index-database/commit/3adfb5f51cd43f70fd49ec524e709cbcac5bd395) | `` flake.lock: Update ``                                |