### PR TITLE
chore(flake/nix-index-database): `b65f8d80` -> `ebbc1c05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754800038,
-        "narHash": "sha256-UbLO8/0pVBXLJuyRizYOJigtzQAj8Z2bTnbKSec/wN0=",
+        "lastModified": 1755404379,
+        "narHash": "sha256-Q6ZxZDBmD/B988Jjbx7/NchxOKIpOKBBrx9Yb0zMzpQ=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "b65f8d80656f9fcbd1fecc4b7f0730f468333142",
+        "rev": "ebbc1c05f786ae39bb5e04e57bf2c10c44a649e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`ebbc1c05`](https://github.com/nix-community/nix-index-database/commit/ebbc1c05f786ae39bb5e04e57bf2c10c44a649e3) | `` update generated.nix to release 2025-08-17-034715 `` |
| [`6991c112`](https://github.com/nix-community/nix-index-database/commit/6991c112026d92ab4dfb95beef1665de6c45cd4d) | `` flake.lock: Update ``                                |