### PR TITLE
chore(flake/nixpkgs): `fbcf476f` -> `20075955`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -478,11 +478,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
| [`c78c366c`](https://github.com/NixOS/nixpkgs/commit/c78c366c0b08bbd5a99ef60fa037c1b5f5d3c760) | `` rtklib-ex: init at 2.5.0 ``                                                      |
| [`0c28d57e`](https://github.com/NixOS/nixpkgs/commit/0c28d57e029f66e07a130481aea6cea3a1ca63ff) | `` service/portable: Add meta placeholder ``                                        |
| [`098f006b`](https://github.com/NixOS/nixpkgs/commit/098f006bfca4705d7a480990f3d4834dcbc32b23) | `` vmTools: use getOutput for MODULE_DIR ``                                         |
| [`539450b9`](https://github.com/NixOS/nixpkgs/commit/539450b9027c6a13d2ef24be85405f34e29264ff) | `` go-sendxmpp: 0.14.1 -> 0.15.0 ``                                                 |
| [`d9d6cc66`](https://github.com/NixOS/nixpkgs/commit/d9d6cc6666f2d89d2095161c74ebaef878c336fc) | `` vmTools: reference modules closure already created ``                            |
| [`74f6ed85`](https://github.com/NixOS/nixpkgs/commit/74f6ed8595fd7461b94b1902f7b491a350e28720) | `` forgejo-runner: 9.0.3 -> 9.1.0 ``                                                |
| [`6055918b`](https://github.com/NixOS/nixpkgs/commit/6055918b2dff8bd64bc732328169496596a19101) | `` python3Packages.google-cloud-compute: 1.34.0 -> 1.35.0 ``                        |
| [`2231d178`](https://github.com/NixOS/nixpkgs/commit/2231d178b3862fe27857f688c9f93e01496e973a) | `` cargo-tally: 1.0.67 -> 1.0.68 ``                                                 |
| [`2b077792`](https://github.com/NixOS/nixpkgs/commit/2b0777920256f946586b445b9b4a3b6c8b2aad6f) | `` zram-generator: disable tests on loongarch64 ``                                  |
| [`89a28ebb`](https://github.com/NixOS/nixpkgs/commit/89a28ebb3771d096b644cf017a668c1c7a02c18a) | `` muffon: 2.2.0 -> 2.3.0 ``                                                        |
| [`e13b0421`](https://github.com/NixOS/nixpkgs/commit/e13b04211c2785c6b9d2ca1f37b29e95549ef7f1) | `` python313Packages.word2number: fix build ``                                      |
| [`996994a2`](https://github.com/NixOS/nixpkgs/commit/996994a20e9f576f6a97440ac069002bba9ed142) | `` halo: 2.21.6 -> 2.21.7 ``                                                        |
| [`62c4ed5a`](https://github.com/NixOS/nixpkgs/commit/62c4ed5ad73369bf427eaa7f8095ccb6a1f35525) | `` mrustc: 0.10.1 -> 0.11.2 (#375039) ``                                            |
| [`1ebe8b99`](https://github.com/NixOS/nixpkgs/commit/1ebe8b99ee0efc30a6f4537527a2f1eed0a84bed) | `` treewide: remove alxsimon as maintainer (#434934) ``                             |
| [`a098e801`](https://github.com/NixOS/nixpkgs/commit/a098e80118f4781b9846c4e248dd8e93c2138c85) | `` josm: revert workaround to broken fetchsvn ``                                    |
| [`386cb0ad`](https://github.com/NixOS/nixpkgs/commit/386cb0ad85fa94642a99f0d72f4b471ea7a1218a) | `` cloud-init: 25.1.4 -> 25.2 ``                                                    |
| [`76c006aa`](https://github.com/NixOS/nixpkgs/commit/76c006aa46297a9eea3767d2929625edde008d26) | `` bookstack: 25.07 -> 25.07.1 ``                                                   |
| [`ab39dc05`](https://github.com/NixOS/nixpkgs/commit/ab39dc052faa949ce0020a70ea6f3a6b90a72ed7) | `` simdutf: 7.3.5 -> 7.3.6 ``                                                       |
| [`88d5d6c9`](https://github.com/NixOS/nixpkgs/commit/88d5d6c99347b0a5cbf3f1ce1cd00a4a7f40339d) | `` bleach: 4.6.0 -> 5.0.0 ``                                                        |
| [`97eb7ee0`](https://github.com/NixOS/nixpkgs/commit/97eb7ee0da337d385ab015a23e15022c865be75c) | `` ocamlPackages.ppxlib: 0.33.0 → 0.36.0 ``                                         |
| [`40ba664b`](https://github.com/NixOS/nixpkgs/commit/40ba664bbf3045bb4cdf971ae5f388664bf79133) | `` libretro-shaders-slang: 0-unstable-2025-08-07 -> 0-unstable-2025-08-14 ``        |
| [`e8b70103`](https://github.com/NixOS/nixpkgs/commit/e8b701035a51a63d909aaf0efc9bc0e5ae24474e) | `` libretro.snes9x: 0-unstable-2025-08-10 -> 0-unstable-2025-08-11 ``               |
| [`b8ab39d0`](https://github.com/NixOS/nixpkgs/commit/b8ab39d065f0c498a08af41a14ae9444bbbb220b) | `` gale: 1.9.2 -> 1.9.5 ``                                                          |
| [`436d2e38`](https://github.com/NixOS/nixpkgs/commit/436d2e38e725b2ac34ab6365f7eb815b14bbe011) | `` python3Packages.databricks-sdk: 0.62.0 -> 0.63.0 ``                              |
| [`d31f96b1`](https://github.com/NixOS/nixpkgs/commit/d31f96b146e553d0ccb84edad93b772a834c35bf) | `` isort: migrate to by-name ``                                                     |
| [`8f0368ad`](https://github.com/NixOS/nixpkgs/commit/8f0368ad08503494eeb343ef142294bbca6c5d38) | `` avalonia: 11.3.3 -> 11.3.4 ``                                                    |
| [`6dde564f`](https://github.com/NixOS/nixpkgs/commit/6dde564f1665cab79e4f4f8aada89f79e3333a8d) | `` python3Packages.aioslimproto: 3.1.0 -> 3.1.1 ``                                  |
| [`d2b428af`](https://github.com/NixOS/nixpkgs/commit/d2b428afa8cd1d6853999b53ba1b29cf113acae4) | `` python3Packages.mss: 10.0.0 -> 10.1.0 ``                                         |
| [`50122b4a`](https://github.com/NixOS/nixpkgs/commit/50122b4a8d9848266032fc2ea009eac51f953b0e) | `` zed-editor: 0.199.9 -> 0.199.10 ``                                               |
| [`56785485`](https://github.com/NixOS/nixpkgs/commit/56785485669a9864c2087f739a1496e87cb86b69) | `` python3Packages.hist: 2.8.1 -> 2.9.0 ``                                          |
| [`0a961b63`](https://github.com/NixOS/nixpkgs/commit/0a961b639b2a4f54c2d4be98546b5d25ea9d7d0e) | `` mtail: 3.2.11 -> 3.2.12 ``                                                       |
| [`8755455f`](https://github.com/NixOS/nixpkgs/commit/8755455f0d5a022396fc7530308dd41dac42cca1) | `` fabric-ai: 1.4.280 -> 1.4.291 ``                                                 |
| [`d970a4e1`](https://github.com/NixOS/nixpkgs/commit/d970a4e1a8768a5c3c4ff4c9c82758f98f07ce1b) | `` python3Packages.hf-xet: 1.1.7 -> 1.1.8 ``                                        |
| [`0e037ba0`](https://github.com/NixOS/nixpkgs/commit/0e037ba07d3d71ed0d5e8050c190c4fca811be23) | `` roon-server: 2.53.1544 -> 2.54.1554 ``                                           |
| [`9498af81`](https://github.com/NixOS/nixpkgs/commit/9498af814cd5206c8de86eecc614f29ecf3de8c6) | `` fzf-make: 0.59.0 -> 0.60.0 ``                                                    |
| [`6e214784`](https://github.com/NixOS/nixpkgs/commit/6e2147842cf741f6ef8edfc07b371c9b4327ba2f) | `` ginkgo: 2.23.4 -> 2.24.0 ``                                                      |
| [`ec2de0cc`](https://github.com/NixOS/nixpkgs/commit/ec2de0cc223a631b51e70cd630dc817b9aa8241f) | `` haven: 1.0.6 -> 1.1.0 ``                                                         |
| [`9bce75f8`](https://github.com/NixOS/nixpkgs/commit/9bce75f8581fc7b492eae124f4d09106e0b81244) | `` python3Packages.orbax-checkpoint: 0.11.22 -> 0.11.23 ``                          |
| [`55d5d3e6`](https://github.com/NixOS/nixpkgs/commit/55d5d3e68d2fe28b8f88d060009cba7eec0fc7cd) | `` obsidian: 1.8.10 -> 1.9.10 ``                                                    |
| [`8806e6d1`](https://github.com/NixOS/nixpkgs/commit/8806e6d17584774d4d2f7ad66fb8be4428a68f3f) | `` localsend: fix tests.localsend ``                                                |
| [`403fb390`](https://github.com/NixOS/nixpkgs/commit/403fb390ad8817ff7a4deacabee8041f0c2c2e3e) | `` kazumi: 1.7.4 -> 1.7.6 ``                                                        |
| [`d0dd9e1c`](https://github.com/NixOS/nixpkgs/commit/d0dd9e1c3a7a6da6c40ad69e5c9bcbb985638baf) | `` nixos/lact: allow configuring declaratively ``                                   |
| [`f8a7597f`](https://github.com/NixOS/nixpkgs/commit/f8a7597f5d80c116d775e86175f5b7592be9b441) | `` racket: make lib paths consistent ``                                             |
| [`1700b190`](https://github.com/NixOS/nixpkgs/commit/1700b1908bedfacc75c9d19e82bce1c1244dcab8) | `` llama-cpp-rocm: init at 6134 ``                                                  |
| [`086e8a6b`](https://github.com/NixOS/nixpkgs/commit/086e8a6bb0a1ff5932d9cfc78f0bebfa97e874b8) | `` steampipePackages.steampipe-plugin-aws: 1.21.0 -> 1.22.0 ``                      |
| [`d25bc8df`](https://github.com/NixOS/nixpkgs/commit/d25bc8df5c7ee36545fbbe95a34063f628ca9837) | `` vscode-extensions.ufo5260987423.magic-scheme: 0.0.5 -> 0.0.6 ``                  |
| [`e0407abd`](https://github.com/NixOS/nixpkgs/commit/e0407abdb410100aa939b590d8a81343f67c6ea7) | `` vscode-extensions.shopify.ruby-lsp: 0.9.31 -> 0.9.32 ``                          |
| [`fdcfb20b`](https://github.com/NixOS/nixpkgs/commit/fdcfb20b2eb63549f8b6ef7ffac5892b0731a5ef) | `` go-judge: 1.9.4 -> 1.9.5 ``                                                      |
| [`13b0ff3b`](https://github.com/NixOS/nixpkgs/commit/13b0ff3b3cb47e56f814f99778fe6c3ad38a3016) | `` mihomo-party: 1.8.3 -> 1.8.4 ``                                                  |
| [`d3af8f20`](https://github.com/NixOS/nixpkgs/commit/d3af8f201c05a810931a6ab34a46ef280fe91c85) | `` nototools: 0.2.20 -> 0.3.2 ``                                                    |
| [`cee55b8b`](https://github.com/NixOS/nixpkgs/commit/cee55b8bc0125b42b177806970f3f97c94107892) | `` kiro: init at 0.2.13 ``                                                          |
| [`74b034b5`](https://github.com/NixOS/nixpkgs/commit/74b034b5bf6ff6dd321851d8dd7502df4364fd8c) | `` maintainers: add vuks ``                                                         |
| [`0ce938ff`](https://github.com/NixOS/nixpkgs/commit/0ce938ffddef130a15dfddae1449a86c97048254) | `` maintainers: add skaphi ``                                                       |
| [`592c0aae`](https://github.com/NixOS/nixpkgs/commit/592c0aaeb40571653af61b004ac37310d451eddb) | `` gajim: 2.2.0 → 2.3.4 ``                                                          |
| [`40083f58`](https://github.com/NixOS/nixpkgs/commit/40083f589d1268ff88a83e179f14abc2bb10e19a) | `` yyjson: 0.11.1 -> 0.12.0 ``                                                      |
| [`bfe9c894`](https://github.com/NixOS/nixpkgs/commit/bfe9c8949fc584c54a444f90e181db6512f85805) | `` anyrun: 0-unstable-2025-05-27 -> 0-unstable-2025-08-18 ``                        |
| [`444831ea`](https://github.com/NixOS/nixpkgs/commit/444831ea24b2bcfa0c7a46581779fd8273de3fd5) | `` autosuspend: 8.0.0 -> 9.0.0 ``                                                   |
| [`2cbeff92`](https://github.com/NixOS/nixpkgs/commit/2cbeff92c472aa202f167fce11704c4c5b4276a4) | `` svix-server: 1.71.0 -> 1.73.0 ``                                                 |
| [`6204e966`](https://github.com/NixOS/nixpkgs/commit/6204e966f9365d7c5af1d1613fdaa360fb310907) | `` yubico-piv-tool: 2.7.1 -> 2.7.2 ``                                               |
| [`666545fc`](https://github.com/NixOS/nixpkgs/commit/666545fc487fbba52e161e4ec6c3165b8882aae0) | `` mixtool: init at 0-unstable-2025-07-07 ``                                        |
| [`b886b761`](https://github.com/NixOS/nixpkgs/commit/b886b76149c1c3de2df7b9e910ed5c1bed03f105) | `` rcon-cli: 1.7.1 -> 1.7.2 ``                                                      |
| [`a8e563e7`](https://github.com/NixOS/nixpkgs/commit/a8e563e74b29b92ba061153b580d341161564bd9) | `` nextcloud-spreed-signaling: 2.0.3 -> 2.0.4 ``                                    |
| [`de3b71ba`](https://github.com/NixOS/nixpkgs/commit/de3b71ba40b0af0762f3cb96c1ad18c9db86bc77) | `` gst_all_1.gst-editing-services: enable/disable tests in Meson ``                 |
| [`8e093581`](https://github.com/NixOS/nixpkgs/commit/8e093581b5a3e86fce13af4345148c2250faaffe) | `` or-tools: re-enable tests on x86_64-linux ``                                     |
| [`64d9c348`](https://github.com/NixOS/nixpkgs/commit/64d9c348e35928fcd5bd41f0051658f6ceffb338) | `` candy-icons: 0-unstable-2025-07-10 -> 0-unstable-2025-08-13 ``                   |
| [`51136e91`](https://github.com/NixOS/nixpkgs/commit/51136e91d9745c0224364694206d149f034b5e03) | `` platformsh: 5.1.1 -> 5.2.0 ``                                                    |
| [`0b9c0e80`](https://github.com/NixOS/nixpkgs/commit/0b9c0e8084748ce05bea0ff81db780736257df65) | `` opencode: 0.4.26 -> 0.5.6 ``                                                     |
| [`3aadbd7b`](https://github.com/NixOS/nixpkgs/commit/3aadbd7bb702ac8e3c0fe6484b08305bfa58ae6b) | `` maintainers: update kevincox's Matrix address ``                                 |
| [`2318ee74`](https://github.com/NixOS/nixpkgs/commit/2318ee749e5361c6ff8b9b194eb4bfbb61b4c1ef) | `` ocamlPackages.mlx: 0.9 -> 0.10 ``                                                |
| [`cefe6f9d`](https://github.com/NixOS/nixpkgs/commit/cefe6f9dd4e0275a26b4288c3a73e1efcc894cd5) | `` debian-devscripts: Add missing IO::String Perl dependency for uscan ``           |
| [`951b2f95`](https://github.com/NixOS/nixpkgs/commit/951b2f95502d876100e888e5fd87315327da1793) | `` linux_xanmod_latest: 6.15.9 -> 6.15.10 ``                                        |
| [`2e755fee`](https://github.com/NixOS/nixpkgs/commit/2e755fee7bac3eb43173ad66b83e2d74c15e1dd9) | `` linux_xanmod: 6.12.41 -> 6.12.42 ``                                              |
| [`bc3410f6`](https://github.com/NixOS/nixpkgs/commit/bc3410f6efa6ca0b11f43acc1fa7f30441f1ee00) | `` crosvm: 0-unstable-2025-08-01 -> 0-unstable-2025-08-07 ``                        |
| [`8f48682f`](https://github.com/NixOS/nixpkgs/commit/8f48682ff5d60f74772137e9bf49077d7bcabd30) | `` amp-cli: 0.0.1754827277-g1b1a5d -> 0.0.1755532879-g2b6e3d ``                     |
| [`18a6a462`](https://github.com/NixOS/nixpkgs/commit/18a6a462658d940d311e047ad02cdd8e60f8454b) | `` libretro.nestopia: 0-unstable-2025-08-09 -> 0-unstable-2025-08-14 ``             |
| [`93f851d1`](https://github.com/NixOS/nixpkgs/commit/93f851d127d12def2784f5cd29411fa29f2c27ef) | `` remind: 05.04.02 -> 06.00.00 ``                                                  |
| [`d2f58ec9`](https://github.com/NixOS/nixpkgs/commit/d2f58ec9188454c7c688dc067585eeb3337347bb) | `` sdl_gamecontrollerdb: 0-unstable-2025-08-05 -> 0-unstable-2025-08-17 ``          |
| [`5381f4d6`](https://github.com/NixOS/nixpkgs/commit/5381f4d6693f2cae162c30dc9ad2060ec917775c) | `` androidndkPackages_{21,23,24,25,26}: drop ``                                     |
| [`6e959288`](https://github.com/NixOS/nixpkgs/commit/6e959288bbb37a57f4152d5639476ad064aacc1e) | `` lib.systems.examples: bump Android SDK and NDK ``                                |
| [`ecb90c5b`](https://github.com/NixOS/nixpkgs/commit/ecb90c5bc8096868fb2434c8fc264f43d012ce4a) | `` ansel: add mbornand as maintainer ``                                             |
| [`fabd6242`](https://github.com/NixOS/nixpkgs/commit/fabd6242e2a79380358be3695bdf85b5b03ea598) | `` ansel: tell the build script we package ansel ``                                 |
| [`a1d176f3`](https://github.com/NixOS/nixpkgs/commit/a1d176f3a3b93da501e21ac1407c9d3734192992) | `` ansel: remove pcre from buildInputs ``                                           |
| [`35bb4a9d`](https://github.com/NixOS/nixpkgs/commit/35bb4a9dac05c2ff5faabf109ec83f5568afb5a5) | `` ansel: add missing dependencies ``                                               |
| [`913cca4d`](https://github.com/NixOS/nixpkgs/commit/913cca4d065035c23f3e30646f45c20fd74aa0bb) | `` ansel: sort inputs ``                                                            |
| [`e3a4e203`](https://github.com/NixOS/nixpkgs/commit/e3a4e203832c907d17fce059fb7d7d170f0281a1) | `` ansel: remove special version of libavif ``                                      |
| [`99e583be`](https://github.com/NixOS/nixpkgs/commit/99e583be0061af440e4a9717f4193d2923ff2348) | `` ansel: fix compilation ``                                                        |
| [`2b10f117`](https://github.com/NixOS/nixpkgs/commit/2b10f117913a1314f152f479193cb4bb065965b4) | `` saxon: add -xslt symlink ``                                                      |
| [`b9192b4d`](https://github.com/NixOS/nixpkgs/commit/b9192b4dc310aa0b8b1e6bfd88345de54e2ca964) | `` h2o: src.sha256 → src.hash ``                                                    |
| [`03e079da`](https://github.com/NixOS/nixpkgs/commit/03e079da8e7ac9e046bb15e95b25a1e793c3598c) | `` h2o: 2.3.0-untagged-2025-08-13 → 2.3.0-untagged-2025-08-14 ``                    |
| [`dc5539cb`](https://github.com/NixOS/nixpkgs/commit/dc5539cb9f7a70ab79c2cc7eefe69fd6677ef6c0) | `` h2o: 2.3.0.20250717 → 2.3.0-untagged-2025-08-13 ``                               |
| [`dd781e6a`](https://github.com/NixOS/nixpkgs/commit/dd781e6aad59851eac92df199504ccc4ea552c48) | `` terra: 1.1.0 -> 1.2.0 ``                                                         |
| [`95926c7e`](https://github.com/NixOS/nixpkgs/commit/95926c7e8c2caf8fed8e5d9a99c4c6d37f89f837) | `` c2ffi: llvm-16.0.0-0-unstable-2023-11-18 -> llvm-18.1.0-0-unstable-2024-04-20 `` |
| [`21e1bb11`](https://github.com/NixOS/nixpkgs/commit/21e1bb1152bd76a17ae3156305b7222c0b6ccda8) | `` wasmedge: bump LLVM to 19 ``                                                     |
| [`01e8f570`](https://github.com/NixOS/nixpkgs/commit/01e8f570c67955ab92be0ef352066f16b63940f2) | `` nixos/malloc: unpin LLVM for Scudo ``                                            |
| [`529489ff`](https://github.com/NixOS/nixpkgs/commit/529489ffd31fe33c98d7acd46921d99991189d16) | `` androidenv.androidPkgs.emulator: drop unused LLVM library ``                     |
| [`86e39d17`](https://github.com/NixOS/nixpkgs/commit/86e39d17dba7ba049f8509e2d374288386cc94ec) | `` python313Packages.shiboken2: unpin LLVM ``                                       |
| [`5af7cbec`](https://github.com/NixOS/nixpkgs/commit/5af7cbec0b5c4ab1cc4b814b05f73e184c86f2d6) | `` ghdl-llvm: unpin LLVM ``                                                         |
| [`257866d9`](https://github.com/NixOS/nixpkgs/commit/257866d92b7fd7a1da0f1d98fddad3f8d1669792) | `` flutterPackages-source.stable.engine: unpin LLVM ``                              |
| [`fb89ed36`](https://github.com/NixOS/nixpkgs/commit/fb89ed36816388e7e2b05e9c20eb1175f25e8391) | `` libsForQt5.qtwebengine: bump LLVM to 19 ``                                       |
| [`6774d062`](https://github.com/NixOS/nixpkgs/commit/6774d062fe8418d00385b284a0b9c50ffd58330f) | `` libsForQt5.qtwebengine: backport upstream patch for gperf ≥ 3.2 ``               |
| [`0eebff6c`](https://github.com/NixOS/nixpkgs/commit/0eebff6cbf2815797aaf9cec0a91e7b8818b419a) | `` tracee: unpin LLVM ``                                                            |
| [`e82363bc`](https://github.com/NixOS/nixpkgs/commit/e82363bc92247659eabd2ee831038a8cbaa97820) | `` tetragon: unpin LLVM ``                                                          |
| [`0b084fbd`](https://github.com/NixOS/nixpkgs/commit/0b084fbd7058bca827cf75931d4095681259ee02) | `` postgresql16Packages.pgvecto-rs: unpin LLVM ``                                   |
| [`c7abe9d3`](https://github.com/NixOS/nixpkgs/commit/c7abe9d3dace9e725dbc1c2dadd2f4ced2a4be69) | `` solanum: 0-unstable-2025-07-20 -> 0-unstable-2025-08-18 ``                       |
| [`197b504e`](https://github.com/NixOS/nixpkgs/commit/197b504eedede54ec60b0701cd3fb7f0b71e687c) | `` kubescape: 3.0.37 -> 3.0.38 ``                                                   |
| [`4ebe160b`](https://github.com/NixOS/nixpkgs/commit/4ebe160b24c0891b3a0d462b3df8cd4866f6ab10) | `` python3Packages.mlx-lm: 0.26.0 -> 0.26.3 ``                                      |
| [`3b9bf641`](https://github.com/NixOS/nixpkgs/commit/3b9bf641c322396f8fdfecdd1d443b09f82a6e79) | `` python3Packages.lm-eval: 0.4.8 -> 0.4.9.1 ``                                     |
| [`cb9b10bf`](https://github.com/NixOS/nixpkgs/commit/cb9b10bfd56557aa9b03cdff4bfc63997541eaaa) | `` linuxKernel.kernels.linux_zen: 6.16 -> 6.16.1 ``                                 |
| [`4c65774e`](https://github.com/NixOS/nixpkgs/commit/4c65774ecce10851562fb70e1be525616302bf26) | `` gnome-user-share: Fix cross ``                                                   |
| [`9dfd9339`](https://github.com/NixOS/nixpkgs/commit/9dfd93392e3d72a9de5a0fa3d75090110ecd8df7) | `` firebird_4: 4.0.5 -> 4.0.6 ``                                                    |