### PR TITLE
chore(flake/nixvim-flake): `ef44301d` -> `a9821cf4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753655972,
-        "narHash": "sha256-x1gsih/gAiUo6qw/ZjcFm3KqKLL/P1f9HgPGoi8bXQI=",
+        "lastModified": 1753706533,
+        "narHash": "sha256-ZNyVwyj+4qvaOT/gQWfNypP8qtHmXtt02D9WDZH4IPU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "4f584b5b366303510702b10c496ab27a44e90426",
+        "rev": "e1aa35fb04047df11a9c1ab539a0bac35ddad509",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1753724174,
-        "narHash": "sha256-2+A7JUcsmgczKayEctl5xmlqFYUABBd6syhxasTOi+k=",
+        "lastModified": 1753761092,
+        "narHash": "sha256-c+ETWizw5OjMCdE1w/mBrdrwfQK+5NP778umzuoLpcY=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "ef44301d120c85963e2a760b9b4b4374afc7a93e",
+        "rev": "a9821cf438e48fe3c2b710b81b6321f0470856f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                          |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------ |
| [`a9821cf4`](https://github.com/alesauce/nixvim-flake/commit/a9821cf438e48fe3c2b710b81b6321f0470856f9) | `` chore(flake/nixpkgs): 7fd36ee8 -> 17f6bd17 `` |
| [`e789dcdb`](https://github.com/alesauce/nixvim-flake/commit/e789dcdb97f6cf582229eb56856b9f54c6560d06) | `` chore(flake/nixvim): 4f584b5b -> e1aa35fb ``  |