### PR TITLE
chore(flake/stylix): `9810b32b` -> `2567b924`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1755546184,
-        "narHash": "sha256-KxRj/8SydDk3gzamS0VEewo5pu8JAYhSZ5GPcImPGNQ=",
+        "lastModified": 1755636375,
+        "narHash": "sha256-HQQ7LdyHWCUcRBeGLTwJm+tJ8hmuglSzP/ZLeNBjFkk=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "9810b32b9b7520e3b37358ff8e793fb5034c3299",
+        "rev": "2567b924669c566d132ce4cafd4bc0a119846b52",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`e01d56cf`](https://github.com/nix-community/stylix/commit/e01d56cf5c00449f4d0af4013512ed906ed7d3c9) | `` stylix/droid: fix import droid modules (#1823) ``    |
| [`3335202e`](https://github.com/nix-community/stylix/commit/3335202ed032912053e8132efc25b5cd4c8982b7) | `` ci: ISSUE_TEMPLATE: improve and match PR template `` |
| [`f6a351a4`](https://github.com/nix-community/stylix/commit/f6a351a444e9c3992c2573853f23e196899fb139) | `` treewide: add awwpotato to core maintainers list ``  |
| [`7abe83d1`](https://github.com/nix-community/stylix/commit/7abe83d1ed362ecc874dce06a3d686b778cfdf27) | `` fontconfig: set defaultFonts with mkOrder 600 ``     |
| [`f2711be0`](https://github.com/nix-community/stylix/commit/f2711be0a3038686bdbfff7cc0854418fa4f2551) | `` fontconfig: refactor using `lib.genAttrs` ``         |