### PR TITLE
chore(flake/nixvim-flake): `dc9219dc` -> `24e18eb0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754416808,
-        "narHash": "sha256-c6yg0EQ9xVESx6HGDOCMcyRSjaTpNJP10ef+6fRcofA=",
+        "lastModified": 1755446520,
+        "narHash": "sha256-I0Ok1OGDwc1jPd8cs2VvAYZsHriUVFGIUqW+7uSsOUM=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9c52372878df6911f9afc1e2a1391f55e4dfc864",
+        "rev": "4b04db83821b819bbbe32ed0a025b31e7971f22e",
         "type": "github"
       },
       "original": {
@@ -422,11 +422,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1755174649,
-        "narHash": "sha256-6X4BW+3C2nfkorMfe+tuoeYrdddxPtLqOJ1rZxuxPrc=",
+        "lastModified": 1755401725,
+        "narHash": "sha256-QbLpahB71HbJpzARdzLgVf5PMVW7z4xD1L/xBhauyyQ=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "8adab2f65abc01e088b03c2e1e9210c0cf9519d2",
+        "rev": "520987cafbfad2531bdc73eebc556a49f1b67fb7",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1755374860,
-        "narHash": "sha256-7xwSiVuh1l+q+shzk/MUxmjnW/GJlshjRCw63ErDU7A=",
+        "lastModified": 1755518759,
+        "narHash": "sha256-pVHJThQ+wq5zHklLuFt3QEJyR23lyWGWeKblZ3pUXiI=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "dc9219dcb47b7b240e5859bccdc1b0ffe447d37e",
+        "rev": "24e18eb05b94197a461069abb5ba7f343040bea9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                         |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`24e18eb0`](https://github.com/alesauce/nixvim-flake/commit/24e18eb05b94197a461069abb5ba7f343040bea9) | `` feat(config/folding): Enable nvim-ufo as folding provider `` |
| [`93f1d1d7`](https://github.com/alesauce/nixvim-flake/commit/93f1d1d76408887b84587266a0e5577a36001a36) | `` chore(flake/git-hooks): 9c523728 -> 4b04db83 ``              |
| [`bc859ad2`](https://github.com/alesauce/nixvim-flake/commit/bc859ad2aa5190d7f8160f69d244a51ead78507e) | `` chore(flake/nix-fast-build): 8adab2f6 -> 520987ca ``         |