### PR TITLE
chore(flake/stylix): `606944b1` -> `5259682c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -135,21 +135,6 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
-      "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -290,32 +275,6 @@
         "type": "github"
       }
     },
-    "git-hooks_3": {
-      "inputs": {
-        "flake-compat": [
-          "stylix",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_3",
-        "nixpkgs": [
-          "stylix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -341,28 +300,6 @@
       "inputs": {
         "nixpkgs": [
           "nixvim-flake",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_3": {
-      "inputs": {
-        "nixpkgs": [
-          "stylix",
           "git-hooks",
           "nixpkgs"
         ]
@@ -692,13 +629,8 @@
         "base16-helix": "base16-helix",
         "base16-vim": "base16-vim",
         "firefox-gnome-theme": "firefox-gnome-theme",
-        "flake-compat": "flake-compat_3",
         "flake-parts": "flake-parts_3",
-        "git-hooks": "git-hooks_3",
         "gnome-shell": "gnome-shell",
-        "home-manager": [
-          "home-manager"
-        ],
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -711,11 +643,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751656637,
-        "narHash": "sha256-x1uJ6wQ7C+N/Zx9liQzjyVOEwGf5tcKogSoGgxASZOg=",
+        "lastModified": 1751840923,
+        "narHash": "sha256-4HZxn+PrWytrWVg5c5SEetv3m9/k7rngJq27zKuRIfo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "606944b16862d43934fec3311f9cb9f478b7f99b",
+        "rev": "5259682ce58d935f248297bf1c9793a5cee0787e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`5259682c`](https://github.com/nix-community/stylix/commit/5259682ce58d935f248297bf1c9793a5cee0787e) | `` cava: add testbed (#1617) ``                                             |
| [`a5c1532a`](https://github.com/nix-community/stylix/commit/a5c1532ab8bf9566331f83be91517e02132f3d99) | `` flake: partition dev inputs (#1289) ``                                   |
| [`a294d8b2`](https://github.com/nix-community/stylix/commit/a294d8b2a3d9c127e654eadbd6d8938353ec410f) | `` stylix: fix 'unguarded' typo (#1613) ``                                  |
| [`5cd1e4ff`](https://github.com/nix-community/stylix/commit/5cd1e4ffd9d1ad06d5dc3c3b08d8687ce95e4a08) | `` wayfire: remove illegal `config.stylix` access (#1609) ``                |
| [`bba3152b`](https://github.com/nix-community/stylix/commit/bba3152bd28b92f5fd051ef22f3c1d14fd6ce156) | `` treewide: standardize URL format by removing trailing slashes (#1566) `` |
| [`50ed5ddd`](https://github.com/nix-community/stylix/commit/50ed5ddd1072a6b10e6368cc338d759ffa02df9b) | `` {neovim, vim}: add testbeds (#1571) ``                                   |
| [`1bd6d031`](https://github.com/nix-community/stylix/commit/1bd6d031acacf64cef2b45a570d114f16c4b9ae6) | `` rio: use mkTarget (#1599) ``                                             |
| [`aca5e11a`](https://github.com/nix-community/stylix/commit/aca5e11a1fc8cf5b9aa73ba64433c64e06f328ff) | `` rio: add testbed (#1600) ``                                              |