### PR TITLE
chore(flake/stylix): `f826d321` -> `c32c82e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1752965417,
-        "narHash": "sha256-FDec+RoFgSrk3YPedcjNiBK+acaHO4Vt0YDTMdKdw1w=",
+        "lastModified": 1753055255,
+        "narHash": "sha256-t7jZUPQSqlNA3wdIhmZuz7CPAMXCo6CsoAGyrR++jXA=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "f826d3214b8a9be3f158d5cc7514c4130674324b",
+        "rev": "c32c82e460b9022c4c20cf51014db1665e866ffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                             |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`c32c82e4`](https://github.com/nix-community/stylix/commit/c32c82e460b9022c4c20cf51014db1665e866ffb) | `` zen-browser: init (#1694) ``                                     |
| [`62bd6e52`](https://github.com/nix-community/stylix/commit/62bd6e52a541f5f717671812fd3556cb5bec40cf) | `` i3: use mkTarget (#1655) ``                                      |
| [`4af7cbde`](https://github.com/nix-community/stylix/commit/4af7cbde9cdae25e5ecc4a95693b9e0e30ace8b6) | `` qt: guard nixosConfig instead of isLinux and osConfig (#1722) `` |
| [`9242b3ec`](https://github.com/nix-community/stylix/commit/9242b3ec8e0d253f32614778ed4996af7aaf9438) | `` ci: fix generated all-maintainers path (#1728) ``                |