### PR TITLE
chore(flake/home-manager): `d2ffdedf` -> `f8af2cbe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755442500,
-        "narHash": "sha256-RHK4H6SWzkAtW/5WBHsyugaXJX25yr5y7FAZznxcBJs=",
+        "lastModified": 1755491080,
+        "narHash": "sha256-ib1Xi13NEalrFqQAHceRsb+6aIPANFuQq80SS/bY10M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2ffdedfc39c591367b1ddf22b4ce107f029dcc3",
+        "rev": "f8af2cbe386f9b96dd9efa57ab15a09377f38f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`f8af2cbe`](https://github.com/nix-community/home-manager/commit/f8af2cbe386f9b96dd9efa57ab15a09377f38f4d) | `` issue_template: remove git blame from issue template (#7692) `` |
| [`5ca4c81f`](https://github.com/nix-community/home-manager/commit/5ca4c81fd5a9bbe6899379ee729d6f495564ed3f) | `` ci: bump actions/checkout from 4 to 5 (#7690) ``                |