### PR TITLE
chore(flake/nix-fast-build): `9ee30c01` -> `1ad948fd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1753007040,
-        "narHash": "sha256-fTDnQ2lvX2sLIq8Kego6YP93R3P5tctcuGJ+wj2rzoQ=",
+        "lastModified": 1753122370,
+        "narHash": "sha256-aY6fzoA7UYy1gJZodum68bQj1K2JnLLU+QAE4Qk7R3Y=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "9ee30c01cf8fee2379c80d189d8ec2e96a48b74a",
+        "rev": "1ad948fd78de6dd3de0751798e6a435bb167705b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`1ad948fd`](https://github.com/Mic92/nix-fast-build/commit/1ad948fd78de6dd3de0751798e6a435bb167705b) | `` chore(deps): update flake-parts digest to 644e0fc (#197) `` |
| [`1c08694e`](https://github.com/Mic92/nix-fast-build/commit/1c08694ec8c1aaa747cc79d8733ab4bf70998833) | `` chore(deps): lock file maintenance (#196) ``                |