### PR TITLE
chore(flake/home-manager): `206ed3c7` -> `3978bcd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752093218,
-        "narHash": "sha256-+3rXu8ewcNDi65/2mKkdSGrivQs5zEZVp5aYszXC0d0=",
+        "lastModified": 1752180332,
+        "narHash": "sha256-CCufHi/GclygJZbbsKyTvqylz5E3pH2oHFL9ycB8YMM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "206ed3c71418b52e176f16f58805c96e84555320",
+        "rev": "3978bcd6961847385121db30c58dbd444d4a73df",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                    |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`3978bcd6`](https://github.com/nix-community/home-manager/commit/3978bcd6961847385121db30c58dbd444d4a73df) | `` thunderbird: configure SMTP and GPG for aliases ``      |
| [`d52abd5b`](https://github.com/nix-community/home-manager/commit/d52abd5b525e2f4ccc57b07db9759d1a147472fd) | `` email: allow more extensive configuration of aliases `` |
| [`729c5e54`](https://github.com/nix-community/home-manager/commit/729c5e5465a0585b2c492a40d9308ec3ad78a296) | `` docker-cli: add module (#7411) ``                       |
| [`d52da303`](https://github.com/nix-community/home-manager/commit/d52da303efeb39d67fdedd08f7d8fc8efd5f4332) | `` firefox: add extension permissions (#7402) ``           |
| [`fb12dbbc`](https://github.com/nix-community/home-manager/commit/fb12dbbce39ca29919e2b45913ce244c54d009de) | `` lutris: make module x86_64-linux only (#7425) ``        |
| [`d81cb050`](https://github.com/nix-community/home-manager/commit/d81cb050f5530fc84aa0ddb421d50722ee662600) | `` hyprshell: add module (#7409) ``                        |
| [`50330593`](https://github.com/nix-community/home-manager/commit/50330593f33d0b873e0b6b05294164d093c0992a) | `` flake.lock: Update (#7419) ``                           |