### PR TITLE
chore(flake/home-manager): `3976e050` -> `f2795aa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752265577,
-        "narHash": "sha256-YhnBM3oknReSFTAuc2SMwekwjl9nDd5PUhcar4DsefM=",
+        "lastModified": 1752361671,
+        "narHash": "sha256-AliH6gxw6l9OFZCUuXgxmH+UvTKPeyHzBu4lnvQ8Ick=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3976e0507edc9a5f332cb2be93fa20e646d22374",
+        "rev": "f2795aa053ef11f958fba49aef15a5c4d9734c02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                        |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`f2795aa0`](https://github.com/nix-community/home-manager/commit/f2795aa053ef11f958fba49aef15a5c4d9734c02) | `` ci: tag-maintainers further refactoring (#7446) ``                          |
| [`ea24675e`](https://github.com/nix-community/home-manager/commit/ea24675e4f4f4c494ccb04f6645db2a394d348ee) | `` lib: Improve KDL generator (#7429) ``                                       |
| [`ae62fd8a`](https://github.com/nix-community/home-manager/commit/ae62fd8ad8347e6bb5b615057f39f33d595a1c47) | `` tests/zsh: add zprof test ``                                                |
| [`196487c5`](https://github.com/nix-community/home-manager/commit/196487c54f58f237fade6b85dfd57f097c8b5581) | `` zsh: group plugins in a separate directory ``                               |
| [`26b987cf`](https://github.com/nix-community/home-manager/commit/26b987cf8840e74b89bf3fe42d48fdf84af108b3) | `` zsh: move deprecated options to separate file ``                            |
| [`80a07bc6`](https://github.com/nix-community/home-manager/commit/80a07bc6f7f062d78c7dbc91ae8863eca0cabb2a) | `` zsh: move history to separate file ``                                       |
| [`3d95ab3c`](https://github.com/nix-community/home-manager/commit/3d95ab3cdca4e931b062e4dff39dea5563cbc2e3) | `` zsh: move zprof to separate file ``                                         |
| [`9b76feaf`](https://github.com/nix-community/home-manager/commit/9b76feafd02c84935ca3dea671057ca28b08131f) | `` zsh: move oh-my-zsh to separate file ``                                     |
| [`392ddb64`](https://github.com/nix-community/home-manager/commit/392ddb642abec771d63688c49fa7bcbb9d2a5717) | `` home-manager: add flake support for repl command (#7439) ``                 |
| [`7c6f7377`](https://github.com/nix-community/home-manager/commit/7c6f7377ccca88c45a28875e7755c38b604c5ff3) | `` vscode: enable defining `mcp.json` separate from `settings.json` (#7441) `` |