### PR TITLE
chore(flake/home-manager): `0630790b` -> `7035020a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753888434,
-        "narHash": "sha256-xQhSeLJVsxxkwchE4s6v1CnOI6YegCqeA1fgk/ivVI4=",
+        "lastModified": 1753983724,
+        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0630790b31d4547d79ff247bc3ba1adda3a017d9",
+        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                        |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`7035020a`](https://github.com/nix-community/home-manager/commit/7035020a507ed616e2b20c61491ae3eaa8e5462c) | `` anki: set valid language default ``                         |
| [`e2238e60`](https://github.com/nix-community/home-manager/commit/e2238e60736a2dd86f5bcf6fafee72429a9cd6ff) | `` anki: remove trailing whitespace ``                         |
| [`4e97102b`](https://github.com/nix-community/home-manager/commit/4e97102bd44899c514411aa8e604ecc33a9da356) | `` nh: add options for specific flakes (#7566) ``              |
| [`bd82507e`](https://github.com/nix-community/home-manager/commit/bd82507edd860c453471c46957cbbe3c9fd01b5c) | `` home-manager: re-enable gcroot handling for NixOS module `` |