### PR TITLE
chore(flake/nix-index-database): `85686025` -> `deff7a9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751774635,
-        "narHash": "sha256-DuOznGdgMxeSlPpUu6Wkq0ZD5e2Cfv9XRZeZlHWMd1s=",
+        "lastModified": 1752346111,
+        "narHash": "sha256-SVxCIYnbED0rNYSpm3QQoOhqxYRp1GuE9FkyM5Y2afs=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "85686025ba6d18df31cc651a91d5adef63378978",
+        "rev": "deff7a9a0aa98a08d8c7839fe2658199ce9828f8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                     |
| ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`1dabe081`](https://github.com/nix-community/nix-index-database/commit/1dabe08190253287d1238059b46487911bf5e70a) | `` Use module-instantiated nixpkgs ``                       |
| [`e7745792`](https://github.com/nix-community/nix-index-database/commit/e77457923021afe202eec6be1e681ab08fbfd8bd) | `` print warning message when hmModules is used ``          |
| [`e12a2236`](https://github.com/nix-community/nix-index-database/commit/e12a223611ef4a4e0e9f0920c9b0faa8900d65ed) | `` use the official output name for home-manager modules `` |