### PR TITLE
chore(flake/home-manager): `72cc1e31` -> `f49e872f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753617834,
-        "narHash": "sha256-WEVfKrdIdu5CpppJ0Va3vzP0DKlS+ZTLbBjugMO2Drg=",
+        "lastModified": 1753732062,
+        "narHash": "sha256-vojVM0SgFP8crFh1LDDXkzaI9/er/1cuRfbNPhfBHyc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "72cc1e3134a35005006f06640724319caa424737",
+        "rev": "f49e872f55e36e67ebcb906ff65f86c7a1538f7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`f49e872f`](https://github.com/nix-community/home-manager/commit/f49e872f55e36e67ebcb906ff65f86c7a1538f7c) | `` zsh: lib better docstrings ``                                       |
| [`a1b7e7f5`](https://github.com/nix-community/home-manager/commit/a1b7e7f510b93a48406adc894eed6d0811147d11) | `` tests/antidote: remove deprecated relative path usage ``            |
| [`471eeaa9`](https://github.com/nix-community/home-manager/commit/471eeaa9753a186338da134243584a44ccfde099) | `` zsh: add khaneliman maintainer ``                                   |
| [`08f16235`](https://github.com/nix-community/home-manager/commit/08f162350c5d0062dfc1dd0b628448099bbc8317) | `` news: add news entry for zsh path refactor ``                       |
| [`e52c6c3d`](https://github.com/nix-community/home-manager/commit/e52c6c3da3f9b16e085ef32a75237169c95364bf) | `` zsh: env var assertion for dotdir ``                                |
| [`40af7ba0`](https://github.com/nix-community/home-manager/commit/40af7ba06ba959a191ac1297f5f4e6c2786a1e39) | `` zsh: relative path deprecation warning ``                           |
| [`9ff467fb`](https://github.com/nix-community/home-manager/commit/9ff467fbe7d42972068cfcfc9167838e7c66aabc) | `` tests/zsh: add more path test cases ``                              |
| [`938ecd79`](https://github.com/nix-community/home-manager/commit/938ecd797f17b5baa408f7a0af01747a81e4bed6) | `` zsh: fix lib function for env var path parsing ``                   |
| [`20cf285e`](https://github.com/nix-community/home-manager/commit/20cf285e9f8e5e3968abca80081c03ea96e7ea73) | `` maintainers: update all-maintainers.nix (#7558) ``                  |
| [`a7b7c6f5`](https://github.com/nix-community/home-manager/commit/a7b7c6f520b51f3577bd6b7a7493d2cdbcb22ec6) | `` docs: add upgrade guide for NixOS version transitions ``            |
| [`3156a1c4`](https://github.com/nix-community/home-manager/commit/3156a1c4196e03e66ce16220d4f2e58cb19718cb) | `` docs: minor manual style fix ``                                     |
| [`e4b032ba`](https://github.com/nix-community/home-manager/commit/e4b032ba5113664f0b8b23d956e59ce8e0bc349d) | `` ci: re-enable home manager install and uninstall tests on darwin `` |
| [`a07400a2`](https://github.com/nix-community/home-manager/commit/a07400a2e53a59e1b06ef5b76f0062bcaf3500fc) | `` ci: don't duplicate test runs on github ``                          |
| [`800f16a9`](https://github.com/nix-community/home-manager/commit/800f16a9c53c279cdd1cdf847bdff5e99438eeb0) | `` tests: forward only test chunks to buildbot ``                      |
| [`7a02711a`](https://github.com/nix-community/home-manager/commit/7a02711a610d921f53e3a5b6a38fe3e71adc51cd) | `` tests: integration tests only run on linux ``                       |
| [`9fa2ad30`](https://github.com/nix-community/home-manager/commit/9fa2ad30c5df6dfa3bfed5ba057dc530b309c0bb) | `` buildbot-nix.toml: add file ``                                      |
| [`234f10ec`](https://github.com/nix-community/home-manager/commit/234f10ec6d97a45b401f23caa2de46954b2164bd) | `` tests/flake: add buildbot output ``                                 |
| [`e45ff565`](https://github.com/nix-community/home-manager/commit/e45ff5651ceecfb5b0a2cb37b11a73a7f713235f) | `` ci: split tests into chunks ``                                      |