### PR TITLE
chore(flake/stylix): `84e7ea0a` -> `0da583a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752170554,
-        "narHash": "sha256-4FY36NjEACoNXk8lSarwif/UJtABR9tCLxV9ro9p9RQ=",
+        "lastModified": 1752250117,
+        "narHash": "sha256-zCPV1a8w9hRn5ukOQwaAggA3X5cMmVsZVBYo8wLfLuU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "84e7ea0aa447fbc11293e76977302ab1ee0fab38",
+        "rev": "0da583a359fd911d5cbfd2c789424b888b777a4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                            |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`0da583a3`](https://github.com/nix-community/stylix/commit/0da583a359fd911d5cbfd2c789424b888b777a4b) | `` flake: update nvf dev input (#1673) ``                          |
| [`0150050d`](https://github.com/nix-community/stylix/commit/0150050d6eed373b04fd85e08bd2ae7b5cc8d3b2) | `` wayfire: mixup between wayfire and wf-shell settings (#1670) `` |
| [`458d2835`](https://github.com/nix-community/stylix/commit/458d283547015183db68b82f17244ad9bbce0ddf) | `` spicetify: make background color different from text (#1626) `` |
| [`d395780b`](https://github.com/nix-community/stylix/commit/d395780b9c5c36f191b990b2021c71af180a1982) | `` {i3,sway}: move deprecation alias out of imports (#1667) ``     |