### PR TITLE
chore(flake/stylix): `03699ed2` -> `f826d321`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752750082,
-        "narHash": "sha256-NoVAqy+Wj4tgkvrYB8zWncl8Z6Hb80aX3t/TYGdsfaM=",
+        "lastModified": 1752965417,
+        "narHash": "sha256-FDec+RoFgSrk3YPedcjNiBK+acaHO4Vt0YDTMdKdw1w=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "03699ed214f6e8195bc7199d6ae3aeccf9732b08",
+        "rev": "f826d3214b8a9be3f158d5cc7514c4130674324b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                               |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`f826d321`](https://github.com/nix-community/stylix/commit/f826d3214b8a9be3f158d5cc7514c4130674324b) | `` stylix: add generated all-maintainers file (#1654) ``                              |
| [`e4cc192b`](https://github.com/nix-community/stylix/commit/e4cc192b263f17fb58e616301e29b1498e72f390) | `` ci: use cachix/install-nix-action (#1725) ``                                       |
| [`24499b00`](https://github.com/nix-community/stylix/commit/24499b0049881959bd4e159b6fe4e96e4c03db25) | `` stylix: conditionally load external modules in testbeds (#1698) ``                 |
| [`2e2e96f6`](https://github.com/nix-community/stylix/commit/2e2e96f6b0720c9e974093b6521b8848ddd5706c) | `` treewide: remove blank lines around 'let', 'in', and function arguments (#1700) `` |