### PR TITLE
chore(flake/stylix): `480649bb` -> `84e7ea0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752083519,
-        "narHash": "sha256-NbLWT1fOfyoNdt5ZH65h0JnGzF8uSZPsjdo5PmW2AHI=",
+        "lastModified": 1752170554,
+        "narHash": "sha256-4FY36NjEACoNXk8lSarwif/UJtABR9tCLxV9ro9p9RQ=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "480649bbdf8ef423c84a7152ceadf22839a5acbb",
+        "rev": "84e7ea0aa447fbc11293e76977302ab1ee0fab38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                          |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`84e7ea0a`](https://github.com/nix-community/stylix/commit/84e7ea0aa447fbc11293e76977302ab1ee0fab38) | `` {nixvim,nvf}: add testbeds (#1579) ``         |
| [`46d4a5d6`](https://github.com/nix-community/stylix/commit/46d4a5d694b125cd8c05372275b47ff10f2930aa) | `` i3: remove redudant legacy comment (#1656) `` |