### PR TITLE
chore(flake/nixvim-flake): `f03d6f2f` -> `2c1e73bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753121425,
-        "narHash": "sha256-TVcTNvOeWWk1DXljFxVRp+E0tzG1LhrVjOGGoMHuXio=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "644e0fc48951a860279da645ba77fe4a6e814c5e",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1754933997,
-        "narHash": "sha256-TsBGGFo3ruhu1EbSuG0ZQR+KFtVg+lgQPQZEZV+zgpE=",
+        "lastModified": 1755111453,
+        "narHash": "sha256-TuBYORqiTbgUpUfVkcSQB2664SKDU5Fxfqb7uGpWY34=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "4d204b0e917587eb39dcdc48077e15bba88d9b80",
+        "rev": "ca71de01f4fa3a79409c2d02dddb495494de1d11",
         "type": "github"
       },
       "original": {
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1754264148,
-        "narHash": "sha256-i73/RHYnrRj1AW7r42qzEX1CruxAdVLXcn2iuWBQy64=",
+        "lastModified": 1755095763,
+        "narHash": "sha256-cFwtMaONA4uKYk/rBrmFvIAQieZxZytoprzIblTn1HA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "0b87d94432f3d2e2154a055f18dcb6531c6c90ab",
+        "rev": "ecc7880e00a2a735074243d8a664a931d73beace",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1754963678,
-        "narHash": "sha256-jHLtO18Y8hIqn7nBxYo0c7M0wMqZ/9P5fU1aLgNTpks=",
+        "lastModified": 1755226857,
+        "narHash": "sha256-CprH3omNfW245LWkMJOCoRW5ABu3+qiQOlmrYMCHIy0=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "f03d6f2fc6bdddfdb2412c7d2810b2c9189d09c4",
+        "rev": "2c1e73bc25dae09aef1d70c8f21d6708627811e7",
         "type": "github"
       },
       "original": {
@@ -594,11 +594,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753450833,
-        "narHash": "sha256-Pmpke0JtLRzgdlwDC5a+aiLVZ11JPUO5Bcqkj0nHE/k=",
+        "lastModified": 1754301638,
+        "narHash": "sha256-aRgzcPDd2axHFOuMlPLuzmDptUM2JU8mUL3jfgbBeyc=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "40987cc1a24feba378438d691f87c52819f7bd75",
+        "rev": "a60091045273484c040a91f5c229ba298f8ecc27",
         "type": "github"
       },
       "original": {
@@ -827,11 +827,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754492133,
-        "narHash": "sha256-B+3g9+76KlGe34Yk9za8AF3RL+lnbHXkLiVHLjYVOAc=",
+        "lastModified": 1754847726,
+        "narHash": "sha256-2vX8QjO5lRsDbNYvN9hVHXLU6oMl+V/PsmIiJREG4rE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1298185c05a56bff66383a20be0b41a307f52228",
+        "rev": "7d81f6fb2e19bf84f1c65135d1060d829fae2408",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
| [`2c1e73bc`](https://github.com/alesauce/nixvim-flake/commit/2c1e73bc25dae09aef1d70c8f21d6708627811e7) | `` fix: Removing explicit enable of cmp plugin, setting cmp integration to false for lspkind `` |
| [`1083c87d`](https://github.com/alesauce/nixvim-flake/commit/1083c87d49f254b1b26815144f1268040f3ab537) | `` fix: Removing explicit enable of cmp plugin, setting cmp integration to false for lspkind `` |
| [`09d19e8a`](https://github.com/alesauce/nixvim-flake/commit/09d19e8aca763afa1ae2ad7511e757a1915f080c) | `` fix: Explicitly enable nvim-cmp plugin ``                                                    |
| [`453f3a0c`](https://github.com/alesauce/nixvim-flake/commit/453f3a0c3f95e8e7d010d48b7090dfab5d90399a) | `` chore(flake/nixvim): 0b87d944 -> ecc7880e ``                                                 |
| [`b30f8fea`](https://github.com/alesauce/nixvim-flake/commit/b30f8fea7f5b26da9b82eb694591c20ce5daa1b2) | `` chore(config/navigation/nvim-tree): Update deprecated attribute names ``                     |
| [`5b039a6a`](https://github.com/alesauce/nixvim-flake/commit/5b039a6a6c61fb8238963790ec05f74f91ecd146) | `` chore(flake/nix-fast-build): 4d204b0e -> ca71de01 ``                                         |