### PR TITLE
chore(flake/home-manager): `f6deff17` -> `78fc50f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751239699,
-        "narHash": "sha256-zA1uUdAq3c26fHm26xMWMuF5COhI18EzaH7az/P2OWM=",
+        "lastModified": 1751309344,
+        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f6deff178cc4d6049d30785dbfc831e6c6e3a219",
+        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`78fc50f1`](https://github.com/nix-community/home-manager/commit/78fc50f1cf8e57a974ff4bfe654563fce43d6289) | `` direnv: fix nushell cell-path handling (#7339) ``               |
| [`ee2189cb`](https://github.com/nix-community/home-manager/commit/ee2189cb2f6c9e2b9c734a839faa20ed2ba8b577) | `` gh: insert empty helper when using credential helper (#7347) `` |
| [`0f21ed51`](https://github.com/nix-community/home-manager/commit/0f21ed5182a158d2f84e9136f6bf8539fd9a6890) | `` bash: change sessionVariables to attrsOf ... (#7300) ``         |