### PR TITLE
chore(flake/home-manager): `f49e872f` -> `ab148052`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753732062,
-        "narHash": "sha256-vojVM0SgFP8crFh1LDDXkzaI9/er/1cuRfbNPhfBHyc=",
+        "lastModified": 1753829416,
+        "narHash": "sha256-Shx91k6pLdX8wK6LchsHRXWAWODvy6fHAbUqOmye43A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f49e872f55e36e67ebcb906ff65f86c7a1538f7c",
+        "rev": "ab14805267c132c5e9ac66129ca5361abd592a3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                      |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`ab148052`](https://github.com/nix-community/home-manager/commit/ab14805267c132c5e9ac66129ca5361abd592a3a) | `` darwinScrublist: add superfile ``                                         |
| [`fc55d9a4`](https://github.com/nix-community/home-manager/commit/fc55d9a42b178a62edb15a1d11b7085274a922a2) | `` flake.lock: Update ``                                                     |
| [`4bf12467`](https://github.com/nix-community/home-manager/commit/4bf124678be14242e916f4dec2596158900780d4) | `` hyprland: Add `"output"` to `importantPrefixes` option default (#7507) `` |
| [`909d3939`](https://github.com/nix-community/home-manager/commit/909d39391efa9a1f74f7386cb6919b2722e06310) | `` PULL_REQUEST_TEMPLATE: nixfmt-rfc-style -> nixfmt (#7580) ``              |
| [`b108e6b7`](https://github.com/nix-community/home-manager/commit/b108e6b7f75d2767a1a559345689e7bedfe7dd11) | `` editorconfig: fix insert_final_newline unset for json files ``            |
| [`1a8b119e`](https://github.com/nix-community/home-manager/commit/1a8b119e60158711ac53962f7a6ad478796f449a) | `` tests/caffeine: add test coverage ``                                      |
| [`cec4c1be`](https://github.com/nix-community/home-manager/commit/cec4c1be7eaae2ad3ec780b3c7cd26dbe8c3ce20) | `` tests/ssh-agent: add test coverage ``                                     |
| [`85a52871`](https://github.com/nix-community/home-manager/commit/85a5287116c6c09ce01ff006a3f14ba7a9d3c21b) | `` tests/gnome-keyring: add test coverage ``                                 |
| [`2f588d27`](https://github.com/nix-community/home-manager/commit/2f588d275ebd8243be6c29e7bf3ec7409baa0aa7) | `` hyprsunset: add program to home packages ``                               |
| [`f4e8bc1a`](https://github.com/nix-community/home-manager/commit/f4e8bc1ab6d3e2a178b86141d39f8b847dc52a1b) | `` hyprsunset: refactor implementation ``                                    |
| [`fa184c54`](https://github.com/nix-community/home-manager/commit/fa184c5460b1099ad7dafeba0ae980a998a12d8d) | `` hyprsunset: Add tests for transitons option ``                            |
| [`7c01358f`](https://github.com/nix-community/home-manager/commit/7c01358ff6f555330addf5f606d39fb97c70f8e3) | `` hyprsunset: Add tests for hyprsunset.conf file ``                         |
| [`6ff07a01`](https://github.com/nix-community/home-manager/commit/6ff07a01a811f3866e8fab0e30e48392e5741865) | `` hyprsunset: deprecate transitions option ``                               |
| [`8aaf3b53`](https://github.com/nix-community/home-manager/commit/8aaf3b53192e62abfd28eddf79f9a9de9d7834f5) | `` hyprsunset: Update module to use hyprsunset.conf ``                       |
| [`03fdb312`](https://github.com/nix-community/home-manager/commit/03fdb31290d1a4a8d23f52206283450d304c3841) | `` treewide: add missing package options (#7575) ``                          |
| [`25deca89`](https://github.com/nix-community/home-manager/commit/25deca893974aae98c9be151fb47d6284c053470) | `` Translate using Weblate (Finnish) ``                                      |
| [`1fa11c8e`](https://github.com/nix-community/home-manager/commit/1fa11c8e830b919b85d9d975567aad12cba69e8c) | `` Translate using Weblate (Turkish) ``                                      |
| [`1364772b`](https://github.com/nix-community/home-manager/commit/1364772b57c0dd751dfa3d9baf6c0978c52e0adc) | `` Translate using Weblate (Japanese) ``                                     |
| [`cfe397c8`](https://github.com/nix-community/home-manager/commit/cfe397c8c091a06a5a0a4e683e6fca2e57a8312f) | `` arrpc: assert linux ``                                                    |
| [`0f9fae16`](https://github.com/nix-community/home-manager/commit/0f9fae161dba7c828de66d1111dfd82909cbd6f8) | `` tests/arrpc: add service module test coverage ``                          |
| [`1ed730a9`](https://github.com/nix-community/home-manager/commit/1ed730a9771eba6b9426e58b8d29baa7084cba89) | `` ci: manage reviewers doesn't re-add manually removed reviewers ``         |
| [`2c8306e5`](https://github.com/nix-community/home-manager/commit/2c8306e506718d4c7596ba0b2a595a8e623fc009) | `` ci: manage reviewers add dry run option ``                                |
| [`50adf8fc`](https://github.com/nix-community/home-manager/commit/50adf8fcaa97c9d64309f2d507ed8be54ea23110) | `` PR_TEMPLATE: remove maintainer cc section (#7569) ``                      |