### PR TITLE
chore(flake/home-manager): `d0300c88` -> `13a83d1b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752814804,
-        "narHash": "sha256-irfg7lnfEpJY+3Cffkluzp2MTVw1Uq9QGxFp6qadcXI=",
+        "lastModified": 1753056897,
+        "narHash": "sha256-AVVMBFcuOXqIgmShvRv9TED3fkiZhQ0ZvlhsPoFfkNE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d0300c8808e41da81d6edfc202f3d3833c157daf",
+        "rev": "13a83d1b6545b7f0e8f7689bad62e7a3b1d63771",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`13a83d1b`](https://github.com/nix-community/home-manager/commit/13a83d1b6545b7f0e8f7689bad62e7a3b1d63771) | `` zed-editor: support tasks (#7493) ``                         |
| [`7834432c`](https://github.com/nix-community/home-manager/commit/7834432ca540b4179959b4864c40ed29f2720732) | `` thunderbird: support declaration of address books (#7443) `` |
| [`e0402627`](https://github.com/nix-community/home-manager/commit/e0402627096f236943a6691fbe037b55dabef4d1) | `` flake.lock: Update (#7505) ``                                |