### PR TITLE
chore(flake/home-manager): `2b73c2fc` -> `72cc1e31`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753567913,
-        "narHash": "sha256-eYrqSRI1/mrnVGCGYO+zkKHUszwJQodq/qDHh+mzvkI=",
+        "lastModified": 1753617834,
+        "narHash": "sha256-WEVfKrdIdu5CpppJ0Va3vzP0DKlS+ZTLbBjugMO2Drg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2b73c2fcca690b6eca4f520179e54ae760f25d4e",
+        "rev": "72cc1e3134a35005006f06640724319caa424737",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`72cc1e31`](https://github.com/nix-community/home-manager/commit/72cc1e3134a35005006f06640724319caa424737) | `` tests/hyprlock: update tests with upstream changes ``     |
| [`0daef6fb`](https://github.com/nix-community/home-manager/commit/0daef6fbe0d71cd81967d9595a60c515a31ad034) | `` hyprlock: update example config ``                        |
| [`e8867156`](https://github.com/nix-community/home-manager/commit/e88671567b5020c41fa1880ef08428f91448548b) | `` zsh: only apply plugins when zsh is enabled (#7555) ``    |
| [`710771af`](https://github.com/nix-community/home-manager/commit/710771af3d1c8c3f86a9e5d562616973ed5f3f21) | `` docs: add a poison module ``                              |
| [`6ce43381`](https://github.com/nix-community/home-manager/commit/6ce433818580edc2acbf7282455331c4a5b95aae) | `` nixos: increase laziness regarding shared modules ``      |
| [`ed1eeeee`](https://github.com/nix-community/home-manager/commit/ed1eeeeee6279c371fbc0e4b6d68bc0b39077a16) | `` xdg-terminal-exec: make sure the module is imported ``    |
| [`42924f0e`](https://github.com/nix-community/home-manager/commit/42924f0eff0f6694d9e374e9c08a75fabc3eb140) | `` xdg-terminal-exec: minor cleanup of option description `` |
| [`63dd0e94`](https://github.com/nix-community/home-manager/commit/63dd0e9409accc1df46b81199f423c0446397775) | `` opencode: minor cleanup of option description ``          |