### PR TITLE
chore(flake/stylix): `ea60526c` -> `fbe1dab7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753117651,
-        "narHash": "sha256-7gWBlUOe2c0nYGyoVDa9hw15pI3DXDR0KK+nYh9KOpU=",
+        "lastModified": 1753296482,
+        "narHash": "sha256-VPLaHVhU6/CwnMHTjhf6945qyrXEcpjxKfpWqQXtnxI=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ea60526c8c2a1c5df2743a9495814dc0b319ef3b",
+        "rev": "fbe1dab7783a3d579dc57be8ceee148104e0930b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                       |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`fbe1dab7`](https://github.com/nix-community/stylix/commit/fbe1dab7783a3d579dc57be8ceee148104e0930b) | `` stylix: apply stylix.iconTheme option rename to all sub-options (#1744) `` |
| [`37673b1d`](https://github.com/nix-community/stylix/commit/37673b1de0703a637f3a8abe8da8a097d076a377) | `` zen-browser: fix select tags not being readable (#1738) ``                 |
| [`6e8c6906`](https://github.com/nix-community/stylix/commit/6e8c6906c15cb235eb164db9766a9ba1f51f94d4) | `` i3: remove readOnly from exportedBar (#1737) ``                            |