### PR TITLE
chore(flake/stylix): `c32c82e4` -> `ea60526c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753055255,
-        "narHash": "sha256-t7jZUPQSqlNA3wdIhmZuz7CPAMXCo6CsoAGyrR++jXA=",
+        "lastModified": 1753117651,
+        "narHash": "sha256-7gWBlUOe2c0nYGyoVDa9hw15pI3DXDR0KK+nYh9KOpU=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "c32c82e460b9022c4c20cf51014db1665e866ffb",
+        "rev": "ea60526c8c2a1c5df2743a9495814dc0b319ef3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                        |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`1021b7d7`](https://github.com/nix-community/stylix/commit/1021b7d7322c4a3eada82bc6e60c6bedf08cfce1) | `` stylix: simplify API by renaming stylix.iconTheme option to stylix.icons `` |
| [`699262a0`](https://github.com/nix-community/stylix/commit/699262a0f8cd42ea1e786351cf91b1403fa7598e) | `` stylix: rename icon.nix to icon-theme.nix ``                                |