### PR TITLE
chore(flake/nixvim-flake): `236641f4` -> `c1cf1345`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1753197138,
-        "narHash": "sha256-b9KMEpONYE4tm2lL5SCEyAqTuyn8peUpQ9kxSfWhXRI=",
+        "lastModified": 1753408908,
+        "narHash": "sha256-0mW62bQsmhpkyKK1DeikxEq6EqkSn3o/FlTieIVUMwo=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "236641f4375c37af687e07ca38772646c4e89e06",
+        "rev": "c1cf1345275fc44e040cc2965370dc03234e640c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`c1cf1345`](https://github.com/alesauce/nixvim-flake/commit/c1cf1345275fc44e040cc2965370dc03234e640c) | `` chore(flake/nixpkgs): c87b95e2 -> fc02ee70 `` |