### PR TITLE
chore(flake/nur): `1047bb61` -> `857656ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -587,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757131536,
-        "narHash": "sha256-dShqHgkCXOHQIAoISzfn7nv1Fv57aAqK3yDktTzVykA=",
+        "lastModified": 1763439378,
+        "narHash": "sha256-crrc67dVALnwvqqOcbpJCrAy15XL/Rsqw/vcs83U0Xs=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1047bb615b4cd70ece868f84ee1654b4388b17af",
+        "rev": "857656caf8814b29859f36bb9f886b13bb519add",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                      |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`857656ca`](https://github.com/nix-community/NUR/commit/857656caf8814b29859f36bb9f886b13bb519add) | `` automatic update ``                       |
| [`76ea83a9`](https://github.com/nix-community/NUR/commit/76ea83a95c8221f346dd8ad332a939e7739f99fc) | `` automatic update ``                       |
| [`640c762a`](https://github.com/nix-community/NUR/commit/640c762a7617ef743bca9ff4b6e793d4d99bb12d) | `` automatic update ``                       |
| [`d4c3be1a`](https://github.com/nix-community/NUR/commit/d4c3be1ad2214890b0955a02406c4aee49379bf8) | `` automatic update ``                       |
| [`2c06b519`](https://github.com/nix-community/NUR/commit/2c06b5197b6d8d2c838db71d9916313b33a0c1ba) | `` automatic update ``                       |
| [`95c3dadc`](https://github.com/nix-community/NUR/commit/95c3dadc53c06629c2f9edc1ec0986bccafeb215) | `` automatic update ``                       |
| [`748780ee`](https://github.com/nix-community/NUR/commit/748780ee1b02608ab1c37e8b83c673937c6ec785) | `` automatic update ``                       |
| [`f2f71536`](https://github.com/nix-community/NUR/commit/f2f715365f2ed742a6fc4f9e46ae91772e992c19) | `` add nighthawk repository (#1025) ``       |
| [`63ee8db8`](https://github.com/nix-community/NUR/commit/63ee8db822ef4b83fb17dffde4212b46b1bd5ed8) | `` automatic update ``                       |
| [`b57983fe`](https://github.com/nix-community/NUR/commit/b57983fe1d18b3f0a15ebecb6b6f437f642a8009) | `` automatic update ``                       |
| [`cd3b9c3d`](https://github.com/nix-community/NUR/commit/cd3b9c3d66c7f0bbbb29cecc3a3ab4e090b0e346) | `` automatic update ``                       |
| [`780f4d42`](https://github.com/nix-community/NUR/commit/780f4d420064e8a81a9ef1dfed85918478c42bef) | `` automatic update ``                       |
| [`04ae7902`](https://github.com/nix-community/NUR/commit/04ae7902c4f6d153e000046d591f49adcab45f51) | `` automatic update ``                       |
| [`a68b1014`](https://github.com/nix-community/NUR/commit/a68b1014e8f6c98fb64d1a9bac5df74e626adac1) | `` automatic update ``                       |
| [`13faa958`](https://github.com/nix-community/NUR/commit/13faa9580983e55aeb5458d95e35a5c4f051260c) | `` automatic update ``                       |
| [`2121a469`](https://github.com/nix-community/NUR/commit/2121a46976c46071ef6bf79729c79e2c3dd993dd) | `` automatic update ``                       |
| [`36004017`](https://github.com/nix-community/NUR/commit/360040176cc685b7efd0ac61c2046245aaaaaa32) | `` automatic update ``                       |
| [`755d4918`](https://github.com/nix-community/NUR/commit/755d4918c949acd2c27ae267811db8bb82e6355e) | `` automatic update ``                       |
| [`0aa6ceec`](https://github.com/nix-community/NUR/commit/0aa6ceec504cdde3db41534f3dcb71e860e39e24) | `` automatic update ``                       |
| [`ab8326e6`](https://github.com/nix-community/NUR/commit/ab8326e69d68f701e01c2359972a065993e4d769) | `` automatic update ``                       |
| [`2d6ab37f`](https://github.com/nix-community/NUR/commit/2d6ab37fdbcec32c52ce7722d368d80c0c458cf9) | `` automatic update ``                       |
| [`dec0d78a`](https://github.com/nix-community/NUR/commit/dec0d78a7b8ab5fa382912dbfdca33108682b09e) | `` automatic update ``                       |
| [`263f45af`](https://github.com/nix-community/NUR/commit/263f45afd86d9c3cb8f61fb7af44c465d4493b88) | `` automatic update ``                       |
| [`2c6ac2bd`](https://github.com/nix-community/NUR/commit/2c6ac2bd2949215d01938333e25619d97f858d5a) | `` automatic update ``                       |
| [`36511507`](https://github.com/nix-community/NUR/commit/3651150786ee33f53c5d7fa6a795fb91ef7a3b1a) | `` automatic update ``                       |
| [`6bd47753`](https://github.com/nix-community/NUR/commit/6bd477535ba71aa22d2712c8735c92812a1c74dc) | `` automatic update ``                       |
| [`d0ab7f01`](https://github.com/nix-community/NUR/commit/d0ab7f015ec855c9023c99f34b8bb7f4562597a8) | `` automatic update ``                       |
| [`0616e04e`](https://github.com/nix-community/NUR/commit/0616e04e3a273205a2fdd6acf687be859a4955cf) | `` automatic update ``                       |
| [`ce6bfb72`](https://github.com/nix-community/NUR/commit/ce6bfb72eb8d6894358681a766a997d8e699740a) | `` automatic update ``                       |
| [`ce3d7010`](https://github.com/nix-community/NUR/commit/ce3d701015f40c55659133a3bbf9920815c7ed7b) | `` automatic update ``                       |
| [`b9c7ead1`](https://github.com/nix-community/NUR/commit/b9c7ead1388197115b7ca42bc993d3fb1cd82e74) | `` automatic update ``                       |
| [`1f95493e`](https://github.com/nix-community/NUR/commit/1f95493ede5a72a8fbd76a6e1c51555898745a9a) | `` automatic update ``                       |
| [`eb904845`](https://github.com/nix-community/NUR/commit/eb904845191b2e18649092b920b09395784e0c21) | `` automatic update ``                       |
| [`79386cb8`](https://github.com/nix-community/NUR/commit/79386cb86161661cbb369a0cf5e8ecf4f721ac26) | `` automatic update ``                       |
| [`ec18e176`](https://github.com/nix-community/NUR/commit/ec18e17628704d06019646b01c013e656f62cb02) | `` automatic update ``                       |
| [`0c46dd9a`](https://github.com/nix-community/NUR/commit/0c46dd9ab10e52bf160222720c0c828265d1a55a) | `` automatic update ``                       |
| [`ccb13d8c`](https://github.com/nix-community/NUR/commit/ccb13d8c68ca005ddff2d88ad759a65f43efff92) | `` automatic update ``                       |
| [`a0e27626`](https://github.com/nix-community/NUR/commit/a0e27626b393cc5cfb0439e51bc1aafdbdc3a340) | `` automatic update ``                       |
| [`0b3f3e1d`](https://github.com/nix-community/NUR/commit/0b3f3e1dccd401cf354fb652271dabe5fc6fa623) | `` automatic update ``                       |
| [`a91ad971`](https://github.com/nix-community/NUR/commit/a91ad9715510da63cdcbb0fef7458a43bca67505) | `` automatic update ``                       |
| [`66a67e8c`](https://github.com/nix-community/NUR/commit/66a67e8c798cdf9b8804533e7f5596cc815c21ae) | `` automatic update ``                       |
| [`293f62df`](https://github.com/nix-community/NUR/commit/293f62dfaaf6fc2861e73aafde9fdb7b83e5bd4a) | `` automatic update ``                       |
| [`985486ca`](https://github.com/nix-community/NUR/commit/985486cafe4c6da8d06797a22863b4320443d274) | `` automatic update ``                       |
| [`b3229aaa`](https://github.com/nix-community/NUR/commit/b3229aaa95d7b1a0d5768bd1ccbb1c5205424eda) | `` automatic update ``                       |
| [`5e1b72e5`](https://github.com/nix-community/NUR/commit/5e1b72e5f90db95095fb32ad5d8151456af0e318) | `` automatic update ``                       |
| [`9cefb301`](https://github.com/nix-community/NUR/commit/9cefb301d10cf1cd8d98a98e41f36c1fc9390ff2) | `` automatic update ``                       |
| [`e920a0f7`](https://github.com/nix-community/NUR/commit/e920a0f7bd310fb33c1abba4fb1133fcca6d0489) | `` automatic update ``                       |
| [`e81075b9`](https://github.com/nix-community/NUR/commit/e81075b9e83c02351414d25a1d3cb65ce99c048e) | `` automatic update ``                       |
| [`5e4a2bd2`](https://github.com/nix-community/NUR/commit/5e4a2bd2c5703e2435476a38269d281e083f92b4) | `` automatic update ``                       |
| [`9a989770`](https://github.com/nix-community/NUR/commit/9a98977038a0331f95c22407a19b4330133a0450) | `` automatic update ``                       |
| [`e67f9ea1`](https://github.com/nix-community/NUR/commit/e67f9ea103c12b26a57f93d2b39e6e05ec25d06c) | `` automatic update ``                       |
| [`f8589a41`](https://github.com/nix-community/NUR/commit/f8589a4150fbea17da0ebff26e0163c50eb25381) | `` automatic update ``                       |
| [`c02fd137`](https://github.com/nix-community/NUR/commit/c02fd1373d7a39443bc46e91619352345426664e) | `` automatic update ``                       |
| [`75a0c0d4`](https://github.com/nix-community/NUR/commit/75a0c0d46315eb9af21ac32485284e15d07d8c75) | `` automatic update ``                       |
| [`60e6a31f`](https://github.com/nix-community/NUR/commit/60e6a31f06067aaf8399a81881c08d74ba22b624) | `` automatic update ``                       |
| [`8129fe09`](https://github.com/nix-community/NUR/commit/8129fe0913270718decaaa9ef9c89e271e87f934) | `` automatic update ``                       |
| [`17e6464c`](https://github.com/nix-community/NUR/commit/17e6464c25a8312a265eca1f4a9474208b9a9d78) | `` automatic update ``                       |
| [`4231f5a5`](https://github.com/nix-community/NUR/commit/4231f5a541af36ca875124933780172e80950b42) | `` automatic update ``                       |
| [`9bfdc8bd`](https://github.com/nix-community/NUR/commit/9bfdc8bd2cda553f8551909f54614113bd943dba) | `` automatic update ``                       |
| [`05629e4c`](https://github.com/nix-community/NUR/commit/05629e4c33f0097410ac6832a323ef8c5319a7a3) | `` automatic update ``                       |
| [`4a3dcd34`](https://github.com/nix-community/NUR/commit/4a3dcd3420859a9fd6c136b80cea3011884d5b59) | `` automatic update ``                       |
| [`11bc1d26`](https://github.com/nix-community/NUR/commit/11bc1d265c34f6e73396e8ceaf0528b709834f31) | `` automatic update ``                       |
| [`ea4ee66e`](https://github.com/nix-community/NUR/commit/ea4ee66ecd89aee3869210d984d1a966e72891dc) | `` automatic update ``                       |
| [`de4c04e9`](https://github.com/nix-community/NUR/commit/de4c04e9662153905d19b283aae6e70c73c038c0) | `` automatic update ``                       |
| [`41f95b9c`](https://github.com/nix-community/NUR/commit/41f95b9c593328907604ea57301d4c83b909e3f4) | `` automatic update ``                       |
| [`486d1c81`](https://github.com/nix-community/NUR/commit/486d1c81c72268403309bc2f664fa99a0531e95a) | `` automatic update ``                       |
| [`c7ecb970`](https://github.com/nix-community/NUR/commit/c7ecb97070eee0f90e0f315dd33404b86712b9db) | `` automatic update ``                       |
| [`65c77673`](https://github.com/nix-community/NUR/commit/65c776732e5a890b755c9ed3654c23b52068a4e8) | `` automatic update ``                       |
| [`dffd88b6`](https://github.com/nix-community/NUR/commit/dffd88b620c2d3db584dbd1d3527b516a554a879) | `` automatic update ``                       |
| [`95a166ef`](https://github.com/nix-community/NUR/commit/95a166efa9055f0ba29fd57b9cbe8d1769c584e2) | `` automatic update ``                       |
| [`22ec9e45`](https://github.com/nix-community/NUR/commit/22ec9e451bec1bc1f3a7f0f61f8f5d81779f8b2f) | `` automatic update ``                       |
| [`ffd0e317`](https://github.com/nix-community/NUR/commit/ffd0e317cb732cf5a4291f3b9c84f8501f35f7c0) | `` automatic update ``                       |
| [`56c98d85`](https://github.com/nix-community/NUR/commit/56c98d85a715d44cff1cc58e3acc50abbb6333e2) | `` automatic update ``                       |
| [`5d5a8e8b`](https://github.com/nix-community/NUR/commit/5d5a8e8b02cc4a5a67718b2f3720ef72427e2bab) | `` automatic update ``                       |
| [`31da56b4`](https://github.com/nix-community/NUR/commit/31da56b47450291b0b9823c80a9b6f328c287aa7) | `` automatic update ``                       |
| [`69e5bea6`](https://github.com/nix-community/NUR/commit/69e5bea6b48e444adcdd77c0a64c06ab4c98160f) | `` automatic update ``                       |
| [`f085c96e`](https://github.com/nix-community/NUR/commit/f085c96ee022a6679e4488b6eb33814a47a1a79c) | `` automatic update ``                       |
| [`b15a43c1`](https://github.com/nix-community/NUR/commit/b15a43c133262bc94154e1cd466710a0a8c8d34f) | `` automatic update ``                       |
| [`bd5a5dbc`](https://github.com/nix-community/NUR/commit/bd5a5dbc9be09947989a0d03acc4b3a50c7777c0) | `` automatic update ``                       |
| [`5ce75241`](https://github.com/nix-community/NUR/commit/5ce75241e4aee42bc80c0323dcbd9b13d40d5169) | `` automatic update ``                       |
| [`f01f16c5`](https://github.com/nix-community/NUR/commit/f01f16c52d097c673c2424a5d79967781b6dbb34) | `` automatic update ``                       |
| [`68197491`](https://github.com/nix-community/NUR/commit/68197491ae3e462ae80d16638bca59db882e058c) | `` automatic update ``                       |
| [`9d1d526a`](https://github.com/nix-community/NUR/commit/9d1d526a57981b85f16e1cade98b9ce9fe82b5e2) | `` automatic update ``                       |
| [`b8cbc89c`](https://github.com/nix-community/NUR/commit/b8cbc89c3a1c4fa4b777984223305744fa13b8f2) | `` automatic update ``                       |
| [`d09caddb`](https://github.com/nix-community/NUR/commit/d09caddbb193696056eab3b1e189c485ee4ec653) | `` automatic update ``                       |
| [`fd390fb6`](https://github.com/nix-community/NUR/commit/fd390fb6c49e9cf2cecc2515abf4714559df25dd) | `` automatic update ``                       |
| [`0db50cc5`](https://github.com/nix-community/NUR/commit/0db50cc5b18d5a9bb0e2076e36e0d5e14307a8c3) | `` automatic update ``                       |
| [`7fc35bdd`](https://github.com/nix-community/NUR/commit/7fc35bdd764676bc542a30b9e9ebe527dee0b02f) | `` automatic update ``                       |
| [`8ec4f456`](https://github.com/nix-community/NUR/commit/8ec4f456d3739329a05e699d35ae5f56fd842e7c) | `` automatic update ``                       |
| [`7486e57d`](https://github.com/nix-community/NUR/commit/7486e57dee5ddfdcb14c90466a5290d22d60ebcd) | `` automatic update ``                       |
| [`dd597878`](https://github.com/nix-community/NUR/commit/dd597878865891e48ba1b3dd162c4f3ac7858127) | `` automatic update ``                       |
| [`a409b2b3`](https://github.com/nix-community/NUR/commit/a409b2b390fea5b634982034c52ef50f8335946c) | `` automatic update ``                       |
| [`218daebe`](https://github.com/nix-community/NUR/commit/218daebea38479495f06cb33ee6f1ab3a3de2b11) | `` automatic update ``                       |
| [`7101b445`](https://github.com/nix-community/NUR/commit/7101b4453c90c3fd62b2bfed5bf910a1f7b2beff) | `` automatic update ``                       |
| [`7785de96`](https://github.com/nix-community/NUR/commit/7785de96d573779493b52eeae4141a3b0fe8c239) | `` automatic update ``                       |
| [`2349379d`](https://github.com/nix-community/NUR/commit/2349379dd34314a7b03245c3c6cd4a96386d8bc0) | `` automatic update ``                       |
| [`9db6dc06`](https://github.com/nix-community/NUR/commit/9db6dc06c41812884be2b0562c12dd4fe4e153b4) | `` automatic update ``                       |
| [`7bfbeb0a`](https://github.com/nix-community/NUR/commit/7bfbeb0abac81db0525f7f31d44837aced8554c4) | `` automatic update ``                       |
| [`83220fbd`](https://github.com/nix-community/NUR/commit/83220fbd6e332c028c550668a23292751b775c55) | `` automatic update ``                       |
| [`d60d6e4e`](https://github.com/nix-community/NUR/commit/d60d6e4e7359bcf7827c3236c63edc54f829dd14) | `` automatic update ``                       |
| [`dc14adfb`](https://github.com/nix-community/NUR/commit/dc14adfb7d8049deb4cd0b18fc04ad0900c3aff1) | `` automatic update ``                       |
| [`a41b63a6`](https://github.com/nix-community/NUR/commit/a41b63a63db68a4ddf9fe61bf135dcbab40c9aa3) | `` automatic update ``                       |
| [`d02b08b0`](https://github.com/nix-community/NUR/commit/d02b08b0ea3ebd4535c22dc12e4d840c897f2bc8) | `` automatic update ``                       |
| [`3eff2001`](https://github.com/nix-community/NUR/commit/3eff20011f88b3b9cceb24c5cc1b496b38dc1d5f) | `` automatic update ``                       |
| [`73ec022b`](https://github.com/nix-community/NUR/commit/73ec022b9fb7b7a984d655a2c2d3e2d84df701d7) | `` automatic update ``                       |
| [`b8a9adc1`](https://github.com/nix-community/NUR/commit/b8a9adc1b8f09253c849d461c5f8f2dfd2d9b864) | `` automatic update ``                       |
| [`487d239a`](https://github.com/nix-community/NUR/commit/487d239ab8b7800cb3cdf5bf1e49343e899f36e2) | `` automatic update ``                       |
| [`c32efc5c`](https://github.com/nix-community/NUR/commit/c32efc5ca1b5c4564e44d97eff3ee0a9cebca04f) | `` automatic update ``                       |
| [`5d7fd64a`](https://github.com/nix-community/NUR/commit/5d7fd64a4d106e03c188959f260453e79939cb13) | `` automatic update ``                       |
| [`043ae64b`](https://github.com/nix-community/NUR/commit/043ae64b04924341f7cee4ff9b33b1ad2d01b00d) | `` automatic update ``                       |
| [`cb44dde8`](https://github.com/nix-community/NUR/commit/cb44dde82a279a626f8b3283fdcf52849d3ab3d4) | `` automatic update ``                       |
| [`0467b47b`](https://github.com/nix-community/NUR/commit/0467b47b55dab83a3827be3b2398fefd16f72e90) | `` automatic update ``                       |
| [`12dc2ef3`](https://github.com/nix-community/NUR/commit/12dc2ef308ac02d867e5eb7a0afe3c1f05b9a05f) | `` automatic update ``                       |
| [`3967673d`](https://github.com/nix-community/NUR/commit/3967673d3482fa9f3a0ff10816ca976f85b10599) | `` automatic update ``                       |
| [`ab5a70b4`](https://github.com/nix-community/NUR/commit/ab5a70b4b4117a9e88408978aff8d5cb1fb160a6) | `` automatic update ``                       |
| [`eb858dd1`](https://github.com/nix-community/NUR/commit/eb858dd105c1094cd6016fe1da9c87f63acffc45) | `` automatic update ``                       |
| [`f2f690e4`](https://github.com/nix-community/NUR/commit/f2f690e4f7e96af88ff56fc91c4ec9de576b100e) | `` automatic update ``                       |
| [`817f5558`](https://github.com/nix-community/NUR/commit/817f555889fc15efdb349b652056969bd952b0d1) | `` automatic update ``                       |
| [`9fc00a9a`](https://github.com/nix-community/NUR/commit/9fc00a9ae7f7ecea54249c2d79dcb8b613774cdf) | `` automatic update ``                       |
| [`ab182a04`](https://github.com/nix-community/NUR/commit/ab182a048de4f988389dc548b7ea673073e34191) | `` automatic update ``                       |
| [`ecb177d1`](https://github.com/nix-community/NUR/commit/ecb177d1f2ae3e803b86f5269bd24bf20b561a14) | `` automatic update ``                       |
| [`a4e09ab3`](https://github.com/nix-community/NUR/commit/a4e09ab3c59b35fb4eaeb42145342524f87e84a9) | `` automatic update ``                       |
| [`f08252bf`](https://github.com/nix-community/NUR/commit/f08252bf1809e653f3b463b0252577d72e810714) | `` automatic update ``                       |
| [`cb7fdaaf`](https://github.com/nix-community/NUR/commit/cb7fdaafb7dd7e475e7cf2554eae4072849a96c5) | `` automatic update ``                       |
| [`3e1a8d08`](https://github.com/nix-community/NUR/commit/3e1a8d085374351f7b16ce281a81ac8534a63b6f) | `` automatic update ``                       |
| [`93311e01`](https://github.com/nix-community/NUR/commit/93311e0106dddccc2937361015a1137c879291f0) | `` automatic update ``                       |
| [`802279cb`](https://github.com/nix-community/NUR/commit/802279cb387d5872a38121a0695d878acce67651) | `` automatic update ``                       |
| [`676d434d`](https://github.com/nix-community/NUR/commit/676d434de3ea49731baac247153937d602e40ff0) | `` automatic update ``                       |
| [`60fefbe5`](https://github.com/nix-community/NUR/commit/60fefbe5842c9dd4cab4d62f57d6f119df838cfb) | `` automatic update ``                       |
| [`82d14418`](https://github.com/nix-community/NUR/commit/82d14418898c87e46c788eae0922a0f7906a9b5d) | `` automatic update ``                       |
| [`0f33b2c2`](https://github.com/nix-community/NUR/commit/0f33b2c2501c424a60aa8f90fe2e2fbf5eab0945) | `` automatic update ``                       |
| [`fbd14e72`](https://github.com/nix-community/NUR/commit/fbd14e7211921588f53d67b6f210ea67f1490084) | `` automatic update ``                       |
| [`7a818df1`](https://github.com/nix-community/NUR/commit/7a818df15b94993c2dd7afc9e81aeb2cf63e4bb3) | `` automatic update ``                       |
| [`90d82e17`](https://github.com/nix-community/NUR/commit/90d82e1731f7ed1d391027f352c089fa21f87bac) | `` automatic update ``                       |
| [`a5f855d4`](https://github.com/nix-community/NUR/commit/a5f855d41b4ef94731dfc2297caf9e75a142d0ab) | `` automatic update ``                       |
| [`0056a949`](https://github.com/nix-community/NUR/commit/0056a949d549d92d4b9a860ffef6b87fdb0209e6) | `` automatic update ``                       |
| [`916aec49`](https://github.com/nix-community/NUR/commit/916aec490f2f4273c5c606cf6485a62c3b503c98) | `` automatic update ``                       |
| [`3313a539`](https://github.com/nix-community/NUR/commit/3313a539850392cf4424d1ad1eba485f91a30c90) | `` automatic update ``                       |
| [`bcfacf98`](https://github.com/nix-community/NUR/commit/bcfacf9869bfc1b47ce28b5be9b722e63db20601) | `` automatic update ``                       |
| [`eeed5c68`](https://github.com/nix-community/NUR/commit/eeed5c68eefae91585377a5dfe48f501c9d0bdc0) | `` automatic update ``                       |
| [`e69b942e`](https://github.com/nix-community/NUR/commit/e69b942e1f3e88c2505d3b079ac1c50646bb36bf) | `` automatic update ``                       |
| [`40093cbf`](https://github.com/nix-community/NUR/commit/40093cbf7e3ac5e5bc5e2ab4bbb07158f508c1cb) | `` automatic update ``                       |
| [`7f2f0a6a`](https://github.com/nix-community/NUR/commit/7f2f0a6a49fba88efced1ccba98667dd8636b8f8) | `` automatic update ``                       |
| [`5958e862`](https://github.com/nix-community/NUR/commit/5958e8620ffcfee453ddb0dd6f237bc3acbbab52) | `` automatic update ``                       |
| [`74687953`](https://github.com/nix-community/NUR/commit/74687953b72eae903b117b1144a26afdc7bfab6c) | `` automatic update ``                       |
| [`c6ade40b`](https://github.com/nix-community/NUR/commit/c6ade40b2ee0f3b76efffe0af48c6403795ad4b8) | `` automatic update ``                       |
| [`8bf91da2`](https://github.com/nix-community/NUR/commit/8bf91da2127f116cc3ccb035ee09a39c2b9bb841) | `` automatic update ``                       |
| [`cdd5f1a6`](https://github.com/nix-community/NUR/commit/cdd5f1a6b6df6a350624038f5cab2f5d0058f075) | `` automatic update ``                       |
| [`a16285f3`](https://github.com/nix-community/NUR/commit/a16285f322ed413bc2943418c65775343b5d2d46) | `` automatic update ``                       |
| [`b03233d5`](https://github.com/nix-community/NUR/commit/b03233d54a4fb6c483b4e0226f363fdb73f79859) | `` automatic update ``                       |
| [`3f88d4e8`](https://github.com/nix-community/NUR/commit/3f88d4e8f330dd9f89937855ddd1168130cfaf7c) | `` automatic update ``                       |
| [`d817cd4f`](https://github.com/nix-community/NUR/commit/d817cd4fe4ab4fda501e071fa9bfb85f76304245) | `` automatic update ``                       |
| [`6f16ce71`](https://github.com/nix-community/NUR/commit/6f16ce71cb22c3f72a367aeccabc91e7283e42b4) | `` automatic update ``                       |
| [`17cffaa2`](https://github.com/nix-community/NUR/commit/17cffaa2d134e5741a82c8476446f08a28169a22) | `` automatic update ``                       |
| [`362dd38e`](https://github.com/nix-community/NUR/commit/362dd38ee11f752afe4e7c5e972899c485465d4a) | `` automatic update ``                       |
| [`f7d1e010`](https://github.com/nix-community/NUR/commit/f7d1e0104f5e688d6ef01f76b887ddcc99432a68) | `` automatic update ``                       |
| [`71f020f1`](https://github.com/nix-community/NUR/commit/71f020f1033175bf3c0a956eb60ddcc31352caca) | `` automatic update ``                       |
| [`53e4ae00`](https://github.com/nix-community/NUR/commit/53e4ae00d4c1a9f0a9ebbd859d9e0bb4b85a1615) | `` automatic update ``                       |
| [`8e0dc4b9`](https://github.com/nix-community/NUR/commit/8e0dc4b9fd033d5a31785533076f926bc0a29fb2) | `` automatic update ``                       |
| [`1e24757b`](https://github.com/nix-community/NUR/commit/1e24757b2987b65e65e775cd751ab71f27e9f7ee) | `` automatic update ``                       |
| [`83bcc17f`](https://github.com/nix-community/NUR/commit/83bcc17ff47765bcbdaaec5f9fe26b9a2a825baa) | `` automatic update ``                       |
| [`8c0d7c52`](https://github.com/nix-community/NUR/commit/8c0d7c52aaf0ff0b22ca6ccd431220df9d977bb7) | `` automatic update ``                       |
| [`6ba5e4b5`](https://github.com/nix-community/NUR/commit/6ba5e4b5576891a832e4ef563c80bc7981a0709d) | `` automatic update ``                       |
| [`b449243f`](https://github.com/nix-community/NUR/commit/b449243fc20be5b369fe59979ab0abf8861f37ba) | `` automatic update ``                       |
| [`303141f1`](https://github.com/nix-community/NUR/commit/303141f1256871301cb9809d68d21e8f86022511) | `` automatic update ``                       |
| [`d1598942`](https://github.com/nix-community/NUR/commit/d15989424b714e47281ed7ba7778e22d0b629a2a) | `` automatic update ``                       |
| [`8e77b973`](https://github.com/nix-community/NUR/commit/8e77b973b95b2bfd472f2d19683d76237fbec767) | `` automatic update ``                       |
| [`2712fb70`](https://github.com/nix-community/NUR/commit/2712fb70b786a703e39fddf77414469d16654e94) | `` automatic update ``                       |
| [`d81169a3`](https://github.com/nix-community/NUR/commit/d81169a3e6612b0e4c20c5b07717353030bdf779) | `` automatic update ``                       |
| [`b5de4d94`](https://github.com/nix-community/NUR/commit/b5de4d943071ebbdbcd65cec6bb0348bdb37727c) | `` automatic update ``                       |
| [`8c978ae8`](https://github.com/nix-community/NUR/commit/8c978ae82bb1d5cd1a1e18d9fcce2cbe2b844346) | `` automatic update ``                       |
| [`5904db2f`](https://github.com/nix-community/NUR/commit/5904db2fb5fe6f548196b9619eb8aadbc6b7f957) | `` automatic update ``                       |
| [`caeff9df`](https://github.com/nix-community/NUR/commit/caeff9df90568dd7aee333c6aef650ce3fa8d814) | `` automatic update ``                       |
| [`ef14c89b`](https://github.com/nix-community/NUR/commit/ef14c89be0f2225a3d5c463bc5f4d28fe1538041) | `` automatic update ``                       |
| [`e9c5007d`](https://github.com/nix-community/NUR/commit/e9c5007d6d85de2611bb931fc6e1b2324268f023) | `` automatic update ``                       |
| [`4cbf2708`](https://github.com/nix-community/NUR/commit/4cbf270857000bdd7af7ee52a7bc72448a299dec) | `` automatic update ``                       |
| [`4f397e9f`](https://github.com/nix-community/NUR/commit/4f397e9f3629bab41b2c7492433be299c1098350) | `` automatic update ``                       |
| [`d48a3e1e`](https://github.com/nix-community/NUR/commit/d48a3e1ebeda312d667b7da4a006cc88b8ff7cc4) | `` automatic update ``                       |
| [`e4cf0fd7`](https://github.com/nix-community/NUR/commit/e4cf0fd7a95ea1019d3580305994d8a357aa9180) | `` automatic update ``                       |
| [`49c556dc`](https://github.com/nix-community/NUR/commit/49c556dcbaf23228c300757d5456ce47ee534088) | `` automatic update ``                       |
| [`a096356c`](https://github.com/nix-community/NUR/commit/a096356c3fbd1eb83b4158a0806ad38e5715c2b8) | `` automatic update ``                       |
| [`6027139a`](https://github.com/nix-community/NUR/commit/6027139a67815567184b8ed6810830ab6c2041d8) | `` automatic update ``                       |
| [`26e578bf`](https://github.com/nix-community/NUR/commit/26e578bfe8bd7bd4e6466e6a950cc44c65893f19) | `` automatic update ``                       |
| [`8e59aa9a`](https://github.com/nix-community/NUR/commit/8e59aa9a730b2ff940adb9a104b81a64c54a7790) | `` automatic update ``                       |
| [`377d75fd`](https://github.com/nix-community/NUR/commit/377d75fd87cb5583d7f876cede2961f8319fbecc) | `` automatic update ``                       |
| [`f043639e`](https://github.com/nix-community/NUR/commit/f043639e9fdc4395ba9e89b4f33b59dc772302d8) | `` automatic update ``                       |
| [`8e6211c2`](https://github.com/nix-community/NUR/commit/8e6211c2d18844fee176678a999ef0500b5a2494) | `` automatic update ``                       |
| [`53ad00e6`](https://github.com/nix-community/NUR/commit/53ad00e6d77057542c4f4ac4fc4dc2c470bdee8f) | `` automatic update ``                       |
| [`1a4c9929`](https://github.com/nix-community/NUR/commit/1a4c9929ac3ad35e530082c3f31ca4bb892ec946) | `` automatic update ``                       |
| [`a16a13a9`](https://github.com/nix-community/NUR/commit/a16a13a9322ab54ed5898b5088e00a86a463601c) | `` automatic update ``                       |
| [`ef4e5330`](https://github.com/nix-community/NUR/commit/ef4e5330a47f3e9012dba91343e03c9020ef865a) | `` automatic update ``                       |
| [`79b1bfee`](https://github.com/nix-community/NUR/commit/79b1bfeea7beed0d47d11748ed1323e1597023f9) | `` automatic update ``                       |
| [`3487e3e3`](https://github.com/nix-community/NUR/commit/3487e3e3c2c6401ecb7f5b8c5ebaa5f97d0a2f30) | `` fix file path of ccicnce113424 (#1023) `` |
| [`55c2a698`](https://github.com/nix-community/NUR/commit/55c2a698d7bb729ead6412f163fbc5979828a664) | `` automatic update ``                       |
| [`5bac1cf7`](https://github.com/nix-community/NUR/commit/5bac1cf7d9a373859fbe2a1578e460153752eced) | `` automatic update ``                       |
| [`12dc96c6`](https://github.com/nix-community/NUR/commit/12dc96c62324bf66c9ab7c725de63a695d73cba5) | `` automatic update ``                       |
| [`f9e9e7a3`](https://github.com/nix-community/NUR/commit/f9e9e7a344b98036f448d168cdd44051fe9a30bc) | `` automatic update ``                       |
| [`090b1e78`](https://github.com/nix-community/NUR/commit/090b1e78dfeb5e623324c53490fdfac40c5d86bc) | `` automatic update ``                       |
| [`38a75272`](https://github.com/nix-community/NUR/commit/38a75272d68d45d6ed974725d7b524c4f3b3d35e) | `` automatic update ``                       |
| [`63ac7f71`](https://github.com/nix-community/NUR/commit/63ac7f71746d0c3febe991aca7263115084d8e63) | `` automatic update ``                       |
| [`62838961`](https://github.com/nix-community/NUR/commit/62838961c9e7f69ca5f5e8a7ac063059e1bf9670) | `` automatic update ``                       |
| [`13f21448`](https://github.com/nix-community/NUR/commit/13f214489440d0a3800a6a5f0b0bbfdd4bfe13d1) | `` automatic update ``                       |
| [`a54c0a17`](https://github.com/nix-community/NUR/commit/a54c0a174669290618a3a30fb2d806c0d1fd5d8c) | `` automatic update ``                       |
| [`2d0cd914`](https://github.com/nix-community/NUR/commit/2d0cd91421b07845af26aca4852ea905f5a15ae4) | `` automatic update ``                       |
| [`1b5579cf`](https://github.com/nix-community/NUR/commit/1b5579cf5b00b48a7108d83a9feb2fc2f60a55d5) | `` automatic update ``                       |
| [`c32b5dea`](https://github.com/nix-community/NUR/commit/c32b5dea1f1e8a8b40f2b293896677f3a1c00e32) | `` automatic update ``                       |
| [`98be2578`](https://github.com/nix-community/NUR/commit/98be2578da8f2ac7d4f6e404936dc45f1d83935d) | `` automatic update ``                       |
| [`f75f7654`](https://github.com/nix-community/NUR/commit/f75f7654256d9c37f65b38952a71ce5d1784400a) | `` automatic update ``                       |
| [`ce2991b3`](https://github.com/nix-community/NUR/commit/ce2991b3dbfb9aa5acfa7d8bb47e450dfb7738de) | `` automatic update ``                       |
| [`c8abe95e`](https://github.com/nix-community/NUR/commit/c8abe95e2f9253fa234b8434b826c6a4c675d625) | `` automatic update ``                       |
| [`39076bc0`](https://github.com/nix-community/NUR/commit/39076bc0ca70a3a2fc7a695a307121586038e84d) | `` automatic update ``                       |
| [`e9607afb`](https://github.com/nix-community/NUR/commit/e9607afb6f771983e738bf0d40b9304cbbed33ae) | `` automatic update ``                       |
| [`2e7da353`](https://github.com/nix-community/NUR/commit/2e7da353afb66ffb90589d99f86bb22d48f78803) | `` automatic update ``                       |
| [`e72d7943`](https://github.com/nix-community/NUR/commit/e72d7943e5cda14ccc8e9fd147c133a9d52c5ca2) | `` automatic update ``                       |
| [`345388b2`](https://github.com/nix-community/NUR/commit/345388b21b3601bc314a619701d02b18a5dc3a90) | `` automatic update ``                       |
| [`14e9857e`](https://github.com/nix-community/NUR/commit/14e9857ef52d2ba71f64f6f09b9a9e3cc1c9a34f) | `` automatic update ``                       |
| [`850d207e`](https://github.com/nix-community/NUR/commit/850d207e1adb623add7cb312e4a7b133633816df) | `` automatic update ``                       |
| [`ed1d8921`](https://github.com/nix-community/NUR/commit/ed1d8921b75859ad12135cde5170dac0a94e45b4) | `` automatic update ``                       |
| [`8851b854`](https://github.com/nix-community/NUR/commit/8851b854544f50ed8b156853e0f87f5a727a97ec) | `` automatic update ``                       |
| [`b10784b3`](https://github.com/nix-community/NUR/commit/b10784b3c496a7a99b4a49ee18356b40fe98f83e) | `` automatic update ``                       |
| [`d1b14075`](https://github.com/nix-community/NUR/commit/d1b14075503fc6d0c07c101cb180f701e3106300) | `` automatic update ``                       |
| [`e0183797`](https://github.com/nix-community/NUR/commit/e0183797e2dd13d5517ae5bccb43105364752103) | `` automatic update ``                       |
| [`37e3fd06`](https://github.com/nix-community/NUR/commit/37e3fd068c51e9253b2477f0c60d844ab72c2410) | `` automatic update ``                       |
| [`0fc08cbe`](https://github.com/nix-community/NUR/commit/0fc08cbe3b401bc70125179834dbd96a4f7394aa) | `` automatic update ``                       |
| [`c0a7ad27`](https://github.com/nix-community/NUR/commit/c0a7ad278927e887e1a888a8e7e353425fe73bb5) | `` automatic update ``                       |
| [`2cc39680`](https://github.com/nix-community/NUR/commit/2cc3968057d08fcb97bcd2f740b647865fd5d95c) | `` automatic update ``                       |
| [`a3fbc87a`](https://github.com/nix-community/NUR/commit/a3fbc87a4f604fce71df5648166588541a4b3a36) | `` automatic update ``                       |
| [`9d554a06`](https://github.com/nix-community/NUR/commit/9d554a06b33c68c68776601f8878d30800f05d55) | `` automatic update ``                       |
| [`8155a130`](https://github.com/nix-community/NUR/commit/8155a130aa0970e6ca6da7f06e86e19dd10bb412) | `` automatic update ``                       |
| [`c9075512`](https://github.com/nix-community/NUR/commit/c9075512700591683bee182bd25ea3693c94c60f) | `` automatic update ``                       |
| [`632742b4`](https://github.com/nix-community/NUR/commit/632742b4cba35aaa42488214d98a768bcea5b7c0) | `` automatic update ``                       |
| [`170bbda1`](https://github.com/nix-community/NUR/commit/170bbda1a55bc3d94bedc817bce2e9650caeb35e) | `` automatic update ``                       |
| [`9226221a`](https://github.com/nix-community/NUR/commit/9226221a39d603a103457140e7d49bf0be10404a) | `` automatic update ``                       |
| [`1ab5e507`](https://github.com/nix-community/NUR/commit/1ab5e5071f76bf0ab9faf1bdb2a8698a74c617ce) | `` automatic update ``                       |
| [`d1c8c13c`](https://github.com/nix-community/NUR/commit/d1c8c13c615f2f46c4bce4c107b56900ac63e77a) | `` automatic update ``                       |
| [`351ca165`](https://github.com/nix-community/NUR/commit/351ca1659918fa4dacf758c7e630200005e48673) | `` automatic update ``                       |
| [`3def0118`](https://github.com/nix-community/NUR/commit/3def011872756b7b751019f21e8c6142653c750b) | `` automatic update ``                       |
| [`9c3fa7d3`](https://github.com/nix-community/NUR/commit/9c3fa7d3ccad687d5497143107ce42852de88fd3) | `` automatic update ``                       |
| [`36c8e007`](https://github.com/nix-community/NUR/commit/36c8e0074f1cb34a2c7ea78f48ca80f7dd6ec8df) | `` automatic update ``                       |
| [`254e463b`](https://github.com/nix-community/NUR/commit/254e463b4ae66552c9aba0a295e0556aaccd63cd) | `` automatic update ``                       |
| [`a053db75`](https://github.com/nix-community/NUR/commit/a053db755b35970d6a0ebd97aaceb8f629faa8e7) | `` automatic update ``                       |
| [`27b24a13`](https://github.com/nix-community/NUR/commit/27b24a13d45b022bcf2b0fe29f3c8a11af342f47) | `` automatic update ``                       |
| [`9fa64f3c`](https://github.com/nix-community/NUR/commit/9fa64f3cd0375deb2611673ac202d56d8be9b001) | `` automatic update ``                       |
| [`73b29161`](https://github.com/nix-community/NUR/commit/73b2916121ca95b25914d41b7e0bda128f99b533) | `` automatic update ``                       |
| [`86f19cf9`](https://github.com/nix-community/NUR/commit/86f19cf9ab6f787eb1ccb275aa9aaf5cf4ab93c1) | `` automatic update ``                       |
| [`76b41cf1`](https://github.com/nix-community/NUR/commit/76b41cf1534aeb1711de1057066b96f9cba7055e) | `` automatic update ``                       |
| [`5423a43d`](https://github.com/nix-community/NUR/commit/5423a43d52b60a79035423fc734581c1f4aa0d00) | `` automatic update ``                       |
| [`cdcd0d8e`](https://github.com/nix-community/NUR/commit/cdcd0d8e61075b55ca72d094e7c8b055c2ccb9a3) | `` automatic update ``                       |
| [`70d96494`](https://github.com/nix-community/NUR/commit/70d9649424acbca92c2257396de7a74e08df18ca) | `` automatic update ``                       |
| [`3e8eeb0d`](https://github.com/nix-community/NUR/commit/3e8eeb0dd9f69afb9771175c4e14f6f05fbde417) | `` automatic update ``                       |