### PR TITLE
chore(flake/nix-fast-build): `97663951` -> `36eb141b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1752057525,
-        "narHash": "sha256-AVjuld7/5LTmvnTGtVCAoTUlDzooThpOsj8sxtm6d8o=",
+        "lastModified": 1752451847,
+        "narHash": "sha256-61GFLI0ikyjh1sbIru5VgmaZHKAHBeo6ZNrlaWDmG4I=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9766395106a9c1f8d4797934d106e02f1787c7bc",
+        "rev": "36eb141bd4b6d799be07db7450a78e885523ff68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                         |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`36eb141b`](https://github.com/Mic92/nix-fast-build/commit/36eb141bd4b6d799be07db7450a78e885523ff68) | `` chore(deps): lock file maintenance (#193) `` |