### PR TITLE
chore(flake/nixvim-flake): `0e6ee776` -> `73968937`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1751746175,
-        "narHash": "sha256-6JABU+UMkaL4c+ZJRQYyFyIkm9ry1fOkhNQgSSjK5OM=",
+        "lastModified": 1751904655,
+        "narHash": "sha256-lHAj9Xh/vBf3cXns1wN5HPw/zwGTO/Uv/ttloBok1n4=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "ef0fa015a8236241bdcc27f32e6a4aa537d96cf8",
+        "rev": "bc997a240953bda9fa526e8a3d6f798a6072308a",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1751853648,
-        "narHash": "sha256-7UFbvXYszx1CSgxTLQkZM8bRGHov/ibqBLZ6fx1PkiM=",
+        "lastModified": 1751939733,
+        "narHash": "sha256-uPHk1WE80Z79gT8+cJFYkeRGYLq7N2+3kKNvAscAp/Y=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "0e6ee776307db5becc4cced76aed5b6bfa61bc79",
+        "rev": "739689378d726c01ad76437410dd739df47a5560",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`73968937`](https://github.com/alesauce/nixvim-flake/commit/739689378d726c01ad76437410dd739df47a5560) | `` chore(flake/nixvim): ef0fa015 -> bc997a24 `` |