### PR TITLE
chore(flake/home-manager): `2a749f47` -> `d2ffdedf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755313937,
-        "narHash": "sha256-pQb7bNcolxYGRiylUCrTddiF+qW2wsUiM9+eRIDUrVU=",
+        "lastModified": 1755442500,
+        "narHash": "sha256-RHK4H6SWzkAtW/5WBHsyugaXJX25yr5y7FAZznxcBJs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a749f4790a14f7168be67cdf6e548ef1c944e10",
+        "rev": "d2ffdedfc39c591367b1ddf22b4ce107f029dcc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`d2ffdedf`](https://github.com/nix-community/home-manager/commit/d2ffdedfc39c591367b1ddf22b4ce107f029dcc3) | `` flake.lock: Update (#7686) ``          |
| [`bc014931`](https://github.com/nix-community/home-manager/commit/bc014931784c62b566cad39b8510e76dde588d94) | `` mypy: init module (#7656) ``           |
| [`3dcae8af`](https://github.com/nix-community/home-manager/commit/3dcae8af51acd6f5ecc039fa23d044439cd19ae0) | `` hyprshot: init module ``               |
| [`b9600670`](https://github.com/nix-community/home-manager/commit/b96006701369a5f576ca20ce0a8ab2ea347ab3b5) | `` maintainers: add joker9944 ``          |
| [`1daeb063`](https://github.com/nix-community/home-manager/commit/1daeb0638a891baf19bca3094598159b17c3cda7) | `` protonmail-bridge: init module ``      |
| [`8275e5d3`](https://github.com/nix-community/home-manager/commit/8275e5d3157ff8797cf7b01f044ad5479e031b42) | `` maintainers: add epixtm ``             |
| [`8b4ac149`](https://github.com/nix-community/home-manager/commit/8b4ac149687e8520187a66f05e9d4eafebf96522) | `` claude-code: init module (#7685) ``    |
| [`56731200`](https://github.com/nix-community/home-manager/commit/567312006a06ccb398816152eb1a5f6b65f8a8b2) | `` tmux: make package nullable (#7682) `` |