### PR TITLE
chore(flake/home-manager): `e96a8a32` -> `a5b56720`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751411489,
-        "narHash": "sha256-x+AJyQ5+4EPDU3NnQ1OPP/KuoG0C6UrbgptEW6PSLQ8=",
+        "lastModified": 1751500614,
+        "narHash": "sha256-mYiYNsTJkbQouC5YHOTgqVpjpELoNf9f4z5ZeY4NfPg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e96a8a325cf23538a7f58b9335b4c4c0b393bacf",
+        "rev": "a5b56720841121d2189c011e445c4be4c943bab5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`a5b56720`](https://github.com/nix-community/home-manager/commit/a5b56720841121d2189c011e445c4be4c943bab5) | `` kitty: add config change signal on darwin (#7375) ``        |
| [`89af52d9`](https://github.com/nix-community/home-manager/commit/89af52d9a893af013f5f4c1d2d56912106827153) | `` tests/firefox: add extension user.js test ``                |
| [`1b25908d`](https://github.com/nix-community/home-manager/commit/1b25908d1dc6832c3cced1aba29b6ff932b6a0bd) | `` firefox: fix user.js extensions.settings creation ``        |
| [`25f003f8`](https://github.com/nix-community/home-manager/commit/25f003f8a9eae31a11938d53cb23e0b4a3c08d3a) | `` ci: tag maintainers automatically for PR reviews (#6921) `` |
| [`9347c61b`](https://github.com/nix-community/home-manager/commit/9347c61bc0cbed0d2062b930144c2cbd557f9189) | `` ci: use GITHUB_TOKEN when app config missing (#7374) ``     |
| [`a7820832`](https://github.com/nix-community/home-manager/commit/a7820832c68180b612587a23f46f1b94a28b3407) | `` ci: fix update-maintainers indentation (#7372) ``           |
| [`bafcf336`](https://github.com/nix-community/home-manager/commit/bafcf336870c9daca80df1c4a09ef926fc497016) | `` ci: use env in update-maintainers changes summary ``        |
| [`be8f7e10`](https://github.com/nix-community/home-manager/commit/be8f7e100f285167793f7ff77ce8e5b60ab48e26) | `` ci: move update-maintainers commit/pr to env ``             |
| [`7241b18a`](https://github.com/nix-community/home-manager/commit/7241b18a7bdaec265b26a7951557a1a1e367d4f8) | `` ci: make update-maintainers check-changes multiline ``      |
| [`7c455533`](https://github.com/nix-community/home-manager/commit/7c455533409411b4053bb6d7db71eb35e0544254) | `` mpvpaper: fix eval if no settings are defined (#7370) ``    |
| [`3d243d4a`](https://github.com/nix-community/home-manager/commit/3d243d4a16cafe855df585b3030aa99261a27a86) | `` ci: fix which branch to show on pr (#7368) ``               |
| [`77027882`](https://github.com/nix-community/home-manager/commit/77027882a7f637f84f7c221406b75f1463f5a321) | `` ci: prefix flake update prs (#7366) ``                      |
| [`4bd46345`](https://github.com/nix-community/home-manager/commit/4bd4634525150766b96facdb8a35bb991de67956) | `` ci: fix update-flake branch inputs (#7345) ``               |
| [`6c53df3b`](https://github.com/nix-community/home-manager/commit/6c53df3b9c809e3b4b30d515e18bfa4c6f079254) | `` flake.lock: Update (#7363) ``                               |
| [`df122690`](https://github.com/nix-community/home-manager/commit/df12269039dcf752600b1bcc176bacf2786ec384) | `` maintainers: update all-maintainers.nix (#7361) ``          |
| [`29d717aa`](https://github.com/nix-community/home-manager/commit/29d717aab5189b3383d965928823ddac8a95e8f3) | `` ci: tests fetch nixpkgs from flake.lock rev ``              |
| [`212f4a4f`](https://github.com/nix-community/home-manager/commit/212f4a4fb20449d51bbc403e3d140778aab4d18a) | `` ci: update-maintainers fetch nixpkgs from flake.lock rev `` |
| [`121b430d`](https://github.com/nix-community/home-manager/commit/121b430df7b5c5eeb9d37dff2a3ba1883a9e51e1) | `` maintainers: fix incorrect entries (#7360) ``               |