### PR TITLE
chore(flake/nixvim-flake): `17aebb2f` -> `0e6ee776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1751414949,
-        "narHash": "sha256-vLGqlaHsvgvA1ozdcMtCGentlDru5UkvPt6f8uJ1gYI=",
+        "lastModified": 1751851538,
+        "narHash": "sha256-mfqGoKVtq7/vt0onTh68R8OuFBtvt4FQr6+Ves3xzSI=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "64b4f81619f1691dba8d886458911d553632b8bb",
+        "rev": "54a7a75eb1e69b3971f236710213a8894adde0ee",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1751767365,
-        "narHash": "sha256-M+f3eDsWy/VUMK4Jhld7QnWZuUnF+xkEwufp7UjcZGU=",
+        "lastModified": 1751853648,
+        "narHash": "sha256-7UFbvXYszx1CSgxTLQkZM8bRGHov/ibqBLZ6fx1PkiM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "17aebb2f3087e773dce90218771e3dedbe13ce91",
+        "rev": "0e6ee776307db5becc4cced76aed5b6bfa61bc79",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`0e6ee776`](https://github.com/alesauce/nixvim-flake/commit/0e6ee776307db5becc4cced76aed5b6bfa61bc79) | `` chore(flake/nix-fast-build): 64b4f816 -> 54a7a75e `` |