### PR TITLE
chore(flake/tinted-schemes): `7fa77635` -> `a4dc01bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1754407877,
-        "narHash": "sha256-fMXajwBkqImbAc3HxFU+EszvGlG+SuXKukSTuNvehig=",
+        "lastModified": 1754563794,
+        "narHash": "sha256-F5nmLro01w6uN7yIigw3d3R8EqKEzOB0i/ySVzmFJYA=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "7fa77635f7f0858f7e72ba51cd017b5a2574cab3",
+        "rev": "a4dc01bf442ec87fdaec71a9546346df7dc423fd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                           |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`a4dc01bf`](https://github.com/tinted-theming/schemes/commit/a4dc01bf442ec87fdaec71a9546346df7dc423fd) | `` Fix base16 and base24 links and format text `` |