### PR TITLE
chore(flake/stylix): `05752c77` -> `d683e35f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752364203,
-        "narHash": "sha256-oJaLYpM8NkQ4LRvv8dCd0eFg2GNopeuToM+3Pp8b+RY=",
+        "lastModified": 1752449117,
+        "narHash": "sha256-Cn24ySH/LN/Q/SsDhpOX4cTMYZa1JMOLNeNsoYqcZpY=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "05752c77acc9dc7ff7454c6fe6da829e3a40e548",
+        "rev": "d683e35fa5ec8bbfd45d52e4b53c7b91f7b38d06",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`d683e35f`](https://github.com/nix-community/stylix/commit/d683e35fa5ec8bbfd45d52e4b53c7b91f7b38d06) | `` stylix: use lib.warn instead of builtins.warn (#1676) ``                           |
| [`218d4424`](https://github.com/nix-community/stylix/commit/218d4424b0634f8e9e3af92df7ca807bda529255) | `` treewide: remove redundant stylix.image Nix store copies (#1659) ``                |
| [`f6c5aaa4`](https://github.com/nix-community/stylix/commit/f6c5aaa4f8b70ec0bf995be43311c38be3131776) | `` stylix: add missing trailing period in mkEnableTargetWith's description (#1681) `` |
| [`2947a837`](https://github.com/nix-community/stylix/commit/2947a83755d206553fb88116058f5322f3bc2d0e) | `` gtksourceview: don't overlay all of gnome2 (#1680) ``                              |
| [`a950a3f5`](https://github.com/nix-community/stylix/commit/a950a3f529e1952a7ddf2af138b90a99edf41fe5) | `` wayfire: remove optional toString (#1658) ``                                       |