### PR TITLE
chore(flake/stylix): `ded4f29a` -> `1b5e1c56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1753978157,
-        "narHash": "sha256-sVy8hb71VawSOIsLv/hMGzpvbbWszdP9aSKI5Drbt6Q=",
+        "lastModified": 1754264048,
+        "narHash": "sha256-Yg1W0sFhBpnglfhWGlFmxzSmte1F157luHAADp5Hguk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "ded4f29a023e0f14506ec16b0e32d129e56341cc",
+        "rev": "1b5e1c5642cf96e07daf14ae4c5ddd23d7ed5623",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                  |
| ----------------------------------------------------------------------------------------------------- | ------------------------ |
| [`1b5e1c56`](https://github.com/nix-community/stylix/commit/1b5e1c5642cf96e07daf14ae4c5ddd23d7ed5623) | `` anki: init (#1801) `` |