### PR TITLE
chore(flake/home-manager): `99a69bdf` -> `fccb44df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756579987,
-        "narHash": "sha256-duCce8zGsaMsrqqOmLOsuaV1PVIw/vXWnKuLKZClsGg=",
+        "lastModified": 1756683562,
+        "narHash": "sha256-3fcIqwm1u+rF3kkgUYYEIcLrs93+Pi+a6AwiEAxdP5g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "99a69bdf8a3c6bf038c4121e9c4b6e99706a187a",
+        "rev": "fccb44df77266a3891939f35197f538dace3442f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`fccb44df`](https://github.com/nix-community/home-manager/commit/fccb44df77266a3891939f35197f538dace3442f) | `` mkFirefoxModule: make policies work on darwin ``                    |
| [`b7cc2466`](https://github.com/nix-community/home-manager/commit/b7cc2466f1a695326ffc1a14040cd4d3b4358ea0) | `` distrobox: add settings option and other general improvements ``    |
| [`a48dd228`](https://github.com/nix-community/home-manager/commit/a48dd228d977b1c5085cb8e014fd0ccfc45ca77b) | `` jq: make `colors` and `package` nullable ``                         |
| [`b4b5f008`](https://github.com/nix-community/home-manager/commit/b4b5f008d772c0e8e9c420cfa0d240a447747e0a) | `` hyprpanel: deprecate `theme.name` option ``                         |
| [`1e759786`](https://github.com/nix-community/home-manager/commit/1e759786e526a87a3c05beeff5db41743d763569) | `` qt: deprecate kde6 ``                                               |
| [`f671e772`](https://github.com/nix-community/home-manager/commit/f671e772d3c3b893e44399afedb84a0b3f27f922) | `` qt: Remove Plasma 5 and related Qt5 packages ``                     |
| [`71b57070`](https://github.com/nix-community/home-manager/commit/71b57070771aac60ca949b47d6b2bd2afd5e49d8) | `` tests/darwinScrublist: add pgclii ``                                |
| [`2842bac6`](https://github.com/nix-community/home-manager/commit/2842bac626ed087e83400a7a23da8e8923c6c7e6) | `` flake.lock: Update ``                                               |
| [`f27974d3`](https://github.com/nix-community/home-manager/commit/f27974d3b4aa0af533539ce626622c7b6b53c3f5) | `` shpool: init shpool module ``                                       |
| [`e4454907`](https://github.com/nix-community/home-manager/commit/e44549074a574d8bda612945a88e4a1fd3c456a8) | `` programs.rclone: fix injecting secret when value begins with "-" `` |
| [`4896177e`](https://github.com/nix-community/home-manager/commit/4896177e2c01ea9c93bd19f4ae0af9c8b3db376d) | `` programs.rclone: set Service.Type=notify ``                         |
| [`feba2b2d`](https://github.com/nix-community/home-manager/commit/feba2b2daa9823b27dc53b53e8e159d9aba33dbd) | `` programs.rclone: fix typo ``                                        |
| [`27d306e1`](https://github.com/nix-community/home-manager/commit/27d306e1e46faac9ae24d50ad75dc93efbb61d51) | `` Translate using Weblate (Bulgarian) ``                              |
| [`30fbfd27`](https://github.com/nix-community/home-manager/commit/30fbfd27a262a86d8c9d4acfff0650c03fe18603) | `` Translate using Weblate (Bulgarian) ``                              |
| [`6c8db975`](https://github.com/nix-community/home-manager/commit/6c8db97536780085f2e7c25d0ea5a9e5c6f19971) | `` Translate using Weblate (Bulgarian) ``                              |