### PR TITLE
chore(flake/home-manager): `78fc50f1` -> `e96a8a32`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751309344,
-        "narHash": "sha256-zmb01yyOXttyhJD3kRtW6Pkt1lsPbJvN3P92/GnI0tk=",
+        "lastModified": 1751411489,
+        "narHash": "sha256-x+AJyQ5+4EPDU3NnQ1OPP/KuoG0C6UrbgptEW6PSLQ8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "78fc50f1cf8e57a974ff4bfe654563fce43d6289",
+        "rev": "e96a8a325cf23538a7f58b9335b4c4c0b393bacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`e96a8a32`](https://github.com/nix-community/home-manager/commit/e96a8a325cf23538a7f58b9335b4c4c0b393bacf) | `` ci: conditional test step runs (#7358) ``                        |
| [`5d2f3e3e`](https://github.com/nix-community/home-manager/commit/5d2f3e3e7fbb2cd8cab8b5f9e51526b1269645b9) | `` ci: fix update-maintainers reference location (#7357) ``         |
| [`77bb9e03`](https://github.com/nix-community/home-manager/commit/77bb9e033b500a7111cee096555d510b715a3fb3) | `` ci: add update-maintainers.yml ``                                |
| [`11db5613`](https://github.com/nix-community/home-manager/commit/11db56137d1efbf663f614c7714c9224d4dd818d) | `` all-maintainers.nix: initial creation ``                         |
| [`44a2308d`](https://github.com/nix-community/home-manager/commit/44a2308db94b063c8dcb6505f61fdd225e571041) | `` scripts/generate-all-maintainers.py: add script ``               |
| [`479f8889`](https://github.com/nix-community/home-manager/commit/479f8889675770881033878a1c114fbfc6de7a4d) | `` bash: support path in sessionVariables again (#7354) ``          |
| [`96354906`](https://github.com/nix-community/home-manager/commit/96354906f58464605ff81d2f6c2ea23211cbf051) | `` files: show better error when file would be clobbered (#7348) `` |
| [`40741217`](https://github.com/nix-community/home-manager/commit/40741217965a63be07dcfcf51865d6f65ef88e71) | `` nh: update maintainers ``                                        |
| [`e8a3e2c1`](https://github.com/nix-community/home-manager/commit/e8a3e2c1e06c1dd488292929f7263ccfa765c7d8) | `` nh: fix clean option behaviour for Darwin ``                     |