### PR TITLE
chore(flake/nixvim-flake): `5c7b9354` -> `2059c28e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -518,11 +518,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1756587208,
-        "narHash": "sha256-pATHF/7rZeEYxnkvLZgrLbCjG4xBJDJ4zkjUiu+hhiU=",
+        "lastModified": 1756727835,
+        "narHash": "sha256-767guSN146cmLD1lvjYzU4Bh7Ry3fzXzj+6hXEtF7rY=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "8bad4d407dace583ebf6a41d32cab479788898fe",
+        "rev": "f5026663f68261a201cd0700ced14971945d8dd9",
         "type": "github"
       },
       "original": {
@@ -545,11 +545,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1756692109,
-        "narHash": "sha256-4yTMdS8oTnHy+LLoJOWEZNYHlImfPLgmrWeOyqIwvY0=",
+        "lastModified": 1756787757,
+        "narHash": "sha256-3vCARJ1uaHY3qHmze8HMUa66sCf1W8GVqS8avxraQzM=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "5c7b9354a880535a170bdf9c12f412bd7c0f5158",
+        "rev": "2059c28ee65fe275be54c80e57ef211262729646",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                              |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------- |
| [`2059c28e`](https://github.com/alesauce/nixvim-flake/commit/2059c28ee65fe275be54c80e57ef211262729646) | `` chore(flake/nixvim): 8bad4d40 -> f5026663 ``      |
| [`95d98419`](https://github.com/alesauce/nixvim-flake/commit/95d9841956b1c82b2cda2c768753309cdfe51161) | `` chore(flake/flake-parts): af66ad14 -> 45242719 `` |