### PR TITLE
chore(flake/darwin): `3a0a38a1` -> `8df64f81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755751773,
-        "narHash": "sha256-d1H34kko9J5fWrxCVgfa1TkIwdkGt/eDSVopAWenw24=",
+        "lastModified": 1755825449,
+        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "3a0a38a1e7ac2c4b4150ea37a491fdffdc9c92e1",
+        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`be2d7d65`](https://github.com/nix-darwin/nix-darwin/commit/be2d7d653567f49223d4d675e4a7d268a6ce90ba) | `` applications: ensure sufficient permissions before updating apps `` |
| [`1f9cca77`](https://github.com/nix-darwin/nix-darwin/commit/1f9cca7781b18a073c45823a24e9bd74eb83d3fe) | `` Copy applications instead of linking them to make macOS happy ``    |
| [`21d733a5`](https://github.com/nix-darwin/nix-darwin/commit/21d733a51f0b4f4b650da3dcf501d7b2c546a245) | `` applications: reformat ``                                           |