### PR TITLE
chore(flake/home-manager): `f0d81a41` -> `475d3579`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754441365,
-        "narHash": "sha256-yYYxwqUydEX/Ta+0HNLRaxW8GQLDRXGdC6xE84ZjRtI=",
+        "lastModified": 1754527677,
+        "narHash": "sha256-qAzCtmKkMz40xFgP9KN+TCKjVieK4u04EWwl2KvVk0E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f0d81a415d7a8fbf57b518aec5cf7dca20576389",
+        "rev": "475d35797d9537354d825260cf583114537affc2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`475d3579`](https://github.com/nix-community/home-manager/commit/475d35797d9537354d825260cf583114537affc2) | `` treefmt: handle deadnix excludes ``               |
| [`62fdc8d4`](https://github.com/nix-community/home-manager/commit/62fdc8d41097313e681446b46681a4f89544e51c) | `` keepassxc: add autostart option ``                |
| [`cb8cfa0e`](https://github.com/nix-community/home-manager/commit/cb8cfa0eb9a7f2ab2edaaf934f5e413b91800c31) | `` keepassxc: add maintainer bmrips ``               |
| [`13c5c2fb`](https://github.com/nix-community/home-manager/commit/13c5c2fb4cbed19ee40552a29a1b0fac8839a2dd) | `` Translate using Weblate (Ukrainian) ``            |
| [`13461dec`](https://github.com/nix-community/home-manager/commit/13461dec40bf03d9196ff79d1abe48408268cc35) | `` git-credential-keepassxc: fix eval ``             |
| [`2a299689`](https://github.com/nix-community/home-manager/commit/2a29968912815e825a8cae73e2535a94424a9d1b) | `` git-credential-keepassxc: init module ``          |
| [`53bf4fab`](https://github.com/nix-community/home-manager/commit/53bf4fab3013c9c200593a45c95469dba12c5315) | `` docs: add tests command documentation ``          |
| [`bf2dc7eb`](https://github.com/nix-community/home-manager/commit/bf2dc7ebd8e3fd10f24cfe0a8acfd3d2676666c7) | `` tests: add tests package to search / run tests `` |
| [`88913c98`](https://github.com/nix-community/home-manager/commit/88913c98fe674e10302bbdb71b4e173f527b69c2) | `` goto: init module ``                              |
| [`ad5d2b4a`](https://github.com/nix-community/home-manager/commit/ad5d2b4aa770fdc74c80fd682fee0b00a8ad7991) | `` rescrobbled: add module ``                        |
| [`f6cc29aa`](https://github.com/nix-community/home-manager/commit/f6cc29aab07640942da39250ac8e23a69ebe0f3e) | `` flake.lock: Update ``                             |
| [`c15ffc85`](https://github.com/nix-community/home-manager/commit/c15ffc850c1f0dff20602742cd660c32bdaa1c8c) | `` news: fix duplicate news id ``                    |
| [`998c2374`](https://github.com/nix-community/home-manager/commit/998c2374f0e332f46ea3100157d0acfcdcfa4e97) | `` news: cleanup invalid timestamps ``               |
| [`ac351d43`](https://github.com/nix-community/home-manager/commit/ac351d435afd1b648b30202edc3f6390497708ae) | `` tests/news: add new test for news entries ``      |
| [`8f02266b`](https://github.com/nix-community/home-manager/commit/8f02266b8e49c1c6bbe122b5602e1c877e42c5be) | `` news: fix font config entry ``                    |
| [`a3790776`](https://github.com/nix-community/home-manager/commit/a3790776751d1a6365aa0717f509d05adee90734) | `` sherlock: init module ``                          |