### PR TITLE
chore(flake/home-manager): `1e548375` -> `e8c19a3c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752467539,
-        "narHash": "sha256-4kaR+xmng9YPASckfvIgl5flF/1nAZOplM+Wp9I5SMI=",
+        "lastModified": 1752603129,
+        "narHash": "sha256-S+wmHhwNQ5Ru689L2Gu8n1OD6s9eU9n9mD827JNR+kw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1e54837569e0b80797c47be4720fab19e0db1616",
+        "rev": "e8c19a3cec2814c754f031ab3ae7316b64da085b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`e8c19a3c`](https://github.com/nix-community/home-manager/commit/e8c19a3cec2814c754f031ab3ae7316b64da085b) | `` maintainers: update all-maintainers.nix ``             |
| [`f14ef40c`](https://github.com/nix-community/home-manager/commit/f14ef40c4578e395e815ae21c0042065167a005d) | `` ci: dont run github_pages on forks ``                  |
| [`6613b6ce`](https://github.com/nix-community/home-manager/commit/6613b6ce49b2f4f62c54faec2479905e8b8dcda2) | `` ci: update-maintainers include eval diff ``            |
| [`30533223`](https://github.com/nix-community/home-manager/commit/30533223ee89f0f07fe2e8a683298c84b667e33f) | `` ci: generate-all-maintainers remove unused function `` |
| [`a1c0a349`](https://github.com/nix-community/home-manager/commit/a1c0a3493867abb0a2da20528e4bff4366ed6fb4) | `` ci: fix tag-maintainers (#7480) ``                     |
| [`f7a45b08`](https://github.com/nix-community/home-manager/commit/f7a45b08319233b9b93ba60bbfccb41df75a7ac1) | `` nix: use-sandbox -> sandbox (#7475) ``                 |
| [`4cc9cc67`](https://github.com/nix-community/home-manager/commit/4cc9cc67ebd2847f5ed332a226e9109c97336ecf) | `` wayfire: fix broken configuration.ini test (#7478) ``  |