### PR TITLE
chore(flake/tinted-schemes): `a4dc01bf` -> `6486b6b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -752,11 +752,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1754563794,
-        "narHash": "sha256-F5nmLro01w6uN7yIigw3d3R8EqKEzOB0i/ySVzmFJYA=",
+        "lastModified": 1754664340,
+        "narHash": "sha256-mpOzHOsADgh17tGekyuXxUbUEqXVv4An1vTDvx5pXOI=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "a4dc01bf442ec87fdaec71a9546346df7dc423fd",
+        "rev": "6486b6b01cbc5421a9f4a64f726ef4ad97a5b09e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                                    |
| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`6486b6b0`](https://github.com/tinted-theming/schemes/commit/6486b6b01cbc5421a9f4a64f726ef4ad97a5b09e) | `` Use colors from github.com/ayu-theme/ayu-colors to style ayu schemes `` |
| [`d15bb579`](https://github.com/tinted-theming/schemes/commit/d15bb57964b5c99e8d092f4e7f77343c059d5272) | `` rename base24-ayu to base24-ayu-dark to match base16-ayu-dark ``        |