### PR TITLE
chore(flake/nix-index-database): `ebbc1c05` -> `52dec1cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -463,11 +463,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755404379,
-        "narHash": "sha256-Q6ZxZDBmD/B988Jjbx7/NchxOKIpOKBBrx9Yb0zMzpQ=",
+        "lastModified": 1756008611,
+        "narHash": "sha256-rfTBWuTXi9/X7GhtF562FKNXKh2kvKb6dwI5lV1SjPE=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "ebbc1c05f786ae39bb5e04e57bf2c10c44a649e3",
+        "rev": "52dec1cb33a614accb9e01307e17816be974d24d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`52dec1cb`](https://github.com/nix-community/nix-index-database/commit/52dec1cb33a614accb9e01307e17816be974d24d) | `` update generated.nix to release 2025-08-24-034025 `` |
| [`efc44208`](https://github.com/nix-community/nix-index-database/commit/efc44208d443ff8952d0d53e908360cbfd1a99c1) | `` flake.lock: Update ``                                |