### PR TITLE
chore(flake/nixvim-flake): `11a206d5` -> `080fd13b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1753878247,
-        "narHash": "sha256-nxwVcC0ptpXenOWAyXTkYysbWAJPBIu2Mgp4XiFOfm4=",
+        "lastModified": 1753977315,
+        "narHash": "sha256-AM3CZh+Emk/cr5Gf6RUf2xzkWdRB+yewP1YWoRxUbYQ=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "1729fe160872c9e53bd6977d92f53ef131606d4e",
+        "rev": "a16c89c175277309fd3dd065fb5bc4eab450ae07",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1754001429,
-        "narHash": "sha256-bOUf+jX6HG4bhuZ6XoxzmB6y4wldvlwHYB5R3BPQrKs=",
+        "lastModified": 1754014493,
+        "narHash": "sha256-p+SDK1BVqyWY0A43+Jzo7+7L6L+2ZKs8FSOS2GXs9o8=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "11a206d52b5c86eb330bae20f8e6c0997f55b00d",
+        "rev": "080fd13b08b6a94ec93f6d199651dbc050ce28cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`080fd13b`](https://github.com/alesauce/nixvim-flake/commit/080fd13b08b6a94ec93f6d199651dbc050ce28cb) | `` chore(flake/nixvim): 1729fe16 -> a16c89c1 `` |