### PR TITLE
chore(flake/nix-fast-build): `8adab2f6` -> `520987ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -396,11 +396,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1755174649,
-        "narHash": "sha256-6X4BW+3C2nfkorMfe+tuoeYrdddxPtLqOJ1rZxuxPrc=",
+        "lastModified": 1755401725,
+        "narHash": "sha256-QbLpahB71HbJpzARdzLgVf5PMVW7z4xD1L/xBhauyyQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "8adab2f65abc01e088b03c2e1e9210c0cf9519d2",
+        "rev": "520987cafbfad2531bdc73eebc556a49f1b67fb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`77c07852`](https://github.com/Mic92/nix-fast-build/commit/77c078525d720647471b0a99ae9431d7bc71d353) | `` Update flake input: nixpkgs `` |