### PR TITLE
chore(flake/nix-index-database): `b7fcd4e2` -> `b65f8d80`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754195341,
-        "narHash": "sha256-YL71IEf2OugH3gmAsxQox6BJI0KOcHKtW2QqT/+s2SA=",
+        "lastModified": 1754800038,
+        "narHash": "sha256-UbLO8/0pVBXLJuyRizYOJigtzQAj8Z2bTnbKSec/wN0=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b7fcd4e26d67fca48e77de9b0d0f954b18ae9562",
+        "rev": "b65f8d80656f9fcbd1fecc4b7f0730f468333142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`b65f8d80`](https://github.com/nix-community/nix-index-database/commit/b65f8d80656f9fcbd1fecc4b7f0730f468333142) | `` update generated.nix to release 2025-08-10-035719 `` |
| [`6784a9ce`](https://github.com/nix-community/nix-index-database/commit/6784a9ce7688876ff7f1c93b1af1de47da48a16f) | `` flake.lock: Update ``                                |