### PR TITLE
chore(flake/home-manager): `7d9e3c35` -> `8b0180dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -405,11 +405,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751638848,
-        "narHash": "sha256-7HiC6w4ROEbMmKtj5pilnLOJej9HkkfU9wEd5QSTyNo=",
+        "lastModified": 1751760902,
+        "narHash": "sha256-qBGNn7T/zOgUDQTo/RM/D2oxMkB2x36j3ajvpVanEVs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7d9e3c35f0d46f82bac791d76260f15f53d83529",
+        "rev": "8b0180dde1d6f4cf632e046309e8f963924dfbd0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`8b0180dd`](https://github.com/nix-community/home-manager/commit/8b0180dde1d6f4cf632e046309e8f963924dfbd0) | `` maintainers: update all-maintainers.nix (#7392) ``                               |
| [`af8a8841`](https://github.com/nix-community/home-manager/commit/af8a884164bb50ad34c09719bdbdb2a1b01b917c) | `` kubeswitch: add module ``                                                        |
| [`92db5be8`](https://github.com/nix-community/home-manager/commit/92db5be8e17c5150c46a2ca8f55a85d20df75643) | `` maintainers: add m0nsterrr ``                                                    |
| [`5a49fe44`](https://github.com/nix-community/home-manager/commit/5a49fe448e81ee05ab48ed3189109b322237ddbf) | `` opencode: init (#7320) ``                                                        |
| [`f117b383`](https://github.com/nix-community/home-manager/commit/f117b383dd591fd579bce5ee7bac07a3fdc1d050) | `` numbat: Allow specifying a path for initFile ``                                  |
| [`26d405da`](https://github.com/nix-community/home-manager/commit/26d405da4179c7dafc0a84e611edfa2f5ddf7faa) | `` numbat: Add initFile option ``                                                   |
| [`d75a5474`](https://github.com/nix-community/home-manager/commit/d75a547415f08a52a1e8fc84a1bef9e48bba4c5c) | `` programs.msmtp: merge extraConfig and extraAccount into configContent (#7385) `` |
| [`36c57c6a`](https://github.com/nix-community/home-manager/commit/36c57c6a1d03a5efbf5e23c04dbe21259d25f992) | `` lib/deprecations: add ignore parameter to remapAttrsRecursive ``                 |
| [`650a38eb`](https://github.com/nix-community/home-manager/commit/650a38ebe819d439ece41b5a1c510b3244896265) | `` ashell: support yaml and toml config ``                                          |
| [`f62e9a81`](https://github.com/nix-community/home-manager/commit/f62e9a8114bc181ae160c9a1d7ce8205fa5619b0) | `` lib/strings: add extra string matching predicates ``                             |
| [`19f0ba9c`](https://github.com/nix-community/home-manager/commit/19f0ba9c52f30c1a26e816a05bddf6b4aa9e327d) | `` lib/deprecations: add remapAttrsRecursive ``                                     |
| [`a4fc77c6`](https://github.com/nix-community/home-manager/commit/a4fc77c63d41b74f156f25fb34be905527865028) | `` ashell: new ashell 0.5.0 config standards ``                                     |
| [`e8da7372`](https://github.com/nix-community/home-manager/commit/e8da7372fd1f0da3fe3874af3aa9ddd78662d8ae) | `` anki: add module (#7274) ``                                                      |
| [`57d1027e`](https://github.com/nix-community/home-manager/commit/57d1027e1eaf1220342248ff18d34f42b0beea7b) | `` aerc: allow config sections to be lines (#7280) ``                               |