### PR TITLE
chore(flake/stylix): `30f50222` -> `ded4f29a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753919664,
-        "narHash": "sha256-U7Ts8VbVD4Z6n67gFx00dkpQJu27fMu173IUopX3pNI=",
+        "lastModified": 1753978157,
+        "narHash": "sha256-sVy8hb71VawSOIsLv/hMGzpvbbWszdP9aSKI5Drbt6Q=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "30f5022236cf8dd257941cb0f910e198e7e464c7",
+        "rev": "ded4f29a023e0f14506ec16b0e32d129e56341cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`ded4f29a`](https://github.com/nix-community/stylix/commit/ded4f29a023e0f14506ec16b0e32d129e56341cc) | `` doc/src/modules: fix admonition formatting (#1814) ``                         |
| [`e544f6ec`](https://github.com/nix-community/stylix/commit/e544f6ec6cabf2f846975408540e30811b3df4e0) | `` ci: visually distinguish user description from PR template content (#1802) `` |