### PR TITLE
chore(flake/nix-fast-build): `690b9c4f` -> `002c4dc7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1754421903,
-        "narHash": "sha256-l5wfRpuHuz9hGfkaVYCsGQJrreTlHU/bdYJxhvi+AD8=",
+        "lastModified": 1754493851,
+        "narHash": "sha256-kecuVrshNkKb04AYxaDNc8pFaLABgbrvPbcyicJ5ECQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "690b9c4f56abc842b5e930e6eb54810c6c49f93f",
+        "rev": "002c4dc74cb683de08a1f863e1831e19f86f3edd",
         "type": "github"
       },
       "original": {
@@ -805,11 +805,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754061284,
-        "narHash": "sha256-ONcNxdSiPyJ9qavMPJYAXDNBzYobHRxw0WbT38lKbwU=",
+        "lastModified": 1754492133,
+        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "58bd4da459f0a39e506847109a2a5cfceb837796",
+        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`002c4dc7`](https://github.com/Mic92/nix-fast-build/commit/002c4dc74cb683de08a1f863e1831e19f86f3edd) | `` chore(deps): update treefmt-nix digest to 1298185 (#213) `` |
| [`e03be500`](https://github.com/Mic92/nix-fast-build/commit/e03be50046743a1861e7ac95741744f420a3ab98) | `` chore(deps): update treefmt-nix digest to bf87ce8 (#212) `` |
| [`85b95df9`](https://github.com/Mic92/nix-fast-build/commit/85b95df96be69378761ef8113501f1a5551ace79) | `` chore(deps): update flake-parts digest to af66ad1 (#211) `` |
| [`e982566c`](https://github.com/Mic92/nix-fast-build/commit/e982566ce3f52a23dd93ff68153cb59cee17a8ec) | `` chore(deps): update treefmt-nix digest to 7828e72 (#210) `` |
| [`011b8763`](https://github.com/Mic92/nix-fast-build/commit/011b876305711f116dc3fed3e802ba970639ebe5) | `` chore(deps): update treefmt-nix digest to 861c262 (#209) `` |