### PR TITLE
chore(flake/nixvim-flake): `d2760807` -> `c0f337f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752158208,
-        "narHash": "sha256-XbXYLUtaB/wHvZYefvaDPbo4eYj27kbtowHfww9bqLw=",
+        "lastModified": 1752358818,
+        "narHash": "sha256-Txnm5vJqZgaHpEM/9OANg1Ux4e9xHQ7iXfQ8EqtqM9s=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "b728cf43d97814df43f5d9bd9dafac9072ccd9e8",
+        "rev": "4b068551d85cb4984fc60268a95097cf7af1ae48",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1752256436,
-        "narHash": "sha256-zr2jukk+VDU/E00o/0H0citYHB4R5uJI1pIf0I7HO/w=",
+        "lastModified": 1752372604,
+        "narHash": "sha256-BgFccn3kuF2U4k3a0qbIm55GUQkl0xNvlpOXI+0bEZ0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "d2760807fbc83a19556a319cdca97337f0e9ea7f",
+        "rev": "c0f337f3881aa3527fd5b66d615f3493a2086ef9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`c0f337f3`](https://github.com/alesauce/nixvim-flake/commit/c0f337f3881aa3527fd5b66d615f3493a2086ef9) | `` chore(flake/nixvim): b728cf43 -> 4b068551 ``  |
| [`52f9ceb7`](https://github.com/alesauce/nixvim-flake/commit/52f9ceb75b0f384c49a5a35954efd95dbd640efe) | `` chore(flake/nixpkgs): 3016b4b1 -> 9807714d `` |