### PR TITLE
chore(flake/stylix): `989312ab` -> `584d9c57`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -642,11 +642,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1756811338,
-        "narHash": "sha256-fwgklhY9kJSTDMGuwHJUVBCuJDVvxxljjGOLhxC84ko=",
+        "lastModified": 1756960927,
+        "narHash": "sha256-iG2DUobrDPzuVpDVHyqph1jtgAS0XOg1x8KGdsEkBms=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "989312ab49e6eb1d076f9d194d43f9f9c513087e",
+        "rev": "584d9c57a8550bace5ffa2901dfebbde367bea54",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                                 |
| ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
| [`584d9c57`](https://github.com/nix-community/stylix/commit/584d9c57a8550bace5ffa2901dfebbde367bea54) | `` fnott: set icon theme (#1873) ``                                     |
| [`98592e3c`](https://github.com/nix-community/stylix/commit/98592e3c5926b67449e558d61a53e5a991d5dc16) | `` doc/src/commit_convention: add subsystem nesting commit example ``   |
| [`ee128898`](https://github.com/nix-community/stylix/commit/ee128898d9d8daa1168c06a2d13266d41903099e) | `` doc/src/commit_convention: consistently indicate root directories `` |