### PR TITLE
chore(flake/home-manager): `dd026d86` -> `6911d3e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755625756,
-        "narHash": "sha256-t57ayMEdV9g1aCfHzoQjHj1Fh3LDeyblceADm2hsLHM=",
+        "lastModified": 1755810213,
+        "narHash": "sha256-QdenO8f0PTg+tC6HuSvngKcbRZA5oZKmjUT+MXKOLQg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "dd026d86420781e84d0732f2fa28e1c051117b59",
+        "rev": "6911d3e7f475f7b3558b4f5a6aba90fa86099baa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                            |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`6911d3e7`](https://github.com/nix-community/home-manager/commit/6911d3e7f475f7b3558b4f5a6aba90fa86099baa) | `` nix-gc: rename frequency to dates ``                            |
| [`3001400e`](https://github.com/nix-community/home-manager/commit/3001400e9ff29ec5e6d81d82dc3865d3df7254aa) | `` rclone: move activation script to systemd service ``            |
| [`56b87499`](https://github.com/nix-community/home-manager/commit/56b87499874d16c43f4a732084650cb50b048f15) | `` rclone: modularize subtests ``                                  |
| [`e6422763`](https://github.com/nix-community/home-manager/commit/e6422763eb4594099a889d05304c3cfd06e47c8f) | `` Translate using Weblate (Hebrew) ``                             |
| [`282b4c98`](https://github.com/nix-community/home-manager/commit/282b4c98de97da6667cb03de4f427371734bc39c) | `` blueman-applet: Add option to change systemd targets (#7702) `` |
| [`3c3510e6`](https://github.com/nix-community/home-manager/commit/3c3510e61ca5c15a0f13d73c2232fa2d5478a86c) | `` programs/nix-search-tv: add quotes ``                           |
| [`c2977f8b`](https://github.com/nix-community/home-manager/commit/c2977f8bca62a38ba42fea88a85f67e09d8ffcb2) | `` Add translation using Weblate (Hebrew) ``                       |