### PR TITLE
chore(flake/stylix): `1d7a7814` -> `480649bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752012890,
-        "narHash": "sha256-ozqfSCB8vDqV+W4VF0+lwen50YWhFCNxp1ruCm/6bP8=",
+        "lastModified": 1752083519,
+        "narHash": "sha256-NbLWT1fOfyoNdt5ZH65h0JnGzF8uSZPsjdo5PmW2AHI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "1d7a78147d5f2f6c97beb41b7815ab9cd213ef81",
+        "rev": "480649bbdf8ef423c84a7152ceadf22839a5acbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                |
| ----------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`480649bb`](https://github.com/nix-community/stylix/commit/480649bbdf8ef423c84a7152ceadf22839a5acbb) | `` mako: fix testbed name (#1653) ``                                   |
| [`9028a74f`](https://github.com/nix-community/stylix/commit/9028a74f88d5ed31f4cff3483f3c143346ce43ea) | `` stylix: use isFunction (#1652) ``                                   |
| [`4eadb250`](https://github.com/nix-community/stylix/commit/4eadb2503b80f0251ff2c48856f9450474a70688) | `` stylix: guard against config.stylix.*.enable in mkTarget (#1640) `` |
| [`7b9a528d`](https://github.com/nix-community/stylix/commit/7b9a528d6ce61feef42ef3ede42792438e59e205) | `` treewide: replace builtins.toString with toString (#1657) ``        |
| [`82a1f36f`](https://github.com/nix-community/stylix/commit/82a1f36f80a0bdc9875c8b868ea6fe930b09887c) | `` ci: fix 'has: port to stable' labeling (#1621) ``                   |