### PR TITLE
chore(flake/nixvim-flake): `5e3798db` -> `ef44301d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753533009,
-        "narHash": "sha256-4KlfDVsYL9c3ogEehJcQOBZ+pUBH7Lwvlu2J6FCtSJc=",
+        "lastModified": 1753655972,
+        "narHash": "sha256-x1gsih/gAiUo6qw/ZjcFm3KqKLL/P1f9HgPGoi8bXQI=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "29edaafdb088cee3d8c616a4a5bb48b5eecc647c",
+        "rev": "4f584b5b366303510702b10c496ab27a44e90426",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1753582295,
-        "narHash": "sha256-9cEb5/3TELO0fNF+MWuqloYukJvljFwsU8D4LaF1P/8=",
+        "lastModified": 1753724174,
+        "narHash": "sha256-2+A7JUcsmgczKayEctl5xmlqFYUABBd6syhxasTOi+k=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5e3798db04f034394a0291efcf75d3659affca52",
+        "rev": "ef44301d120c85963e2a760b9b4b4374afc7a93e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`ef44301d`](https://github.com/alesauce/nixvim-flake/commit/ef44301d120c85963e2a760b9b4b4374afc7a93e) | `` chore(flake/nixpkgs): fc02ee70 -> 7fd36ee8 `` |
| [`717eb562`](https://github.com/alesauce/nixvim-flake/commit/717eb56277c7ef2edf805763e1ccca71aa288788) | `` chore(flake/nixvim): 29edaafd -> 4f584b5b ``  |