### PR TITLE
chore(flake/nixvim-flake): `d8cc6670` -> `c4ca7b8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1752804195,
-        "narHash": "sha256-ngD86nFB/vppPDReSVY6M0uP4+GSCGKE21VJwghtBss=",
+        "lastModified": 1752890335,
+        "narHash": "sha256-m1LsGY44sPJWE8Tk2bVye84MpWo39Tlce0cjgcYPV5s=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "d8cc66708f2f4d18147c8dc36c4f9605c192fbe3",
+        "rev": "c4ca7b8bac33acc9888a4decffa97b1707bd912b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`c4ca7b8b`](https://github.com/alesauce/nixvim-flake/commit/c4ca7b8bac33acc9888a4decffa97b1707bd912b) | `` chore(flake/nixpkgs): 62e0f05e -> 6e987485 `` |