### PR TITLE
chore(flake/home-manager): `b08f8737` -> `f56bf065`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756991914,
-        "narHash": "sha256-4ve/3ah5H/SpL2m3qmZ9GU+VinQYp2MN1G7GamimTds=",
+        "lastModified": 1757075491,
+        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b08f8737776f10920c330657bee8b95834b7a70f",
+        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`f56bf065`](https://github.com/nix-community/home-manager/commit/f56bf065f9abedc7bc15e1f2454aa5c8edabaacf) | `` polybar: make sure X-Restart-Triggers is a list `` |
| [`a51e585a`](https://github.com/nix-community/home-manager/commit/a51e585a05d318f988dfe09ec7fe31de966d9a76) | `` Translate using Weblate (German) ``                |