### PR TITLE
chore(flake/nixvim-flake): `ffebe493` -> `5e3798db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753487377,
-        "narHash": "sha256-dEr3pYtC4/1PhP5ADIV8Fjjmxv6WC6UisQAUqtwdews=",
+        "lastModified": 1753533009,
+        "narHash": "sha256-4KlfDVsYL9c3ogEehJcQOBZ+pUBH7Lwvlu2J6FCtSJc=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "3d09c8eaceb7a78ef9f5568024da1616f00c33e3",
+        "rev": "29edaafdb088cee3d8c616a4a5bb48b5eecc647c",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1753563814,
-        "narHash": "sha256-Ycxx5LWhlh9eR0/55dgQb6PNv6UT7X/ohlCGd5gj++c=",
+        "lastModified": 1753582295,
+        "narHash": "sha256-9cEb5/3TELO0fNF+MWuqloYukJvljFwsU8D4LaF1P/8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "ffebe493a72000e6dbeb0f7d0cd1343d12f4389c",
+        "rev": "5e3798db04f034394a0291efcf75d3659affca52",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753385846,
-        "narHash": "sha256-XDu9T2o6Rxe0acpchwQ2aXaRfE/uEYALpVbf+9QDEO4=",
+        "lastModified": 1753450833,
+        "narHash": "sha256-Pmpke0JtLRzgdlwDC5a+aiLVZ11JPUO5Bcqkj0nHE/k=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "5c7e4eff303cba8447ffb443522b3c72bc47a9ba",
+        "rev": "40987cc1a24feba378438d691f87c52819f7bd75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`5e3798db`](https://github.com/alesauce/nixvim-flake/commit/5e3798db04f034394a0291efcf75d3659affca52) | `` chore(flake/nixvim): 3d09c8ea -> 29edaafd `` |