### PR TITLE
chore(flake/home-manager): `475d3579` -> `cc2fa233`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754527677,
-        "narHash": "sha256-qAzCtmKkMz40xFgP9KN+TCKjVieK4u04EWwl2KvVk0E=",
+        "lastModified": 1754613544,
+        "narHash": "sha256-ueR1mGX4I4DWfDRRxxMphbKDNisDeMPMusN72VV1+cc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "475d35797d9537354d825260cf583114537affc2",
+        "rev": "cc2fa2331aebf9661d22bb507d362b39852ac73f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`cc2fa233`](https://github.com/nix-community/home-manager/commit/cc2fa2331aebf9661d22bb507d362b39852ac73f) | `` maintainers: add Kyure_A ``                         |
| [`7a985e8f`](https://github.com/nix-community/home-manager/commit/7a985e8f5dca513a13c7060d0b7260cf1b63728a) | `` maintainers: add elanora96 ``                       |
| [`5f8bb123`](https://github.com/nix-community/home-manager/commit/5f8bb123b9b6d0a9e9bbc82a958d9013007f4955) | `` sheldon: init module ``                             |
| [`5de16c70`](https://github.com/nix-community/home-manager/commit/5de16c704b0fc8f519b2c19ed3f683a9e68f3884) | `` getmail: remove redundant filter ``                 |
| [`dbfcd329`](https://github.com/nix-community/home-manager/commit/dbfcd3292d8af44eed8e41b222cbbf8685b950c6) | `` accounts.email: add option to disable an account `` |
| [`07b994ba`](https://github.com/nix-community/home-manager/commit/07b994baedd3647f57b3fa8c6b022bff56bddbc9) | `` tests: include integration tests in buildbot ``     |
| [`2b87f9a5`](https://github.com/nix-community/home-manager/commit/2b87f9a53a9fc3ba95caa262b6e887a9c933b8b5) | `` tests: refactor outputs ``                          |
| [`faa5b42e`](https://github.com/nix-community/home-manager/commit/faa5b42eca5b59ec9edcda3a5aa4b4524f4c2a12) | `` codex: support XDG Base Directory specification ``  |
| [`d8a475e1`](https://github.com/nix-community/home-manager/commit/d8a475e179888553b6863204a93295da6ee13eb4) | `` tests: add mullvad-vpn to darwin scrublist ``       |
| [`a5506862`](https://github.com/nix-community/home-manager/commit/a5506862dc265a20b6790ae48e017ac2b3da6454) | `` mullvad-vpn: fix home.package -> home.packages ``   |
| [`c7acf2b1`](https://github.com/nix-community/home-manager/commit/c7acf2b1bf1ec6c3a17b0b598e62e4190a1f1844) | `` mullvad-vpn: add module ``                          |
| [`6275d1fc`](https://github.com/nix-community/home-manager/commit/6275d1fc57d3c149691cddba0809ef040dfa7843) | `` accounts.email: add 'davmail' flavor ``             |
| [`5ab62b61`](https://github.com/nix-community/home-manager/commit/5ab62b61fb4d47f2740bfcef52d540f95335360e) | `` accounts.email: add authentication mechanism ``     |