### PR TITLE
chore(flake/tinted-schemes): `7ef9b314` -> `ed9d7d6e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1753976271,
-        "narHash": "sha256-TrVL5MmmuUi2ahfbYUpHWgZIK93WgbzecXmgOTQGSXE=",
+        "lastModified": 1754131179,
+        "narHash": "sha256-zxx9oK1gziEERgpErHEhpqxwooUzLX2roMYhwZR7C1I=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "7ef9b3144e0ccd3f8d80aeaccc49ef62c501fafe",
+        "rev": "ed9d7d6e024c358c68c17527022df3221f61c9f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                         |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`ed9d7d6e`](https://github.com/tinted-theming/schemes/commit/ed9d7d6e024c358c68c17527022df3221f61c9f2) | `` Fix #65 Tomorrow light theme corrections for selection/current-line (#66) `` |