### PR TITLE
chore(flake/home-manager): `3978bcd6` -> `3976e050`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752180332,
-        "narHash": "sha256-CCufHi/GclygJZbbsKyTvqylz5E3pH2oHFL9ycB8YMM=",
+        "lastModified": 1752265577,
+        "narHash": "sha256-YhnBM3oknReSFTAuc2SMwekwjl9nDd5PUhcar4DsefM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3978bcd6961847385121db30c58dbd444d4a73df",
+        "rev": "3976e0507edc9a5f332cb2be93fa20e646d22374",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`3976e050`](https://github.com/nix-community/home-manager/commit/3976e0507edc9a5f332cb2be93fa20e646d22374) | `` test/wpaperd: add test for empty settings ``           |
| [`a3f4b998`](https://github.com/nix-community/home-manager/commit/a3f4b998ecaa9cf87f1a6244a49e5ed96a81f03e) | `` wpaperd: handle empty settings properly ``             |
| [`6d8ed2b4`](https://github.com/nix-community/home-manager/commit/6d8ed2b4fc2aaba8c87f44b1cf4931e22b683583) | `` ci: tag-maintainer workflow refactor (#7436) ``        |
| [`03bf1bd8`](https://github.com/nix-community/home-manager/commit/03bf1bd8d6bad7521ce1c69dbe9b953156ca1148) | `` gtk2: fix missing force option (#7437) ``              |
| [`b8b7e5ec`](https://github.com/nix-community/home-manager/commit/b8b7e5ec3570eb003d55f4947dd39af15c3ca98d) | `` ci: extract-maintainers-meta tweaks (#7434) ``         |
| [`9d343f08`](https://github.com/nix-community/home-manager/commit/9d343f08806148605e61af532e36d80ed47cef3e) | `` ci: update-maintainers cleanup / tweaks (#7433) ``     |
| [`f5b36e5e`](https://github.com/nix-community/home-manager/commit/f5b36e5ecea60542d6f39797974cc6324a834e5e) | `` gtk: add khaneliman maintainer ``                      |
| [`a9594d34`](https://github.com/nix-community/home-manager/commit/a9594d34a28201b93f3ca63b4ac65cd2280420cb) | `` gtk: remove long removed option removal assertion ``   |
| [`fa7d5101`](https://github.com/nix-community/home-manager/commit/fa7d51011f4607a3c44f549d656b27d810b1d885) | `` gtk: refactor and break up to improve readability ``   |
| [`47443585`](https://github.com/nix-community/home-manager/commit/47443585fe686a283626c27c5fb936883b7666e9) | `` tests/gtk: refactor and organize ``                    |
| [`18ff4e1e`](https://github.com/nix-community/home-manager/commit/18ff4e1e11b4a42576a30bd260250059c2bfd989) | `` tests/gtk: expand testing for new customization ``     |
| [`d9915499`](https://github.com/nix-community/home-manager/commit/d9915499e3080fe2afe1f717acabeb697dd21709) | `` gtk: refactor to support more modular customization `` |
| [`e90b2896`](https://github.com/nix-community/home-manager/commit/e90b28967cacc64de7fb8742314ed0d7d12f47c6) | `` wayfire: allow path in settings (#7427) ``             |
| [`ce150018`](https://github.com/nix-community/home-manager/commit/ce15001862e43130b347cb93bed9b4bd4dac990d) | `` cliphist: use lib.getExe (#7431) ``                    |
| [`fab659b3`](https://github.com/nix-community/home-manager/commit/fab659b346c0d4252208434c3c4b3983a4b38fec) | `` trippy: add module (#7426) ``                          |