### PR TITLE
chore(flake/home-manager): `a5b56720` -> `83f97881`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751500614,
-        "narHash": "sha256-mYiYNsTJkbQouC5YHOTgqVpjpELoNf9f4z5ZeY4NfPg=",
+        "lastModified": 1751589297,
+        "narHash": "sha256-3q35cq6BPuwIRL3IoVKYPc72r3OleeuRyf4YAPjEqzA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a5b56720841121d2189c011e445c4be4c943bab5",
+        "rev": "83f978812c37511ef2ffaf75ffa72160483f738a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`83f97881`](https://github.com/nix-community/home-manager/commit/83f978812c37511ef2ffaf75ffa72160483f738a) | `` podman: support mounts configuration (#7377) ``                         |
| [`402333d5`](https://github.com/nix-community/home-manager/commit/402333d5ec2f9eed0f2584555936361f39d2f93e) | `` ci: concurrency protect tag flow ``                                     |
| [`03c3576f`](https://github.com/nix-community/home-manager/commit/03c3576f8b7e3d2154fba3f450e2bfd942024e1e) | `` ci: remove unneeded reviewers ``                                        |
| [`7582cbfa`](https://github.com/nix-community/home-manager/commit/7582cbfabce2ff1626083f1c73a2e3c74ee4cf40) | `` ci: check for new maintainers on updates ``                             |
| [`7044c3ec`](https://github.com/nix-community/home-manager/commit/7044c3eced5319148c09fe9612659765b9297d4a) | `` ci: tag-maintainers fix fetching maintainers (#7380) ``                 |
| [`09ef413c`](https://github.com/nix-community/home-manager/commit/09ef413c804bde7afc259c67b2dcb4cc999913f6) | `` all-maintainers: update ``                                              |
| [`d03fa2d8`](https://github.com/nix-community/home-manager/commit/d03fa2d84c6c7def463f9ff90d6a36d5873de0fc) | `` ci: generate-all-maintainers use nix eval update ``                     |
| [`b46c6937`](https://github.com/nix-community/home-manager/commit/b46c6937970a3dc3141136134f8244b5a928a7f6) | `` lib: add extract-maintainers-meta ``                                    |
| [`28639e64`](https://github.com/nix-community/home-manager/commit/28639e6470ef597fe9f5efc4c6594306859d62ed) | `` ci: cancel previous runs (#7378) ``                                     |
| [`1fa73bb2`](https://github.com/nix-community/home-manager/commit/1fa73bb2cc39e250eb01e511ae6ac83bfbf9f38c) | `` fix(service/gpg-agent): allow SSH ForwardAgent compatibility (#7355) `` |
| [`b182e64c`](https://github.com/nix-community/home-manager/commit/b182e64c01aa4e61a007691525a3ea498a9aee63) | `` zed-editor: survive if previous files are not JSON5 (#7351) ``          |
| [`426b405d`](https://github.com/nix-community/home-manager/commit/426b405d979d893832549b95f23c13537c65d244) | `` ci: add validation workflow for maintainers list ``                     |
| [`66de606f`](https://github.com/nix-community/home-manager/commit/66de606f48f789b0a407d842714de8dd01893dc5) | `` ci: update all-maintainers on merge ``                                  |