### PR TITLE
chore(flake/stylix): `4ead8043` -> `5b257989`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -384,16 +384,16 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
-        "lastModified": 1744584021,
-        "narHash": "sha256-0RJ4mJzf+klKF4Fuoc8VN8dpQQtZnKksFmR2jhWE1Ew=",
+        "lastModified": 1748186689,
+        "narHash": "sha256-UaD7Y9f8iuLBMGHXeJlRu6U1Ggw5B9JnkFs3enZlap0=",
         "owner": "GNOME",
         "repo": "gnome-shell",
-        "rev": "52c517c8f6c199a1d6f5118fae500ef69ea845ae",
+        "rev": "8c88f917db0f1f0d80fa55206c863d3746fa18d0",
         "type": "github"
       },
       "original": {
         "owner": "GNOME",
-        "ref": "48.1",
+        "ref": "48.2",
         "repo": "gnome-shell",
         "type": "github"
       }
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751296480,
-        "narHash": "sha256-PMuzVs9khM7cYrjUCXQeV2OP6WVtbsmdZwa4Cc21y0o=",
+        "lastModified": 1751405764,
+        "narHash": "sha256-romzrDMOWMPZioeChZnrugwaUSpROfkWClHhWHuRnRQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "4ead8043f70cc3b951e704a1f6e40c8a10230e61",
+        "rev": "5b257989a8337dddc22aa04a70d3665d0384abef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                     |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`5b257989`](https://github.com/nix-community/stylix/commit/5b257989a8337dddc22aa04a70d3665d0384abef) | `` gnome: update to GNOME 48.2 (#1559) ``                   |
| [`4bc15ef1`](https://github.com/nix-community/stylix/commit/4bc15ef13c970981e37506491e18d1158af9a70c) | `` blender: use mkTarget (#1509) ``                         |
| [`73b7d0f3`](https://github.com/nix-community/stylix/commit/73b7d0f30039b6e51a02a1cc29215565107ed6c7) | `` stylix: guard home-manager-integration config (#1494) `` |