### PR TITLE
chore(flake/home-manager): `6159629d` -> `b08f8737`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756903364,
-        "narHash": "sha256-vZh/YH2D7oDFek10r0TbGn3qJrqGv69sSP+oF8PFDqQ=",
+        "lastModified": 1756991914,
+        "narHash": "sha256-4ve/3ah5H/SpL2m3qmZ9GU+VinQYp2MN1G7GamimTds=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6159629d05a0e92bb7fb7211e74106ae1d552401",
+        "rev": "b08f8737776f10920c330657bee8b95834b7a70f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                    |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`b08f8737`](https://github.com/nix-community/home-manager/commit/b08f8737776f10920c330657bee8b95834b7a70f) | `` hyprpanel: fix dontAssertNotificationDaemons (#7745) ``                 |
| [`ed1a98c3`](https://github.com/nix-community/home-manager/commit/ed1a98c375450dfccf427adacd2bfd1a7b22eb25) | `` aerospace: use upstream example for exec-on-workspace-change (#7765) `` |
| [`b21c1a61`](https://github.com/nix-community/home-manager/commit/b21c1a61a765acea932eef1e4d225fde25a166e0) | `` vivid: add module (#7772) ``                                            |