### PR TITLE
chore(flake/nixpkgs): `30e2e285` -> `5c724ed1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -541,11 +541,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`7c250bf6`](https://github.com/NixOS/nixpkgs/commit/7c250bf676fb448a2ff187ac8c69e1f088211762) | `` python3Packages.vector: skip failing tests ``                                  |
| [`521e3e5e`](https://github.com/NixOS/nixpkgs/commit/521e3e5eca0d2f076fb4472ef5a36011b1a15559) | `` kdePackages.qt3d: unvendor assimp ``                                           |
| [`2d3d9f49`](https://github.com/NixOS/nixpkgs/commit/2d3d9f497192aa5f8dfd1a4281854816fec6cc76) | `` redis: disable aarch64-linux failing test ``                                   |
| [`769d76a9`](https://github.com/NixOS/nixpkgs/commit/769d76a998f8174f0a1ce36866488c900fc19689) | `` cargo-show-asm: 0.2.50 -> 0.2.51 ``                                            |
| [`3cff6377`](https://github.com/NixOS/nixpkgs/commit/3cff6377b8b46bf4cdaa6a61588e91c8cb8f30c1) | `` python3Packages.eheimdigital: 1.2.0 -> 1.3.0 ``                                |
| [`1158bd72`](https://github.com/NixOS/nixpkgs/commit/1158bd72f5d8d605dcecfd801bed43786a79403a) | `` assimp: remove ehmry from maintainers ``                                       |
| [`548dd365`](https://github.com/NixOS/nixpkgs/commit/548dd3651925a5b9617ab74dc97c40b5d6683c5c) | `` python3Packages.llama-cloud-services: 0.6.37 -> 0.6.41 ``                      |
| [`27661a11`](https://github.com/NixOS/nixpkgs/commit/27661a1142bada4e445b65c239ba3ca743a3cd22) | `` assimp: modernize ``                                                           |
| [`d3c1e174`](https://github.com/NixOS/nixpkgs/commit/d3c1e1747e9511fa32f7947fcf7fa62b3e9e311f) | `` vscode-extensions.amazonwebservices.amazon-q-vscode: 1.78.0 -> 1.81.0 ``       |
| [`2c30e009`](https://github.com/NixOS/nixpkgs/commit/2c30e0098416ca737100e22a073fd5e9c069c1db) | `` python3Packages.pyopencl: 2025.2.4 -> 2025.2.5 ``                              |
| [`e2d2b2c0`](https://github.com/NixOS/nixpkgs/commit/e2d2b2c0247cf32ae3ee081f3a094d698a3d19bd) | `` assimp: 5.4.3 -> 6.0.2 ``                                                      |
| [`4ade3719`](https://github.com/NixOS/nixpkgs/commit/4ade3719f09d94629f10e047c9caad9b93ca8038) | `` linuxKernel.kernels.linux_lqx: 6.15.3 -> 6.15.4 ``                             |
| [`7900a161`](https://github.com/NixOS/nixpkgs/commit/7900a1618fafca40373dec053a0823988ed2d937) | `` workflows/labels: manage "needs: reviewer" label ``                            |
| [`ba56fdf2`](https://github.com/NixOS/nixpkgs/commit/ba56fdf223f92773ec4a040d2f020c80cb4f187d) | `` outline: 0.84.0 -> 0.85.0 ``                                                   |
| [`1bb3dc0a`](https://github.com/NixOS/nixpkgs/commit/1bb3dc0af349865f9adafa74f837bd90c1553668) | `` vscode-extensions.ms-windows-ai-studio.windows-ai-studio: 0.14.4 -> 0.16.0 ``  |
| [`796805d8`](https://github.com/NixOS/nixpkgs/commit/796805d84961c36d431d6c5abb9cb10701ebc6db) | `` vscode-extensions.coder.coder-remote: 1.9.1 -> 1.9.2 ``                        |
| [`87405d27`](https://github.com/NixOS/nixpkgs/commit/87405d273b0789342228865717285dd845e480ac) | `` tailwindcss-language-server: use lts versions of nodejs ``                     |
| [`58332290`](https://github.com/NixOS/nixpkgs/commit/58332290833b3de7ba4f3638b81ab33ca31b157b) | `` tailwindcss-language-server: 0.14.23 -> 0.14.24 ``                             |
| [`6faad7b2`](https://github.com/NixOS/nixpkgs/commit/6faad7b27b63726858972998b55e1b3409d2d8b0) | `` postgresqlPackages.plpgsql_check: 2.7.15 -> 2.8.1 ``                           |
| [`723a2b2e`](https://github.com/NixOS/nixpkgs/commit/723a2b2ea413ff4bb87a0431f69e56798cf85a7a) | `` python3Packages.sagemaker-core: 1.0.40 -> 1.0.41 ``                            |
| [`60518786`](https://github.com/NixOS/nixpkgs/commit/60518786eb58aaf37fe7136dbd3335f9053250f9) | `` dsda-doom: 0.29.2 -> 0.29.3 ``                                                 |
| [`02c8cf76`](https://github.com/NixOS/nixpkgs/commit/02c8cf76fa97b9098b58cae9204c861fdaba6cba) | `` python312Packages.pytenable: 1.7.5 -> 1.8.0 ``                                 |
| [`a5b800ae`](https://github.com/NixOS/nixpkgs/commit/a5b800ae223ff5e3de25ea8b779a1683bf73d640) | `` python312Packages.tencentcloud-sdk-python: 3.0.1411 -> 3.0.1415 ``             |
| [`aee88f2b`](https://github.com/NixOS/nixpkgs/commit/aee88f2b2356333aa31366ebf6621a000a869a9c) | `` python313Packages.twilio: 9.6.3 -> 9.6.4 ``                                    |
| [`85aeb23b`](https://github.com/NixOS/nixpkgs/commit/85aeb23b3ce072bf8cb6958f7cb13f346e0a5037) | `` python313Packages.pyexploitdb: 0.2.86 -> 0.2.87 ``                             |
| [`af8629cb`](https://github.com/NixOS/nixpkgs/commit/af8629cb02d134e97ad667e11e69c740a2548da2) | `` python313Packages.cyclopts: 3.20.0 -> 3.22.1 ``                                |
| [`ef823da6`](https://github.com/NixOS/nixpkgs/commit/ef823da61c9abb88dd4424fa523cde1d25c335ea) | `` python313Packages.banks: 2.1.2 -> 2.1.3 ``                                     |
| [`483a7722`](https://github.com/NixOS/nixpkgs/commit/483a772236cfc2db54b537c346622fbc12abda36) | `` python313Packages.aliyun-python-sdk-sts: 3.1.2 -> 3.1.3 ``                     |
| [`24ed1ffd`](https://github.com/NixOS/nixpkgs/commit/24ed1ffd00c86292bc138969023f00eaedbbe3e8) | `` python313Packages.androidtvremote2: 0.2.2 -> 0.2.3 ``                          |
| [`76cdff31`](https://github.com/NixOS/nixpkgs/commit/76cdff319a7acf5f1f03a8f76bf7e1f036bb3c02) | `` nuclei-templates: 10.2.3 -> 10.2.4 ``                                          |
| [`d23be9b4`](https://github.com/NixOS/nixpkgs/commit/d23be9b417dde2cb9ab1e720b3a13d54f12b5827) | `` php84: 8.4.8 -> 8.4.10 ``                                                      |
| [`629b7488`](https://github.com/NixOS/nixpkgs/commit/629b7488d740100d4e980214399b2561d9594a03) | `` php83: 8.3.22 -> 8.2.23 ``                                                     |
| [`f8792321`](https://github.com/NixOS/nixpkgs/commit/f8792321d725579e3c36a5c8f59049ce0d5b135f) | `` php82: 8.2.28 -> 8.2.29 ``                                                     |
| [`b5309c00`](https://github.com/NixOS/nixpkgs/commit/b5309c0046853bb20b4aeb6fd43998f8645e81e5) | `` php81: 8.1.32 -> 8.1.33 ``                                                     |
| [`2107c026`](https://github.com/NixOS/nixpkgs/commit/2107c026520178cfc6533b2f1e7a7af3ec1c949d) | `` coqPackages.VST: adapt to master ``                                            |
| [`e46146c8`](https://github.com/NixOS/nixpkgs/commit/e46146c876b4aae60d7d8b5336d847e9271f1b6b) | `` python3Packages.signxml: 4.0.5 -> 4.1.0 ``                                     |
| [`fcecbfc9`](https://github.com/NixOS/nixpkgs/commit/fcecbfc9bf9c75aa8bc22d371e57cea3fc609ba8) | `` gnugrep: Fix MinGW Build ``                                                    |
| [`0e020ac9`](https://github.com/NixOS/nixpkgs/commit/0e020ac941453e78455c9ba3d816609b843679a3) | `` mdbook-d2: 0.3.5 -> 0.3.6 ``                                                   |
| [`cafdbe22`](https://github.com/NixOS/nixpkgs/commit/cafdbe221c27f3f1f4d666050972f536c89d65ab) | `` pcsx2: get gtk dialogs working (#421226) ``                                    |
| [`0c398f13`](https://github.com/NixOS/nixpkgs/commit/0c398f13b80569b1ace88bb7790671efa42f14a4) | `` xscreensaver: 6.10.1 -> 6.11 ``                                                |
| [`aff5e54b`](https://github.com/NixOS/nixpkgs/commit/aff5e54bf25f9bcf8819cacf317ed1874ad674f4) | `` wl-clipboard-rs: 0.9.1 -> 0.9.2 ``                                             |
| [`03939543`](https://github.com/NixOS/nixpkgs/commit/039395433f432a12c04b64101215a9cf2c2ad3f5) | `` phpPackages.phan: 5.4.6 -> 5.5.0 ``                                            |
| [`526be080`](https://github.com/NixOS/nixpkgs/commit/526be0801f1de54bb89b82500e8228277df75b14) | `` maple-font: 7.3 -> 7.4 ``                                                      |
| [`d9079a62`](https://github.com/NixOS/nixpkgs/commit/d9079a62dbfe50ce5d2a972d127194210602d709) | `` libsForQt5.ktouch: remove ``                                                   |
| [`9f0ba6c1`](https://github.com/NixOS/nixpkgs/commit/9f0ba6c169f7875622a43662d1668ab2dc869d2d) | `` waybar-lyric: init at 0.10.0 ``                                                |
| [`79320c69`](https://github.com/NixOS/nixpkgs/commit/79320c69068fc21d89e73d60ba14165f498cd1d1) | `` kluctl: 2.26.0 -> 2.27.0 ``                                                    |
| [`970f64a0`](https://github.com/NixOS/nixpkgs/commit/970f64a0e9880053529d40720383757e4f11be06) | `` code-cursor: 1.1.3 -> 1.2.1 ``                                                 |
| [`5b6b23ca`](https://github.com/NixOS/nixpkgs/commit/5b6b23cae1e5f1d042cbfd7136abde4384c327ae) | `` git-repo-updater: Add myself to maintainers ``                                 |
| [`5af05b24`](https://github.com/NixOS/nixpkgs/commit/5af05b24fc607ebc3d6e76d49b3754d5eec8754d) | `` treewide: drop maintainership of packages I don't really maintain ``           |
| [`5e86f9d4`](https://github.com/NixOS/nixpkgs/commit/5e86f9d4b7525a658ad07c4a5fcb211de6166b7b) | `` sqlite-interactive: fix `readline` autodetection ``                            |
| [`fbbb0f9b`](https://github.com/NixOS/nixpkgs/commit/fbbb0f9bd9e27868805cd5d01b91281ce1463399) | `` libretro.pcsx2: 0-unstable-2025-03-15 -> 0-unstable-2025-07-03 ``              |
| [`e97badfd`](https://github.com/NixOS/nixpkgs/commit/e97badfdd741366fa50f71e7b921c64807911f08) | `` nixos/ups: add package option ``                                               |
| [`ea687641`](https://github.com/NixOS/nixpkgs/commit/ea6876416bc809f40ce46248d7bc9c050cd70744) | `` nut: add override for apc_modbus feature ``                                    |
| [`819775e8`](https://github.com/NixOS/nixpkgs/commit/819775e8452635cc4884d991a589df1dec82626c) | `` python3Packages.pylance: 0.30.0 -> 0.31.0 ``                                   |
| [`c49a11ff`](https://github.com/NixOS/nixpkgs/commit/c49a11ff5b968870f2f9e2ed63138760474aaa41) | `` cgns: init at 4.5.0 ``                                                         |
| [`acbe99ca`](https://github.com/NixOS/nixpkgs/commit/acbe99ca03955f2fd5d8a895b2b5e8519762015d) | `` ruff: 0.12.1 -> 0.12.2 ``                                                      |
| [`3b666d62`](https://github.com/NixOS/nixpkgs/commit/3b666d62d7e704792dfec67846e960f8be15f936) | `` python3Packages.pytensor: 2.31.5 -> 2.31.6 ``                                  |
| [`81124a73`](https://github.com/NixOS/nixpkgs/commit/81124a7323468a7db9b9eabfcd6332ae310da30c) | `` python3Packages.flowmc: 0.4.4 -> 0.4.5 ``                                      |
| [`52e82b0b`](https://github.com/NixOS/nixpkgs/commit/52e82b0b04df1abc6f612ba7ef2ecd95eb69a356) | `` parallel-launcher: init at 8.2.0 ``                                            |
| [`1b64ff30`](https://github.com/NixOS/nixpkgs/commit/1b64ff30a2f28c12f562cfeb7789d64ea1b22f33) | `` maintainers: add vanadium5000 ``                                               |
| [`f612de9f`](https://github.com/NixOS/nixpkgs/commit/f612de9f22d82da27f347e8f90f2523f7052c569) | `` cargo-deb: 2.12.1 -> 3.2.0 ``                                                  |
| [`d695adb2`](https://github.com/NixOS/nixpkgs/commit/d695adb2bed9ac88cb9a98fcfc28f601bf6db885) | `` python312Packages.tencentcloud-sdk-python: 3.0.1410 -> 3.0.1411 ``             |
| [`350b666a`](https://github.com/NixOS/nixpkgs/commit/350b666a7332a96456b9318dbee4ea5e87b071e4) | `` star: cleanup and enable all unix platforms ``                                 |
| [`32b31ed2`](https://github.com/NixOS/nixpkgs/commit/32b31ed2de21293da375b9e5be68b9bac3dfb35d) | `` eza: 0.21.6 -> 0.22.0 ``                                                       |
| [`7c0d6e37`](https://github.com/NixOS/nixpkgs/commit/7c0d6e3759bdbcd7bc6c1370604b28a8497d5960) | `` rundeck-cli: 2.0.8 -> 2.0.9 ``                                                 |
| [`ed3f7f14`](https://github.com/NixOS/nixpkgs/commit/ed3f7f140a7f71043986402dad8f8ef8fbb09f53) | `` rundeck-cli: replace `jdk` with `jre11_minimal_headless` ``                    |
| [`5bc9bd32`](https://github.com/NixOS/nixpkgs/commit/5bc9bd32b7894eee908ae35f8b3df2dbc1540133) | `` claude-code: 1.0.38 -> 1.0.41 ``                                               |
| [`5a26e97f`](https://github.com/NixOS/nixpkgs/commit/5a26e97ffe6d16eba5dc546188f5c4da3c0cf657) | `` phpExtensions.vld: 0.18.0-unstable-2024-08-22 -> 0.19.0 ``                     |
| [`192d1340`](https://github.com/NixOS/nixpkgs/commit/192d13403762b4951ae68f34e87e65e1f0f8ded1) | `` kdePackages: Gear 25.04.2 -> 25.04.3 ``                                        |
| [`0a285ce9`](https://github.com/NixOS/nixpkgs/commit/0a285ce966c4a37dd8e06477244403292c4a9ca9) | `` scala-cli: 1.8.2 -> 1.8.3 ``                                                   |
| [`e031c5ff`](https://github.com/NixOS/nixpkgs/commit/e031c5ff6b49c208fccdd701b448da7ae36afd3d) | `` nixos/postgresql: add section about pg_config ``                               |
| [`7de41892`](https://github.com/NixOS/nixpkgs/commit/7de41892091f45a417908ae6f6c0e021d0120bec) | `` firefox-beta-unwrapped: 141.0b4 -> 141.0b5 ``                                  |
| [`b62c5b49`](https://github.com/NixOS/nixpkgs/commit/b62c5b499fc3c2572f4bf4d47852c6b983e4d800) | `` jre11_minimal: init at 11.0.26 ``                                              |
| [`2a76484e`](https://github.com/NixOS/nixpkgs/commit/2a76484e23d63ffaf19fe3ddb3dce76cdfd828f2) | `` diebahn: 2.8.1 -> 2.8.2 ``                                                     |
| [`f6e2b493`](https://github.com/NixOS/nixpkgs/commit/f6e2b4930f3757d850964a7bc45ed8c79ea058ae) | `` home-assistant-custom-components.oref_alert: 2.22.1 -> 3.1.3 ``                |
| [`dbcd3fce`](https://github.com/NixOS/nixpkgs/commit/dbcd3fcef426d58b8e9011ec9d6d7caa3dab06f9) | `` xbill: add platforms ``                                                        |
| [`5b6c3928`](https://github.com/NixOS/nixpkgs/commit/5b6c39281b689bc1db7d6b32bcef70bff44aacda) | `` turbo: add shell completions ``                                                |
| [`43c0e5c3`](https://github.com/NixOS/nixpkgs/commit/43c0e5c366e648542a230d777f6f4504e1a671b6) | `` python312Packages.botocore-stubs: 1.38.30 -> 1.38.46 ``                        |
| [`7edddcfc`](https://github.com/NixOS/nixpkgs/commit/7edddcfc23e66f5d773b3e6c352090e3d1ad57f9) | `` python312Packages.boto3-stubs: 1.38.46 -> 1.39.2 ``                            |
| [`9e6bc90d`](https://github.com/NixOS/nixpkgs/commit/9e6bc90d9b6073159f87af199a4ca6e8cdcc5221) | `` python3Packages.awsiotsdk: 1.23.0 -> 1.24.0 ``                                 |
| [`5cb1f85e`](https://github.com/NixOS/nixpkgs/commit/5cb1f85e4aed54de286e46f20ff57815da139fdf) | `` git-repo-updater: 0.5.1 -> 0.5.2 ``                                            |
| [`771770ca`](https://github.com/NixOS/nixpkgs/commit/771770ca5b790056731846034caeae66dc977a49) | `` mapproxy: 4.1.2 → 5.0.0 ``                                                     |
| [`8157f8da`](https://github.com/NixOS/nixpkgs/commit/8157f8da213157499f735fb9503aa7867030da6b) | `` golangci-lint: 2.1.6 -> 2.2.1 (#421854) ``                                     |
| [`53b89aca`](https://github.com/NixOS/nixpkgs/commit/53b89aca2becb7ac2a28dfe91590e16784ad0aeb) | `` postgresqlPackages.omnigres: 0-unstable-2025-06-03 -> 0-unstable-2025-06-27 `` |
| [`f6df92d9`](https://github.com/NixOS/nixpkgs/commit/f6df92d9d9b1ec960314b1ab56f07fb2894dec7d) | `` chirpstack-rest-api: 4.12.0 -> 4.13.0 ``                                       |
| [`31a8d4af`](https://github.com/NixOS/nixpkgs/commit/31a8d4af12a5391011acef043da3d46bd6eb64f1) | `` python3Packages.py-ocsf-models: 0.5.0 -> 0.6.0 ``                              |
| [`9210794c`](https://github.com/NixOS/nixpkgs/commit/9210794c425f0405d4ceb4c3fbc6bd4888ea0273) | `` esphome: 2025.6.2 -> 2025.6.3 ``                                               |
| [`53c316d5`](https://github.com/NixOS/nixpkgs/commit/53c316d5e795a062e1e0aa60c87c6d27727551ba) | `` paretosecurity: 0.2.36 -> 0.2.37 ``                                            |
| [`1b12701e`](https://github.com/NixOS/nixpkgs/commit/1b12701e6b4121bb3eb305c337316f83b002eb39) | `` maintainers: add jonhermansen ``                                               |
| [`c6e4c59f`](https://github.com/NixOS/nixpkgs/commit/c6e4c59f1c84de44a66773a8878410487228962a) | `` xbill: fix build ``                                                            |
| [`f88e1c39`](https://github.com/NixOS/nixpkgs/commit/f88e1c39e9839875283eb2f9ba58403333e1b23b) | `` treewide: move StartLimitIntervalSec/StartLimitBurst to unitConfig ``          |
| [`3225bfda`](https://github.com/NixOS/nixpkgs/commit/3225bfdadb380c7b4aaeae811dacdccd4ab69a20) | `` python313Packages.wavinsentio: refactor ``                                     |