### PR TITLE
chore(flake/home-manager): `f2795aa0` -> `1a4d8ffd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752361671,
-        "narHash": "sha256-AliH6gxw6l9OFZCUuXgxmH+UvTKPeyHzBu4lnvQ8Ick=",
+        "lastModified": 1752449767,
+        "narHash": "sha256-P8mQIrgIImASTlNkHPfKwGTmyZgku8EUt6cF52s3N/Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2795aa053ef11f958fba49aef15a5c4d9734c02",
+        "rev": "1a4d8ffd320c2393b72e7ebc5b647122d5703056",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`1a4d8ffd`](https://github.com/nix-community/home-manager/commit/1a4d8ffd320c2393b72e7ebc5b647122d5703056) | `` gurk-rs: fix missing s in home.packages (#7467) `` |
| [`7969ed8b`](https://github.com/nix-community/home-manager/commit/7969ed8baac8363b32775c5f55e132668bab8123) | `` gurk-rs: add module (#7466) ``                     |
| [`bf893ad4`](https://github.com/nix-community/home-manager/commit/bf893ad4cbf46610dd1b620c974f824e266cd1df) | `` tests: re-add module argument ``                   |
| [`fc253984`](https://github.com/nix-community/home-manager/commit/fc25398450cdab61af9654928dfef9d101f51140) | `` zellij: add keybind examples (#7447) ``            |
| [`2a8220dd`](https://github.com/nix-community/home-manager/commit/2a8220dd923f5b4a06a8c8abc11d75e17b11e599) | `` ci: fix tag-maintainers (#7448) ``                 |
| [`908200d6`](https://github.com/nix-community/home-manager/commit/908200d6808bf961718ae96c5aad7ae6b0f8bda9) | `` tests/zellij: add zellij layout test ``            |
| [`78d93389`](https://github.com/nix-community/home-manager/commit/78d9338934a6c9485d9804df6f1a0917b6797180) | `` zellij: add support for layouts generation ``      |