### PR TITLE
chore(flake/home-manager): `9e3a33c0` -> `2c4ef7d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756022458,
-        "narHash": "sha256-J1i35r4HfNDdPpwL0vOBaZopQudAUVtartEerc1Jryc=",
+        "lastModified": 1756247014,
+        "narHash": "sha256-aqMKFVMK/xhv0eJ1006zSmrUaXFO09AkaU8FutDbaZs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9e3a33c0bcbc25619e540b9dfea372282f8a9740",
+        "rev": "2c4ef7d7172708f6247d2ed9b56f0341b9ce63e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`2c4ef7d7`](https://github.com/nix-community/home-manager/commit/2c4ef7d7172708f6247d2ed9b56f0341b9ce63e1) | `` blueman-applet: fix typo in systemdTargets ``     |
| [`3882f886`](https://github.com/nix-community/home-manager/commit/3882f88691147dc325feb6bfece09ab6d058fb67) | `` ssh: remove top level options ``                  |
| [`59aabcd3`](https://github.com/nix-community/home-manager/commit/59aabcd3db975f9ff7a5df918ad17284361723c0) | `` swaylock: document how to fix PAM on non-NixOS `` |
| [`600ce016`](https://github.com/nix-community/home-manager/commit/600ce016e2850d8e5bf7a08d2e92477849434f1d) | `` flake.lock: Update ``                             |
| [`e49a2511`](https://github.com/nix-community/home-manager/commit/e49a2511fe61f4d77974f3394362ae33ba485806) | `` docs: update formatting information ``            |
| [`9ea3df74`](https://github.com/nix-community/home-manager/commit/9ea3df74ea739e519550a77a4ef13c96109346e6) | `` maintainers: update all-maintainers.nix ``        |
| [`32940bca`](https://github.com/nix-community/home-manager/commit/32940bcae87c138976e819113de6e321acb108af) | `` Translate using Weblate (Arabic) ``               |