### PR TITLE
chore(flake/stylix): `45749a79` -> `0ba0ffe9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752598315,
-        "narHash": "sha256-pSm1BqcA6wido27VeNAi86SjpurpL84+ciAXQmrtSzk=",
+        "lastModified": 1752684057,
+        "narHash": "sha256-QRuM25aYp3n2cf59gEJE0VcIoGRX2ps8gp2mzorKodw=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "45749a791efd692c04dee4702b86a31535ed30d2",
+        "rev": "0ba0ffe94cbe20ae739c2aa8cae04cbf900bf56b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                     |
| ----------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`0ba0ffe9`](https://github.com/nix-community/stylix/commit/0ba0ffe94cbe20ae739c2aa8cae04cbf900bf56b) | `` wayprompt: add testbed (#1708) ``                                        |
| [`8c854fe3`](https://github.com/nix-community/stylix/commit/8c854fe383fda20e8befefc31ecf248988a40bcc) | `` stylix: allow choosing testbed desktop (#1222) ``                        |
| [`436ad797`](https://github.com/nix-community/stylix/commit/436ad797df3fea6daab8b47a1ba10c7ae2505625) | `` zellij: update theme based on built-in Catppuccin Mocha theme (#1704) `` |
| [`a92b0ac9`](https://github.com/nix-community/stylix/commit/a92b0ac9da273fa484136283d4ef54ca19eacc4f) | `` ci: bump DeterminateSystems/nix-installer-action from 18 to 19 ``        |