### PR TITLE
chore(flake/nixpkgs): `c87b95e2` -> `fc02ee70`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -478,11 +478,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752950548,
-        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
+        "lastModified": 1753250450,
+        "narHash": "sha256-i+CQV2rPmP8wHxj0aq4siYyohHwVlsh40kV89f3nw1s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
+        "rev": "fc02ee70efb805d3b2865908a13ddd4474557ecf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`410f7b1b`](https://github.com/NixOS/nixpkgs/commit/410f7b1b70a1c12c330451222da4f5d6adc57b9b) | `` google-chrome: 138.0.7204.157 -> 138.0.7204.168 ``                                          |
| [`fd54edc4`](https://github.com/NixOS/nixpkgs/commit/fd54edc4d34ced343a95003d68e696c3bfd7d779) | `` valeronoi: migrate to by-name; refactor (#427499) ``                                        |
| [`16bf4a02`](https://github.com/NixOS/nixpkgs/commit/16bf4a02faa80ad72abbbf37ebb5ed9e7cd19cea) | `` nixos/nextcloud: fix module maintainers (#427548) ``                                        |
| [`47632015`](https://github.com/NixOS/nixpkgs/commit/47632015eee0ba154db920d50851ac92f8409b69) | `` cargonode: drop (#425666) ``                                                                |
| [`0b44ff1c`](https://github.com/NixOS/nixpkgs/commit/0b44ff1c6e90b382c2213caa0ee9ac29420c8443) | `` python3Packages.ahocorapy: drop future dependency ``                                        |
| [`8405a97c`](https://github.com/NixOS/nixpkgs/commit/8405a97c796b8df380b44139523dbacb570e5ce9) | `` python3Packages.aurorapy: drop future dependency ``                                         |
| [`d80ed4cb`](https://github.com/NixOS/nixpkgs/commit/d80ed4cb919c01c0de4bb8b14866c6c3b5e454fe) | `` treewide: conform descriptions to the standards ``                                          |
| [`261944f2`](https://github.com/NixOS/nixpkgs/commit/261944f26b21194ad2f2b83ad62554e07adb9b23) | `` treewide: trim whitespace in homepage strings ``                                            |
| [`ca35bb68`](https://github.com/NixOS/nixpkgs/commit/ca35bb6872672678d4996315faa4a8d1290c98bf) | `` treewide: trim whitespace in description strings ``                                         |
| [`f80037b8`](https://github.com/NixOS/nixpkgs/commit/f80037b84c6fa1302c7ba805da455d208073ef09) | `` pmix: remove nativeBuildInputs pandoc ``                                                    |
| [`08aed995`](https://github.com/NixOS/nixpkgs/commit/08aed995eaf3f3c9b3ab729cee2a0c1a33db97af) | `` python3: fix passthru tests after b937eac ``                                                |
| [`71a74981`](https://github.com/NixOS/nixpkgs/commit/71a749810c467fa124574e33c3229d09a5614a04) | `` python314: 3.14.0b4 -> 3.14.0rc1 ``                                                         |
| [`dcd096d9`](https://github.com/NixOS/nixpkgs/commit/dcd096d9cef92f3915dd5cbb82de68a0fed26944) | `` omnisharp-roslyn: 1.39.13 -> 1.39.14 ``                                                     |
| [`2768c78f`](https://github.com/NixOS/nixpkgs/commit/2768c78fa538c2ea72a41a278285ca427152c1f3) | `` plutovg: 1.2.0 -> 1.3.0 ``                                                                  |
| [`5928307e`](https://github.com/NixOS/nixpkgs/commit/5928307ebce0786ea4b5697a9210f431b9031659) | `` go-i18n: init at 2.6.0 ``                                                                   |
| [`0dad56ce`](https://github.com/NixOS/nixpkgs/commit/0dad56ce954c874fda46381cd4ba39b65fb635d1) | `` treewide: conform descriptions to the standards ``                                          |
| [`99e4bf57`](https://github.com/NixOS/nixpkgs/commit/99e4bf5792854618b67e9039d774171f44fb370a) | `` nixos/tailscale-derper: add enableNginx option to make nginx optional (#425734) ``          |
| [`06bf6f2b`](https://github.com/NixOS/nixpkgs/commit/06bf6f2b69eeb6f89a0a6ec56245279dce43339f) | `` esphome: 2025.7.2 -> 2025.7.3 ``                                                            |
| [`ce9f005b`](https://github.com/NixOS/nixpkgs/commit/ce9f005b489481bfaa24ab36265ca2bb45e4d26c) | `` xbyak: init at 7.28 ``                                                                      |
| [`ad525a3f`](https://github.com/NixOS/nixpkgs/commit/ad525a3ff3c25adbe4a219f1c30df8a38aa42688) | `` flutter332: 3.32.6 -> 3.32.7 ``                                                             |
| [`9e4a6210`](https://github.com/NixOS/nixpkgs/commit/9e4a62109dba3cb7079dd90146a6eca6a42e6830) | `` flutter.updateScript: fix file format ``                                                    |
| [`be500d94`](https://github.com/NixOS/nixpkgs/commit/be500d941bc09bd9deccf7051988f1dd7497fca2) | `` flutter.updateScript: fix some ruff warning ``                                              |
| [`66cbc208`](https://github.com/NixOS/nixpkgs/commit/66cbc208f66cc0e75b36918878cae3da509dce8d) | `` rectangle: 0.88 -> 0.89 ``                                                                  |
| [`9f39891c`](https://github.com/NixOS/nixpkgs/commit/9f39891cbfbc96edc6134f3207ed48a3199387ea) | `` chromium,chromedriver: 138.0.7204.157 -> 138.0.7204.168 ``                                  |
| [`84d2742c`](https://github.com/NixOS/nixpkgs/commit/84d2742c08d8b1432b144fbacf9f701ba5ae6b54) | `` gitlab-ci-ls: fix src hash ``                                                               |
| [`883c69cf`](https://github.com/NixOS/nixpkgs/commit/883c69cfa208dd6926edc345f9d03a307b9ec76c) | `` python3Packages.homeassistant-stubs: 2025.7.2 -> 2025.7.3 ``                                |
| [`251c9548`](https://github.com/NixOS/nixpkgs/commit/251c954884ad55bb7905a30c5aee9f102c7a0a72) | `` home-assistant.python.pkgs.pytest-homeassistant-custom-component: 0.13.261 -> 0.13.262 ``   |
| [`bc948277`](https://github.com/NixOS/nixpkgs/commit/bc948277878a6257b8061e85f777dfc4a6b9f8f0) | `` home-assistant: python314 compat for update-component-packages ``                           |
| [`af8d5c65`](https://github.com/NixOS/nixpkgs/commit/af8d5c652f5bc80e3b263525445dbe8cfc1eb49c) | `` home-assistant: 2025.7.2 -> 2025.7.3 ``                                                     |
| [`6a9bf1e3`](https://github.com/NixOS/nixpkgs/commit/6a9bf1e38a39f269d8a7dd050ab9e035544b0c59) | `` python3Packages.tesla-fleet-api: 1.2.0 -> 1.2.2 ``                                          |
| [`a6b5a1be`](https://github.com/NixOS/nixpkgs/commit/a6b5a1be177586a71c3243a76b7901b1db3bd201) | `` python3Packages.pyenphase: 2.2.1 -> 2.2.2 ``                                                |
| [`52b9bb60`](https://github.com/NixOS/nixpkgs/commit/52b9bb603e23b07f0569bc4ccd139de2b849f234) | `` python3Packages.gios: 6.1.1 -> 6.1.2 ``                                                     |
| [`4d57e4a5`](https://github.com/NixOS/nixpkgs/commit/4d57e4a5e7ff85e15a49175e84d5619f56cd551c) | `` python3Packages.aioamazondevices: 3.3.0 -> 3.5.0 ``                                         |
| [`560499df`](https://github.com/NixOS/nixpkgs/commit/560499df59a04f1f9963ff5871b41ffe0da4aa88) | `` mbake: install completions ``                                                               |
| [`c1e3dac4`](https://github.com/NixOS/nixpkgs/commit/c1e3dac45e0426974049c023648150e941e0ca81) | `` mbake: 1.2.4 -> 1.3.1 ``                                                                    |
| [`c9676494`](https://github.com/NixOS/nixpkgs/commit/c967649486bb66a07812aec8d7670d4af679cbc4) | `` openswitcher: set switcher-control as main program ``                                       |
| [`41b5af93`](https://github.com/NixOS/nixpkgs/commit/41b5af93f132e7e77255b233761934a962afa2d5) | `` home-assistant-custom-components.solarman: init at 1.5.1 ``                                 |
| [`65a42345`](https://github.com/NixOS/nixpkgs/commit/65a423451e8831b17578ef20c39fdfeb468159fb) | `` python3Packages.pysolarmanv5: init at 3.0.6 ``                                              |
| [`6bed326d`](https://github.com/NixOS/nixpkgs/commit/6bed326dc42e16be1ef32520b12637bf96cba125) | `` copilot-language-server: 1.339.0 -> 1.346.0 ``                                              |
| [`1e377fed`](https://github.com/NixOS/nixpkgs/commit/1e377fedf7c63e229b3c86ea46116123b8048332) | `` treewide: strip trailing punctuation from description strings ``                            |
| [`4dc2cc78`](https://github.com/NixOS/nixpkgs/commit/4dc2cc7805f1eb5db8b00696a9c9b09d047da1ec) | `` zoom-us: construct derivation on unsupported systems ``                                     |
| [`43911f67`](https://github.com/NixOS/nixpkgs/commit/43911f67ef18fdce12f39c34c167465e4912c79c) | `` markdown-code-runner: 0.2.0 -> 0.2.3 ``                                                     |
| [`32b93132`](https://github.com/NixOS/nixpkgs/commit/32b931324cf3c0a9a02c30f033707c6739d00665) | `` phpPackages.phpstan: 2.1.17 -> 2.1.19 ``                                                    |
| [`3eed118b`](https://github.com/NixOS/nixpkgs/commit/3eed118bc5fc23504b8958ded6f33aacc425eb24) | `` claude-code: 1.0.56 -> 1.0.57 ``                                                            |
| [`e19b462a`](https://github.com/NixOS/nixpkgs/commit/e19b462acfb33cf180c3fcad96f7f0c661bb0a5c) | `` treewide: add rewine as maintainer for some wayland-related packages ``                     |
| [`1262c774`](https://github.com/NixOS/nixpkgs/commit/1262c7748abf6f741ccbb5475a1e702b0d9b73b2) | `` firefly-iii-data-importer: 1.7.6 -> 1.7.8 ``                                                |
| [`14a9293d`](https://github.com/NixOS/nixpkgs/commit/14a9293dbcf9aca0a4340ed28eb9d9e322d3fe18) | `` discordo: move to by-name ``                                                                |
| [`117ca03e`](https://github.com/NixOS/nixpkgs/commit/117ca03ed26d8ad2f89f56eefddea5cfbbba98ee) | `` Add melange-json-native 2.0.0 (#427482) ``                                                  |
| [`f08d5fcc`](https://github.com/NixOS/nixpkgs/commit/f08d5fcc179a8545391ff0daa5fc9809e7619bfa) | `` syzkaller: use cross compilation in build ``                                                |
| [`22ac4204`](https://github.com/NixOS/nixpkgs/commit/22ac4204025b0db6388862e8683818bf98dd2af6) | `` zoom-us: 6.5.3.2773 -> 6.5.7.3298 ``                                                        |
| [`c93188c8`](https://github.com/NixOS/nixpkgs/commit/c93188c8e6acae53e7379ca32a996730ff2997f0) | `` markdown-code-runner: 0-unstable-2025-04-18 -> 0.2.0 ``                                     |
| [`50898396`](https://github.com/NixOS/nixpkgs/commit/508983965e6518a6653948e9e84583ed3dff2762) | `` dbeaver-bin: 25.1.2 -> 25.1.3 ``                                                            |
| [`71674f4e`](https://github.com/NixOS/nixpkgs/commit/71674f4e40a66eb1ecc3c776e2906b10db57091d) | `` ferdium: update version to 7.1.0 and fix hash values ``                                     |
| [`dd8a23da`](https://github.com/NixOS/nixpkgs/commit/dd8a23dab0b433860dc1baa179007b43bec2fe1c) | `` authentik: support aarch64-linux ``                                                         |
| [`3e919736`](https://github.com/NixOS/nixpkgs/commit/3e919736b226935a050daffee35127b7cdca837e) | `` bcachefs-tools: 1.25.2 -> 1.25.3 ``                                                         |
| [`edde2e84`](https://github.com/NixOS/nixpkgs/commit/edde2e84ef85707179f862194cd232c247d33f8d) | `` sope: Add CVE-2025-53603 ``                                                                 |
| [`66b18a6d`](https://github.com/NixOS/nixpkgs/commit/66b18a6d05217a7d353daa24109bba66396d27d1) | `` dolibarr: 21.0.1 -> 21.0.2 ``                                                               |
| [`662fc0b5`](https://github.com/NixOS/nixpkgs/commit/662fc0b5d8e92ebd2f7930c846715364d7c000b5) | `` clickhouse-backup: 2.6.26 -> 2.6.29 ``                                                      |
| [`f92d77b4`](https://github.com/NixOS/nixpkgs/commit/f92d77b4e71e82122c9bb4f6f55c19ffbaea652e) | `` krita: move to by-name ``                                                                   |
| [`2fb4c919`](https://github.com/NixOS/nixpkgs/commit/2fb4c9190e23e145c35455618fd3f5b733445ab1) | `` ocamlPackages.reason-react(-ppx): 0.15.0 -> 0.16.0 ``                                       |
| [`9afa91a9`](https://github.com/NixOS/nixpkgs/commit/9afa91a92dd796bf4d4df62957150591e38f6015) | `` lf: 35 -> 36 ``                                                                             |
| [`a7ed5c7a`](https://github.com/NixOS/nixpkgs/commit/a7ed5c7ae1ed45f9023dd6ab590eb0e64327de5d) | `` mqtt_cpp: 13.2.1 -> 13.2.2 ``                                                               |
| [`775ba629`](https://github.com/NixOS/nixpkgs/commit/775ba62998c4d603d9a300cb04175a19f114ac0d) | `` spek: move to by-name ``                                                                    |
| [`b040cac3`](https://github.com/NixOS/nixpkgs/commit/b040cac3ba5f8cc01901ef3b63bee86b1d2f1d00) | `` infrastructure-agent: 1.65.3 -> 1.65.4 ``                                                   |
| [`a37099df`](https://github.com/NixOS/nixpkgs/commit/a37099dfd3a6ab516dd0412d2eff5ea098228288) | `` fwbuilder: refactor package definitions and meta ``                                         |
| [`5329425f`](https://github.com/NixOS/nixpkgs/commit/5329425f2e0c77bf2220aff541acebf0dc37b202) | `` fwbuilder: migrate to by-name ``                                                            |
| [`7e025579`](https://github.com/NixOS/nixpkgs/commit/7e025579c80be33f984f93fad41fde9d040e577d) | `` necesse-server: 0.33.0-19201409 -> 0.33.1-19314669 ``                                       |
| [`c81dde52`](https://github.com/NixOS/nixpkgs/commit/c81dde5271623180611dbbd07eb4132d9443aa19) | `` audiobookshelf: add tebriel to maintainers ``                                               |
| [`5a874c90`](https://github.com/NixOS/nixpkgs/commit/5a874c90a268857573a836395793d206b2220f46) | `` audiobookshelf: 2.26.1 -> 2.26.2 ``                                                         |
| [`380cd592`](https://github.com/NixOS/nixpkgs/commit/380cd5924bbdbd310bcf5ce26ba35cd83e766ab6) | `` nixos/qbittorrent: add maintainer undefined-landmark ``                                     |
| [`6caef45a`](https://github.com/NixOS/nixpkgs/commit/6caef45a8fdfcdb6ab8d735dc44e4bf3a2f31877) | `` maintainers: add undefined-landmark ``                                                      |
| [`51df42e9`](https://github.com/NixOS/nixpkgs/commit/51df42e9c43d99d8d07845908a4ca3ad19980cde) | `` rockcraft: ignore broken test ``                                                            |
| [`6bc31113`](https://github.com/NixOS/nixpkgs/commit/6bc3111320b13c4e0f7aa43a05133d3384ff7fea) | `` home-assistant-custom-lovelace-modules.mushroom: 4.4.0 -> 4.5.0 (#427456) ``                |
| [`fb8f3507`](https://github.com/NixOS/nixpkgs/commit/fb8f3507a18a8ea94d4d1ed299945697ed1f9662) | `` authentik,authentik.outposts.{ldap,radius,proxy}: 2025.4.1 -> 2024.6.3 ``                   |
| [`8efcdcd2`](https://github.com/NixOS/nixpkgs/commit/8efcdcd25dec873a35496649834ef585951473df) | `` snapcraft: fix broken test from mismatched dep ``                                           |
| [`4dee7551`](https://github.com/NixOS/nixpkgs/commit/4dee755166eb36889356f1661a599ad0b1a71f61) | `` chhoto-url: 6.2.8 -> 6.2.10 ``                                                              |
| [`ba283292`](https://github.com/NixOS/nixpkgs/commit/ba283292220e5b0bdefee32329a6a141fe2c4954) | `` ksnip: refactor package definitions and meta ``                                             |
| [`7793a47c`](https://github.com/NixOS/nixpkgs/commit/7793a47c4cf418dab2adeb6098eb2eeddead2ccc) | `` ksnip: migrate to by-name ``                                                                |
| [`0f0d34d0`](https://github.com/NixOS/nixpkgs/commit/0f0d34d0e7d905fa4fab9f0023dbd2d2375b94bc) | `` civo: 1.4.0 -> 1.4.1 ``                                                                     |
| [`799c3e01`](https://github.com/NixOS/nixpkgs/commit/799c3e01062d1b1d3c13bee6eb047fd39f937a99) | `` yew-fmt: 0.6.2 -> 0.6.3 ``                                                                  |
| [`d4fadc72`](https://github.com/NixOS/nixpkgs/commit/d4fadc72308b6ec0c09373383d1cc5e61649073d) | `` python3Packages.transformers: 4.53.2 -> 4.53.3 ``                                           |
| [`1757c02c`](https://github.com/NixOS/nixpkgs/commit/1757c02cde18cb0fbdbd67ac0b394bef5c01ef20) | `` go-licence-detector: 0.8.0 -> 0.9.0 ``                                                      |
| [`90459ff4`](https://github.com/NixOS/nixpkgs/commit/90459ff4549f520b77ad3b9c4509fdd8734acc34) | `` kubergrunt: 0.17.3 -> 0.18.0 ``                                                             |
| [`27d0e32c`](https://github.com/NixOS/nixpkgs/commit/27d0e32cf89ec135139c70e29668ca32ce3ae669) | `` python3Packages.python-kadmin-rs: 0.6.0 -> 0.6.1 ``                                         |
| [`cf40f52d`](https://github.com/NixOS/nixpkgs/commit/cf40f52d18b5f18cf8e90c492c4774ae16a61ea4) | `` scaleway-cli: 2.41.0 -> 2.42.0 ``                                                           |
| [`72da9a08`](https://github.com/NixOS/nixpkgs/commit/72da9a082248136b6b8eeadc92856c98a202967a) | `` qucsator-rf: 1.0.6 -> 1.0.7 ``                                                              |
| [`e95dadc5`](https://github.com/NixOS/nixpkgs/commit/e95dadc5749a08d6b5328e3bc44be5429d85e363) | `` electrs: 0.10.9 -> 0.10.10 ``                                                               |
| [`0444b58f`](https://github.com/NixOS/nixpkgs/commit/0444b58f792458aba883dcec232f97a792491ea4) | `` electrs: fix package update script ``                                                       |
| [`6a575cc1`](https://github.com/NixOS/nixpkgs/commit/6a575cc1b536256390a5374e055ce74e0c1c0f64) | `` sheldon: 0.8.4 -> 0.8.5 ``                                                                  |
| [`1868467c`](https://github.com/NixOS/nixpkgs/commit/1868467cfbfbc162ad8adec4ab24ed2fc9432cfa) | `` parallel: 20250622 -> 20250722 ``                                                           |
| [`5e01dd8a`](https://github.com/NixOS/nixpkgs/commit/5e01dd8a97c3ae77daebd62a888157821895f94b) | `` python3Packages.craft-application: 5.4.0 -> 5.5.0 ``                                        |
| [`caa745bd`](https://github.com/NixOS/nixpkgs/commit/caa745bdebb6898b74a781e5a3ac2b3bcefeb676) | `` otio: fix hash ``                                                                           |
| [`88b5a752`](https://github.com/NixOS/nixpkgs/commit/88b5a752cf451e572e60b426ca3f26cde4ce189c) | `` feather-tk: init at 0.3.0 ``                                                                |
| [`7356bc8e`](https://github.com/NixOS/nixpkgs/commit/7356bc8e1633c81d4a8abc20b1b44cc07ab9e1b4) | `` python3Packages.craft-providers: 2.3.1 -> 2.4.0 ``                                          |
| [`b51891ed`](https://github.com/NixOS/nixpkgs/commit/b51891ed50db445e9b4f18d0a3ecff22e790eabb) | `` aquamarine,xdph,hypr*: build using gcc15 ``                                                 |
| [`fd06da68`](https://github.com/NixOS/nixpkgs/commit/fd06da6803a3bacff1d0f8cae986b4d7b9596e4c) | `` snphost: add versionCheckHook ``                                                            |
| [`eba6abdc`](https://github.com/NixOS/nixpkgs/commit/eba6abdc941415e08ec0e2a92b87294290583192) | `` snphost: 0.6.0 -> 0.6.1 ``                                                                  |
| [`e2e26192`](https://github.com/NixOS/nixpkgs/commit/e2e26192e07aa3c0ed9f51fe8211283d13044d35) | `` parca-agent: 0.39.1 -> 0.39.2 ``                                                            |
| [`39bb74e8`](https://github.com/NixOS/nixpkgs/commit/39bb74e8e19ac19f16fbcf99d91418ca886cde90) | `` httptoolkit: pin electron_35 ``                                                             |
| [`2a7784da`](https://github.com/NixOS/nixpkgs/commit/2a7784da9782c91aab0049d0f38130d448df0df3) | `` gfn-electron: pin electron_35 ``                                                            |
| [`0a243bd7`](https://github.com/NixOS/nixpkgs/commit/0a243bd7a3495f5b605eb299597eda7f84648abd) | `` cherry-studio: pin electron_35 ``                                                           |
| [`35a30439`](https://github.com/NixOS/nixpkgs/commit/35a30439d4f8066321e668f3e4ba5a6a6092b458) | `` electron{,-bin,-chromedriver}: 35 -> 37 ``                                                  |
| [`24e9218a`](https://github.com/NixOS/nixpkgs/commit/24e9218ae92faaf24fee57f2290d61abe3d8afc4) | `` otio: init at 0.17.0 ``                                                                     |
| [`06e42729`](https://github.com/NixOS/nixpkgs/commit/06e427292c06e875f251c6397173baf79c41a439) | `` home-assistant-custom-lovelace-modules.advanced-camera-card: 7.14.2 -> 7.14.3 (#427370 ) `` |
| [`b72bcc3a`](https://github.com/NixOS/nixpkgs/commit/b72bcc3aa55a2945028fbf0b8108e931cc6ac328) | `` python3Packages.ffmpy: refactor ``                                                          |
| [`f4187309`](https://github.com/NixOS/nixpkgs/commit/f4187309deafbdfaf59b9bd7997c2c42dd7756e8) | `` gitlab: 18.1.2 -> 18.2.0 ``                                                                 |
| [`78f194b3`](https://github.com/NixOS/nixpkgs/commit/78f194b3ae2a85dabb6789ba0929fc260687fd97) | `` google-chrome: 138.0.7204.100 -> 138.0.7204.157 ``                                          |
| [`12ed2954`](https://github.com/NixOS/nixpkgs/commit/12ed2954d4bef2867a56c78c96e3906fee25ec46) | `` nixos/homebridge: init ``                                                                   |
| [`b26ab810`](https://github.com/NixOS/nixpkgs/commit/b26ab810846076fe984e82379872f3d4f87686d5) | `` homebridge-config-ui-x: init at 5.1.0 ``                                                    |
| [`0f1a6033`](https://github.com/NixOS/nixpkgs/commit/0f1a603304469cc457b5f9ccabdd7d943e3129c3) | `` homebridge: init at 1.11.0 ``                                                               |
| [`310c43ab`](https://github.com/NixOS/nixpkgs/commit/310c43aba3f33646da4d8ecf8516b1c2ba9f5278) | `` python3Packages.testcontainers: 4.10.0 -> 4.12.0 ``                                         |