### PR TITLE
chore(flake/home-manager): `ab148052` -> `0630790b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753829416,
-        "narHash": "sha256-Shx91k6pLdX8wK6LchsHRXWAWODvy6fHAbUqOmye43A=",
+        "lastModified": 1753888434,
+        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ab14805267c132c5e9ac66129ca5361abd592a3a",
+        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                     |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`0630790b`](https://github.com/nix-community/home-manager/commit/0630790b31d4547d79ff247bc3ba1adda3a017d9) | `` tests: include test names in passthru `` |
| [`53524d8b`](https://github.com/nix-community/home-manager/commit/53524d8b274a4710ff9e2bf3468764937217ed8e) | `` tests: chunk size 250 -> 50 ``           |
| [`d732b648`](https://github.com/nix-community/home-manager/commit/d732b648e5a7e3b89439ee25895e4eb24b7e5452) | `` udiskie: fix getExe warning ``           |