### PR TITLE
chore(flake/nixvim-flake): `03dd5993` -> `acd476dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1760948891,
+        "narHash": "sha256-TmWcdiUUaWk8J4lpjzu4gCGxWY6/Ok7mOK4fIFfBuU4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "864599284fc7c0ba6357ed89ed5e2cd5040f0c04",
         "type": "github"
       },
       "original": {
@@ -283,11 +283,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755960406,
-        "narHash": "sha256-RF7j6C1TmSTK9tYWO6CdEMtg6XZaUKcvZwOCD2SICZs=",
+        "lastModified": 1760663237,
+        "narHash": "sha256-BflA6U4AM1bzuRMR8QqzPXqh8sWVCNDzOdsxXEguJIc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "e891a93b193fcaf2fc8012d890dc7f0befe86ec2",
+        "rev": "ca5b894d3e3e151ffc1db040b6ce4dcc75d31c37",
         "type": "github"
       },
       "original": {
@@ -443,11 +443,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1756609731,
-        "narHash": "sha256-ai5enFBtuTqdAnJs2fG4TatnvmJtAPEgMf3oA726FBc=",
+        "lastModified": 1761448641,
+        "narHash": "sha256-rNvRHfYD5A7cRGYTxDQyNKUsrJQLBkv9mPREccZ/BNs=",
         "owner": "Mic92",
         "repo": "nix-fast-build",
-        "rev": "135fd0edf1dff4128f6f38822dbb24f333b8073f",
+        "rev": "41d0b008bb6fb8583ab3e0ce84941f4b0f13b787",
         "type": "github"
       },
       "original": {
@@ -528,22 +528,35 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1763435664,
+        "narHash": "sha256-iauLTpGaVaJiq4h1h058pA6MD0MsAZa0LflSfXo2rc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0ade817efdde79cbc46b624c849027335ebc25c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "nixvim-flake",
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_2",
         "nuschtosSearch": "nuschtosSearch",
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1756946299,
-        "narHash": "sha256-N4PjGA0rittpNZGscKPel+mr/dMcKF73j0yr4rbG3T0=",
+        "lastModified": 1761693014,
+        "narHash": "sha256-fsz6M50kat/MW/UK62KPZzhCGyMXROXjRY6eHga6w0E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "63496f00c681b3e200bd17878a43ec68b7139a66",
+        "rev": "3dd024dc2cbf5b7097e38c0fceac2690d8353e69",
         "type": "github"
       },
       "original": {
@@ -566,11 +579,11 @@
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1756950012,
-        "narHash": "sha256-Va3DZmpMj+ExilsniP0mfNndARM8wMfAT1DuWYknsAI=",
+        "lastModified": 1763489271,
+        "narHash": "sha256-4QOdomdi0QCG1ppPOuCiREpe66A1r086oj3WstqAbdk=",
         "owner": "alesauce",
         "repo": "nixvim-flake",
-        "rev": "03dd599358ee161b1219b014d69c8555df7a22d3",
+        "rev": "acd476dd1db6caf89102f273e32fb2940417732b",
         "type": "github"
       },
       "original": {
@@ -636,11 +649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755555503,
-        "narHash": "sha256-WiOO7GUOsJ4/DoMy2IC5InnqRDSo2U11la48vCCIjjY=",
+        "lastModified": 1760652422,
+        "narHash": "sha256-C88Pgz38QIl9JxQceexqL2G7sw9vodHWx1Uaq+NRJrw=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "6f3efef888b92e6520f10eae15b86ff537e1d2ea",
+        "rev": "3ebeebe8b6a49dfb11f771f761e0310f7c48d726",
         "type": "github"
       },
       "original": {
@@ -891,11 +904,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755934250,
-        "narHash": "sha256-CsDojnMgYsfshQw3t4zjRUkmMmUdZGthl16bXVWgRYU=",
+        "lastModified": 1761311587,
+        "narHash": "sha256-Msq86cR5SjozQGCnC6H8C+0cD4rnx91BPltZ9KK613Y=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "74e1a52d5bd9430312f8d1b8b0354c92c17453e5",
+        "rev": "2eddae033e4e74bf581c2d1dfa101f9033dbd2dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                                                          |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
| [`acd476dd`](https://github.com/alesauce/nixvim-flake/commit/acd476dd1db6caf89102f273e32fb2940417732b) | `` chore(flake/nixpkgs): `7df7ff7d` -> `6a08e6bb` (#667) ``                      |
| [`abe3bb04`](https://github.com/alesauce/nixvim-flake/commit/abe3bb047a386e7e2700abd3006e11942ca16747) | `` ci: Use nothing-but-nix action during CI builds. Don't use determinate nix `` |
| [`77fa4ee3`](https://github.com/alesauce/nixvim-flake/commit/77fa4ee317467f2a1a55cd361bd1006cf01e837a) | `` fix: Remove nixpkgs pin from nixvim input ``                                  |
| [`abaec1fd`](https://github.com/alesauce/nixvim-flake/commit/abaec1fd2f2b9961d07aa68023868c4c6a1eb6d7) | `` chore(flake/nixvim): 42d87fd4 -> 3dd024dc ``                                  |
| [`915ca45d`](https://github.com/alesauce/nixvim-flake/commit/915ca45dd26bf2baedccdbbf479c00441fd33e30) | `` refactor: Simplify Obsidian settings ``                                       |
| [`61a17399`](https://github.com/alesauce/nixvim-flake/commit/61a17399e22ee45af41c5de2d36fd3f53550d587) | `` chore(flake/nix-fast-build): f50063e4 -> 41d0b008 ``                          |
| [`a17b7282`](https://github.com/alesauce/nixvim-flake/commit/a17b7282a536ff7062b5c83e6e307ff72a67f371) | `` chore(flake/nix-fast-build): a0f6a196 -> f50063e4 ``                          |
| [`b128da57`](https://github.com/alesauce/nixvim-flake/commit/b128da5703eba7a9cd4df34b2e4f22e67fd45aa5) | `` chore(flake/flake-parts): 4e627ac2 -> 86459928 ``                             |
| [`05c660a6`](https://github.com/alesauce/nixvim-flake/commit/05c660a630d693496314eb89d6cd449784bcf272) | `` chore(flake/nix-fast-build): 078a515d -> a0f6a196 ``                          |
| [`20e66d7a`](https://github.com/alesauce/nixvim-flake/commit/20e66d7ab82c4daee543b0fca1779fb16211b03e) | `` chore(flake/flake-parts): 758cf729 -> 4e627ac2 ``                             |
| [`64147267`](https://github.com/alesauce/nixvim-flake/commit/641472676a9b82f1b6eec042c976142342a80fd2) | `` chore(flake/git-hooks): 46d55f0a -> ca5b894d ``                               |
| [`e500eb85`](https://github.com/alesauce/nixvim-flake/commit/e500eb85f6cac2bf51d8ca12a8945a7d57889ff0) | `` chore(flake/git-hooks): cfc9f7bb -> 46d55f0a ``                               |
| [`9908d22e`](https://github.com/alesauce/nixvim-flake/commit/9908d22eeedb5660f11f5f0b1de846b9720df139) | `` chore(flake/nix-fast-build): c76c21dc -> 078a515d ``                          |
| [`2aab473e`](https://github.com/alesauce/nixvim-flake/commit/2aab473eaeca6885ec084174d54e3aca6b714eb9) | `` chore(flake/nixpkgs): 554be649 -> 7df7ff7d ``                                 |
| [`abadfc8c`](https://github.com/alesauce/nixvim-flake/commit/abadfc8c80e90cae6b4da88c0616379fbf04b1d2) | `` chore(flake/nix-fast-build): bee1a2dc -> c76c21dc ``                          |
| [`85df6ded`](https://github.com/alesauce/nixvim-flake/commit/85df6ded9099d01c2f3d25e1255b8c692733a627) | `` chore(flake/git-hooks): 54df955a -> cfc9f7bb ``                               |
| [`445b2360`](https://github.com/alesauce/nixvim-flake/commit/445b236008c8df1663e43bfd02c019c3514f9ce2) | `` chore(flake/nixvim): eb54f65d -> 42d87fd4 ``                                  |
| [`5ddad3f0`](https://github.com/alesauce/nixvim-flake/commit/5ddad3f093309b04c0f381d1d51f138022f3ba57) | `` chore(flake/nixvim): fe059cd3 -> eb54f65d ``                                  |
| [`171d11a1`](https://github.com/alesauce/nixvim-flake/commit/171d11a1d4515b9d98d95ee7bdebbde8045a06d6) | `` chore(flake/flake-parts): 45242719 -> 758cf729 ``                             |
| [`e55514cf`](https://github.com/alesauce/nixvim-flake/commit/e55514cf3a938e9d56e47465a861cc43968f72ff) | `` chore(flake/nixvim): 1c802b3e -> fe059cd3 ``                                  |
| [`066dc9f4`](https://github.com/alesauce/nixvim-flake/commit/066dc9f40ffcc9c8801faebf644c30c20f3cc9db) | `` chore(flake/nixvim): 4cec6765 -> 1c802b3e ``                                  |
| [`d59efeb6`](https://github.com/alesauce/nixvim-flake/commit/d59efeb65b824e195a4316b230b444df3d09980d) | `` chore(flake/nix-fast-build): 862aa595 -> bee1a2dc ``                          |
| [`c55a854b`](https://github.com/alesauce/nixvim-flake/commit/c55a854bcc867edeaf4924821e651d4435fc1d9c) | `` chore(flake/nixvim): e0f1e4ae -> 4cec6765 ``                                  |
| [`0cef5abb`](https://github.com/alesauce/nixvim-flake/commit/0cef5abbf94f169a07c6951d62fe73ea25b43387) | `` chore(flake/nixvim): da7b983a -> e0f1e4ae ``                                  |
| [`891ba10f`](https://github.com/alesauce/nixvim-flake/commit/891ba10faa4dce50457802eabef7cf0fa9a0e45b) | `` chore(flake/nixvim): 0c15f88f -> da7b983a ``                                  |
| [`1961d849`](https://github.com/alesauce/nixvim-flake/commit/1961d8491f8cdfc3adc456fcd04cdf3269ad8973) | `` chore(flake/nixpkgs): 0147c2f1 -> 554be649 ``                                 |
| [`31b4f37f`](https://github.com/alesauce/nixvim-flake/commit/31b4f37f116d2039563cacaf8e065008f7493c53) | `` chore(flake/nixvim): 92ba37a3 -> 0c15f88f ``                                  |
| [`53cc014b`](https://github.com/alesauce/nixvim-flake/commit/53cc014bd59680839821cac2f5dca537af0e840e) | `` chore(flake/nix-fast-build): dad0194a -> 862aa595 ``                          |
| [`59a6955c`](https://github.com/alesauce/nixvim-flake/commit/59a6955c2442748e6a85b99b1b37cd7d58b7221e) | `` chore(flake/nixvim): fd0c4235 -> 92ba37a3 ``                                  |
| [`a8a750bb`](https://github.com/alesauce/nixvim-flake/commit/a8a750bb913b2b88dac383b4a44ab501c024e9c0) | `` chore(flake/nixvim): 0c867f9e -> fd0c4235 ``                                  |
| [`781b6020`](https://github.com/alesauce/nixvim-flake/commit/781b6020cc195585358dbef0526117a274be2e53) | `` chore(flake/nixpkgs): c23193b9 -> 0147c2f1 ``                                 |
| [`9d996033`](https://github.com/alesauce/nixvim-flake/commit/9d996033b769db12ef165dc13a0ace6bf9277f15) | `` chore(flake/nixvim): 7f45eae6 -> 0c867f9e ``                                  |
| [`0cffed7b`](https://github.com/alesauce/nixvim-flake/commit/0cffed7be58bd2fb0a9ea0b56e1868fe1f0e55c3) | `` chore(flake/git-hooks): 302af509 -> 54df955a ``                               |
| [`abbde09c`](https://github.com/alesauce/nixvim-flake/commit/abbde09c51670be7358a9c5f77e23e1717a9b799) | `` chore(flake/nixvim): db1a991f -> 7f45eae6 ``                                  |
| [`02f1df2e`](https://github.com/alesauce/nixvim-flake/commit/02f1df2e91efa95909d826a7e9590b22d3cf7d70) | `` chore(flake/nixpkgs): ab0f3607 -> c23193b9 ``                                 |
| [`731f2475`](https://github.com/alesauce/nixvim-flake/commit/731f2475bd444b3291241fc588153baaefdd38c9) | `` chore(flake/git-hooks): b084b2c2 -> 302af509 ``                               |
| [`e4cf5c11`](https://github.com/alesauce/nixvim-flake/commit/e4cf5c11d132989225e6c457ae90923c51e59fab) | `` chore(flake/nixvim): 43c6f729 -> db1a991f ``                                  |
| [`ddd750a1`](https://github.com/alesauce/nixvim-flake/commit/ddd750a10889204f9f3f6353a467092cea2fa094) | `` chore(flake/git-hooks): ab82ab08 -> b084b2c2 ``                               |
| [`b4cb512f`](https://github.com/alesauce/nixvim-flake/commit/b4cb512f11fc27e59f7c875cf869070b8df7ac30) | `` chore(flake/nixpkgs): b599843b -> ab0f3607 ``                                 |
| [`14d6bbdf`](https://github.com/alesauce/nixvim-flake/commit/14d6bbdf1ebe2f2663eb55f09b6825251a2d05b9) | `` chore(flake/nixvim): 5b0a6eb3 -> 43c6f729 ``                                  |
| [`e16fc69a`](https://github.com/alesauce/nixvim-flake/commit/e16fc69adf5c35c06d26683444f82bce71039146) | `` chore(flake/nixvim): 51edc33c -> 5b0a6eb3 ``                                  |
| [`93aabc48`](https://github.com/alesauce/nixvim-flake/commit/93aabc48d3b1affe0f0b2dbe378fd9bdd7e5dd2f) | `` chore(flake/nixpkgs): d7600c77 -> b599843b ``                                 |
| [`f92da3bc`](https://github.com/alesauce/nixvim-flake/commit/f92da3bcba6bf4b33e5a605beddcc8624ad0fe03) | `` chore(flake/nixvim): 7afdd40b -> 51edc33c ``                                  |
| [`6d1ee9b3`](https://github.com/alesauce/nixvim-flake/commit/6d1ee9b3818670d63ff7e7d87668df8b6e788000) | `` chore(flake/git-hooks): e891a93b -> ab82ab08 ``                               |
| [`6c60f1a6`](https://github.com/alesauce/nixvim-flake/commit/6c60f1a6bc8c539d0af54f340e2735205e567924) | `` chore(flake/nix-fast-build): 135fd0ed -> dad0194a ``                          |
| [`51aac2fd`](https://github.com/alesauce/nixvim-flake/commit/51aac2fd4e2cc86bebdabe540253a33200ef239a) | `` chore(flake/nixvim): 4f80458d -> 7afdd40b ``                                  |
| [`ab35ab6a`](https://github.com/alesauce/nixvim-flake/commit/ab35ab6a26969f4c8fe515259c3f10e2b68e171f) | `` chore(flake/nixvim): 63496f00 -> 4f80458d ``                                  |