### PR TITLE
chore(flake/home-manager): `fd9e55f5` -> `206ed3c7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751824240,
-        "narHash": "sha256-aDDC0CHTlL7QDKWWhdbEgVPK6KwWt+ca0QkmHYZxMzI=",
+        "lastModified": 1752093218,
+        "narHash": "sha256-+3rXu8ewcNDi65/2mKkdSGrivQs5zEZVp5aYszXC0d0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fd9e55f5fac45a26f6169310afca64d56b681935",
+        "rev": "206ed3c71418b52e176f16f58805c96e84555320",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                           |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`206ed3c7`](https://github.com/nix-community/home-manager/commit/206ed3c71418b52e176f16f58805c96e84555320) | `` neomutt: improve error when no way to send mail ``             |
| [`bec8ff39`](https://github.com/nix-community/home-manager/commit/bec8ff39811568eb7c8c8d1e2a1a476326748f51) | `` wlogout: use lines for css style ``                            |
| [`218da00b`](https://github.com/nix-community/home-manager/commit/218da00bfa73f2a61682417efe74549416c16ba6) | `` firefoxpwa: add module (#7408) ``                              |
| [`5751fa77`](https://github.com/nix-community/home-manager/commit/5751fa774fa61837f35efb82f3b6e105d4c63ced) | `` twitch-tui: add module (#7416) ``                              |
| [`c0073055`](https://github.com/nix-community/home-manager/commit/c00730550e2dbcb4f8dd1552b3aa9d17d32d5ac6) | `` tray-tui: add module (#7415) ``                                |
| [`1edfb622`](https://github.com/nix-community/home-manager/commit/1edfb62244493fcdfc83304e7d166ba2c90b1553) | `` ci: bump DeterminateSystems/update-flake-lock from 25 to 26 `` |
| [`fa135487`](https://github.com/nix-community/home-manager/commit/fa135487acbfa186b3d545d4d4807b7be5510cd0) | `` issue_template: remove assignees ``                            |
| [`923782b2`](https://github.com/nix-community/home-manager/commit/923782b2c6e31aad339da898f80e103dc951dcc7) | `` issue_template: add new module request ``                      |
| [`619c84d9`](https://github.com/nix-community/home-manager/commit/619c84d9e03efcfb91b69b9f591846d0670aac13) | `` issue_template: update feature request ``                      |