### PR TITLE
chore(flake/stylix): `5259682c` -> `bf0ef81c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -643,11 +643,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1751840923,
-        "narHash": "sha256-4HZxn+PrWytrWVg5c5SEetv3m9/k7rngJq27zKuRIfo=",
+        "lastModified": 1751914048,
+        "narHash": "sha256-xHO3xlw35tCC0f3pN3osPNjgwwwAgusTuZk5iC8oDiE=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5259682ce58d935f248297bf1c9793a5cee0787e",
+        "rev": "bf0ef81c8fcc30c32db9dab32d379f8d9db835e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                        |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`bf0ef81c`](https://github.com/nix-community/stylix/commit/bf0ef81c8fcc30c32db9dab32d379f8d9db835e4) | `` ci: fix testbed labeling (#1606) ``         |
| [`c538d1a3`](https://github.com/nix-community/stylix/commit/c538d1a3571386eaaca31aef7bb5fd5c155327b0) | `` regreet: use mkTarget (#1598) ``            |
| [`ad13dd4e`](https://github.com/nix-community/stylix/commit/ad13dd4eb2747b0ba10bc0f1f23bbe2f52f9c60e) | `` spicetify: use mkTarget ``                  |
| [`beefa934`](https://github.com/nix-community/stylix/commit/beefa934a66b768dc50d8cac9a48812f75172e47) | `` spicetify: remove redundent config check `` |