### PR TITLE
chore(flake/darwin): `1dd19f19` -> `e04a3882`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750618568,
-        "narHash": "sha256-w9EG5FOXrjXGfbqCcQg9x1lMnTwzNDW5BMXp8ddy15E=",
+        "lastModified": 1751313918,
+        "narHash": "sha256-HsJM3XLa43WpG+665aGEh8iS8AfEwOIQWk3Mke3e7nk=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "1dd19f19e4b53a1fd2e8e738a08dd5fe635ec7e5",
+        "rev": "e04a388232d9a6ba56967ce5b53a8a6f713cdfcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                    |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`a79b28f2`](https://github.com/nix-darwin/nix-darwin/commit/a79b28f2fa4d7113a21e4175b34ddfd0bb92df08) | `` readme: update flake guide ``                                           |
| [`b866fbb2`](https://github.com/nix-darwin/nix-darwin/commit/b866fbb28ba37482d4151315b38a9070761fb0c3) | `` readme: bump nix stable version ``                                      |
| [`7f9694a4`](https://github.com/nix-darwin/nix-darwin/commit/7f9694a4be6c55322474a0a00723bcfcf8f21c0d) | `` github-runner/service.nix: fix missing argument in workDir assertion `` |