### PR TITLE
chore(flake/flake-parts): `77826244` -> `644e0fc4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1751413152,
-        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
+        "lastModified": 1753121425,
+        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
+        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                          |
| -------------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`57777256`](https://github.com/hercules-ci/flake-parts/commit/577772566b3f4e9c07d2d033305e9abe5f221dd5) | `` Memoize undeclared systems `` |