### PR TITLE
chore(flake/nixvim-flake): `968923ad` -> `7a3d59b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1753772735,
-        "narHash": "sha256-HUgJOJ4PTcgGh0dvkNTz9E7lJtPXClLiD49dpBdCNJI=",
+        "lastModified": 1754063734,
+        "narHash": "sha256-mFQSJTHgq+RZId64ABCO/PMhGcSdHkc3OXTxAITEMzA=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "3e0cd62c7723cd30ca2bd54fc4811cd8f5c5e5df",
+        "rev": "697f368f89663c3be8fded8a14971ffd37557e12",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1754099934,
-        "narHash": "sha256-PafYIE5KYrWDhC3VOYvaWk8YPGl5FZXtUvN2K1Nkrzk=",
+        "lastModified": 1754187189,
+        "narHash": "sha256-epYs+O1dhtF3PgC689nXRNVZ9aL9fGIPqR1yXW1eLbg=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "968923ad07394ce454ac7e12f80725fdaeaca648",
+        "rev": "7a3d59b321ad90c3b6d18cec6299b6f670da4582",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753772294,
-        "narHash": "sha256-8rkd13WfClfZUBIYpX5dvG3O9V9w3K9FPQ9rY14VtBE=",
+        "lastModified": 1754061284,
+        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6b9214fffbcf3f1e608efa15044431651635ca83",
+        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                 |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`7a3d59b3`](https://github.com/alesauce/nixvim-flake/commit/7a3d59b321ad90c3b6d18cec6299b6f670da4582) | `` chore(flake/nix-fast-build): 3e0cd62c -> 697f368f `` |