### PR TITLE
chore(flake/nix-index-database): `deff7a9a` -> `839e02de`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752346111,
-        "narHash": "sha256-SVxCIYnbED0rNYSpm3QQoOhqxYRp1GuE9FkyM5Y2afs=",
+        "lastModified": 1752441837,
+        "narHash": "sha256-FMH1OSSJp8Cx8MZHXz6KckxJGbCnVMotZNAH3v2WneU=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "deff7a9a0aa98a08d8c7839fe2658199ce9828f8",
+        "rev": "839e02dece5845be3a322e507a79712b73a96ba2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`6d3aa98f`](https://github.com/nix-community/nix-index-database/commit/6d3aa98f90210171a127b75118010c37b37c70ca) | `` fix: home-manager module rename and update readme `` |
| [`12201a43`](https://github.com/nix-community/nix-index-database/commit/12201a430ee613bc720cef21a130b416cb1b5108) | `` flake.lock: Update ``                                |