### PR TITLE
chore(flake/home-manager): `e8c19a3c` -> `dcfd70f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752603129,
-        "narHash": "sha256-S+wmHhwNQ5Ru689L2Gu8n1OD6s9eU9n9mD827JNR+kw=",
+        "lastModified": 1752798675,
+        "narHash": "sha256-oMJhxLVGVC7v0ReNQ/vFVKMQOPUixg/74MnZZ1Wkv4s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e8c19a3cec2814c754f031ab3ae7316b64da085b",
+        "rev": "dcfd70f80fe6d872c2dc58fe3be384a681e56fea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                             |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`dcfd70f8`](https://github.com/nix-community/home-manager/commit/dcfd70f80fe6d872c2dc58fe3be384a681e56fea) | `` ssh-tpm-agent: init module (#7495) ``                                            |
| [`7c78e592`](https://github.com/nix-community/home-manager/commit/7c78e592a895f2f1921f0024848fe193e2f8518e) | `` maintainers: remove duplicate nixpkgs maintainers ``                             |
| [`defabc11`](https://github.com/nix-community/home-manager/commit/defabc11abd602bed3af5fe4111d023f638ccfc3) | `` ci: move validate maintainers logic to lib ``                                    |
| [`bc9f3c84`](https://github.com/nix-community/home-manager/commit/bc9f3c8413a3aaa01ed959c371c1f9e57515965b) | `` direnv: misc cleanup ``                                                          |
| [`8320333a`](https://github.com/nix-community/home-manager/commit/8320333a4547422afb68b6df7ac7edfa2733038b) | `` tests/direnv: refactor tests ``                                                  |
| [`63994b71`](https://github.com/nix-community/home-manager/commit/63994b71d223b48007dbec0089bbfd62d9cd4e1d) | `` direnv: fix silent clobbering global config ``                                   |
| [`e595fe1d`](https://github.com/nix-community/home-manager/commit/e595fe1df49d75e971b33f311e365f032089f450) | `` flake.lock: Update (#7450) ``                                                    |
| [`2d55a529`](https://github.com/nix-community/home-manager/commit/2d55a52963d8a3856792e2fd6604f307176026bc) | `` radio-cli: add module (#7488) ``                                                 |
| [`50adf434`](https://github.com/nix-community/home-manager/commit/50adf43449743dfc0e4e82ab533112ef110bcfb0) | `` nushell: fix `get -i` deprecation (#7490) ``                                     |
| [`8eb2f2a2`](https://github.com/nix-community/home-manager/commit/8eb2f2a26ae540cc89300eed97c61fa264c2ff7f) | `` treewide: Remove unwanted dependencies (#7487) ``                                |
| [`460f1e9a`](https://github.com/nix-community/home-manager/commit/460f1e9af95b081fb7e2022485b6c22b92085936) | `` starship: set `STARSHIP_CONFIG` var and add option to set config path (#7435) `` |