### PR TITLE
chore(flake/stylix): `7f7472cc` -> `45749a79`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752525684,
-        "narHash": "sha256-VmzzmgM0Cz73cYcy7qyOPTK7qj38/PvlR+bQRRDaLV0=",
+        "lastModified": 1752598315,
+        "narHash": "sha256-pSm1BqcA6wido27VeNAi86SjpurpL84+ciAXQmrtSzk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "7f7472cc908a65964fdcc541a978bf8fd1c488f9",
+        "rev": "45749a791efd692c04dee4702b86a31535ed30d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`45749a79`](https://github.com/nix-community/stylix/commit/45749a791efd692c04dee4702b86a31535ed30d2) | `` stylix: remove optional parentheses (#1697) ``                    |
| [`4add678f`](https://github.com/nix-community/stylix/commit/4add678fe3978177744e8af3c72a6a8a1288227b) | `` stylix: do not check lambda pattern names with deadnix (#1689) `` |