### PR TITLE
chore(flake/stylix): `5b257989` -> `9b4ecf4a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751405764,
-        "narHash": "sha256-romzrDMOWMPZioeChZnrugwaUSpROfkWClHhWHuRnRQ=",
+        "lastModified": 1751570224,
+        "narHash": "sha256-ZZ6BH0g6Th9OttOdHw7cDaTbbaGdrSoYJBswt5gfUiU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5b257989a8337dddc22aa04a70d3665d0384abef",
+        "rev": "9b4ecf4aca38f329fc53d35bef32479c30ea74d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                           |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`9b4ecf4a`](https://github.com/nix-community/stylix/commit/9b4ecf4aca38f329fc53d35bef32479c30ea74d6) | `` doc: fix testbed special option doc (#1574) `` |
| [`7da2bbd4`](https://github.com/nix-community/stylix/commit/7da2bbd49e7a399ef2c150e04d0259a151a2e1c7) | `` zed: add testbed (#1575) ``                    |
| [`6fe3f448`](https://github.com/nix-community/stylix/commit/6fe3f44852ddf4085537892c591662853f92eb6d) | `` micro: add testbed (#1572) ``                  |
| [`52401c32`](https://github.com/nix-community/stylix/commit/52401c32651ff1cd94c33fc8aba5f50253a64bc5) | `` ncspot: add testbed (#1573) ``                 |
| [`ecfb0936`](https://github.com/nix-community/stylix/commit/ecfb093658f9101432563014d0d88cb747fe1b80) | `` tmux: add testbed (#1577) ``                   |
| [`d21cfb36`](https://github.com/nix-community/stylix/commit/d21cfb364a78ad72935625e79b8c5d497f0b7616) | `` ashell: fix use of opacity option (#1576) ``   |
| [`3f71d154`](https://github.com/nix-community/stylix/commit/3f71d154867b457adbef04b4982e78b5dc225e62) | `` ashell: init `(#1552) ``                       |