### PR TITLE
chore(flake/nixvim-flake): `5cd4080c` -> `46ed70e9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1752447041,
-        "narHash": "sha256-n5DPC4+lI9/gM0cdogohOUjiz50jhZ5l+Xg5Ucrj76w=",
+        "lastModified": 1752544004,
+        "narHash": "sha256-2IC20X2Aib/qoMSOtE25j0rUEhYFQ1FYm1F3TpQSeco=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "eeec7f7c31f84b33d3c52365b073e06c21104521",
+        "rev": "97819ce539618efb4e4e6c5c340f5a59273cd177",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1752497809,
-        "narHash": "sha256-6ZaFcwLq8VgoB1MyWOGMWY4tkThrh3Jc8rO727HfkrM=",
+        "lastModified": 1752545071,
+        "narHash": "sha256-IcqxzJecYmcwwV0w6YCwwhiQkZV7pHDXEQpWyIx/9Wk=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5cd4080c6f38c3568e0823c5def9daffb1e022a1",
+        "rev": "46ed70e94181b948351c2601c23277b439b1ec8a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`46ed70e9`](https://github.com/alesauce/nixvim-flake/commit/46ed70e94181b948351c2601c23277b439b1ec8a) | `` chore(flake/nixvim): eeec7f7c -> 97819ce5 `` |