### PR TITLE
chore(flake/home-manager): `1d7abbd5` -> `f0d81a41`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754263839,
-        "narHash": "sha256-ck7lILfCNuunsLvExPI4Pw9OOCJksxXwozum24W8b+8=",
+        "lastModified": 1754441365,
+        "narHash": "sha256-yYYxwqUydEX/Ta+0HNLRaxW8GQLDRXGdC6xE84ZjRtI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d7abbd5454db97e0af51416f4960b3fb64a4773",
+        "rev": "f0d81a415d7a8fbf57b518aec5cf7dca20576389",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                         |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
| [`f0d81a41`](https://github.com/nix-community/home-manager/commit/f0d81a415d7a8fbf57b518aec5cf7dca20576389) | `` news: add new feature entries ``                             |
| [`c23168ac`](https://github.com/nix-community/home-manager/commit/c23168acf558fc24adc8240533c4fbf9591f183e) | `` vscode: specify full path ``                                 |
| [`9b59dcee`](https://github.com/nix-community/home-manager/commit/9b59dcee0b0190de497bfc177687265b665c6c1d) | `` vscode: quote path ``                                        |
| [`a0b1afdb`](https://github.com/nix-community/home-manager/commit/a0b1afdb5efbf59f4b6e934d090cf8d150517890) | `` news: add new module entries ``                              |
| [`b7ee8dee`](https://github.com/nix-community/home-manager/commit/b7ee8deefca4f88be521077b2f6975618c7e0ab6) | `` programs/nix-search-tv: init ``                              |
| [`28caf471`](https://github.com/nix-community/home-manager/commit/28caf471a643f951e60b4b71d367b990ff6bbbf1) | `` Add self as maintainer ``                                    |
| [`74b4edc2`](https://github.com/nix-community/home-manager/commit/74b4edc2d28cff9b225ef12ebae9ce14948ba8d8) | `` fontconfig: add options for font rendering ``                |
| [`672381a3`](https://github.com/nix-community/home-manager/commit/672381a34e2bc7c872f6943d46293f0044c6cf87) | `` fontconfig: add maintainer bmrips ``                         |
| [`6d1fddb1`](https://github.com/nix-community/home-manager/commit/6d1fddb13b0663ffd7464c2d39379972502ef126) | `` gcc: init module (#7614) ``                                  |
| [`0cda19d4`](https://github.com/nix-community/home-manager/commit/0cda19d4209bb28db8fcaa54df4621eb97c36b5d) | `` grep: init module (#7613) ``                                 |
| [`36ad7d25`](https://github.com/nix-community/home-manager/commit/36ad7d25fbc60b820d3a06dbf4cf6200948f7fc4) | `` zsh: option to define autoloadable site-functions (#7611) `` |
| [`c5d7e957`](https://github.com/nix-community/home-manager/commit/c5d7e957397ecb7d48b99c928611c6e780db1b56) | `` nushell: remove Philipp-M as maintainer ``                   |