### PR TITLE
chore(flake/nixvim-flake): `43353d71` -> `da77028b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -262,11 +262,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755879220,
-        "narHash": "sha256-2KZl6cU5rzEwXKMW369kLTzinJXXkF3TRExA6qEeVbc=",
+        "lastModified": 1755960406,
+        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3ff4596663c8cbbffe06d863ee4c950bce2c3b78",
+        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
         "type": "github"
       },
       "original": {
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1755900473,
-        "narHash": "sha256-UxpKQvD3dTT4/ueJBDccmHeHfnuUD+864Mzu8GPJZig=",
+        "lastModified": 1755924483,
+        "narHash": "sha256-wNqpEXZuAwPjW8hYKIYzmN+fgEZT/Qx+sUIWXg3EIWU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "18a1b5126f917fbcd65397b9ee429387fdbd51a6",
+        "rev": "91f51aede7c9c769c19f74ba9042b8fdb4ed2989",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1755920605,
-        "narHash": "sha256-nTQPiu1y4FD2u+GmAgZgik00iQHrt7ySFQSUbmIaEZE=",
+        "lastModified": 1756047710,
+        "narHash": "sha256-EJTGgBmi8+ppWfMWrLdKhGLZyWnbBzhE3f4+TrSZbPU=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "43353d7158cb6ea53a0329869beb9ada9e81e5bc",
+        "rev": "da77028b3433ddd7b4dc9380fdef04b4a5af486f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                            |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
| [`da77028b`](https://github.com/alesauce/nixvim-flake/commit/da77028b3433ddd7b4dc9380fdef04b4a5af486f) | `` chore(flake/git-hooks): 3ff45966 -> e891a93b `` |
| [`4c18f915`](https://github.com/alesauce/nixvim-flake/commit/4c18f91530a601d03bba1cdf55921e15a9c28300) | `` chore(flake/nixvim): 18a1b512 -> 91f51aed ``    |