### PR TITLE
chore(flake/stylix): `9b4ecf4a` -> `606944b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751570224,
-        "narHash": "sha256-ZZ6BH0g6Th9OttOdHw7cDaTbbaGdrSoYJBswt5gfUiU=",
+        "lastModified": 1751656637,
+        "narHash": "sha256-x1uJ6wQ7C+N/Zx9liQzjyVOEwGf5tcKogSoGgxASZOg=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9b4ecf4aca38f329fc53d35bef32479c30ea74d6",
+        "rev": "606944b16862d43934fec3311f9cb9f478b7f99b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                      |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`606944b1`](https://github.com/nix-community/stylix/commit/606944b16862d43934fec3311f9cb9f478b7f99b) | `` rofi: fix mkTarget usage (#1593) ``                                       |
| [`6b2898a6`](https://github.com/nix-community/stylix/commit/6b2898a6b7d6fc1956d808d285a1b4ceaf0ca56e) | `` mako: add testbed (#1192) ``                                              |
| [`dea0337e`](https://github.com/nix-community/stylix/commit/dea0337e0bffeeeb941ca6caffb44e966b13a97b) | `` stylix: restrict access to config while using mkTarget (#1368) ``         |
| [`85d84607`](https://github.com/nix-community/stylix/commit/85d84607b2d4a28178f2ec0238ac5eed8e39cd71) | `` flake: sort pre-commit hooks and formatters (#1586) ``                    |
| [`732c666b`](https://github.com/nix-community/stylix/commit/732c666ba54a724bb90d76a1b6f1417bc4823235) | `` ci: fix dependabot backport label (#1585) ``                              |
| [`127fe6cc`](https://github.com/nix-community/stylix/commit/127fe6cc3de1ab0bc2f38eba7469d7a53e306eb1) | `` ci: bump DeterminateSystems/update-flake-lock from 25 to 26 (#1583) ``    |
| [`2fee88f2`](https://github.com/nix-community/stylix/commit/2fee88f2813ad9fbcefc20e5bd39af336cf5b9f3) | `` fuzzel: apply iconTheme (#1497) ``                                        |
| [`825d7911`](https://github.com/nix-community/stylix/commit/825d79112f7a7480a00784e2dcdd91ffadf2d263) | `` nixos-icons: pad hex color values with leading zeros (#1584) ``           |
| [`3c73dee2`](https://github.com/nix-community/stylix/commit/3c73dee2dbdf242a16a6e929f3e574dd0694d85a) | `` ci: bump DeterminateSystems/nix-installer-action from 17 to 18 (#1582) `` |