### PR TITLE
chore(flake/tinted-schemes): `5a775c6f` -> `c279b1ef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1750770351,
-        "narHash": "sha256-LI+BnRoFNRa2ffbe3dcuIRYAUcGklBx0+EcFxlHj0SY=",
+        "lastModified": 1753742647,
+        "narHash": "sha256-NvTte5U88zkBfzhbEZ/xZfRQG5Xn3T0eGO59et/tVx4=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "5a775c6ffd6e6125947b393872cde95867d85a2a",
+        "rev": "c279b1efcd28f05109236fa66b6e153bda3148ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                      |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`c279b1ef`](https://github.com/tinted-theming/schemes/commit/c279b1efcd28f05109236fa66b6e153bda3148ff) | `` Adds base16 everforest-dark-medium theme variant (#64) `` |