### PR TITLE
chore(flake/darwin): `8df64f81` -> `eaacfa11`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755825449,
-        "narHash": "sha256-XkiN4NM9Xdy59h69Pc+Vg4PxkSm9EWl6u7k6D5FZ5cM=",
+        "lastModified": 1757015938,
+        "narHash": "sha256-1qBXNK/QxEjCqIoA2DxWn5gqM8rVxt+OxKodXu1GLTY=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8df64f819698c1fee0c2969696f54a843b2231e8",
+        "rev": "eaacfa1101b84225491d2ceae9549366d74dc214",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                          |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
| [`349b2c66`](https://github.com/nix-darwin/nix-darwin/commit/349b2c66a9e667b2a0f9cbca36fd0acf4c1cae46) | `` `apply` should return `null` if the argument is not a list `` |