### PR TITLE
chore(flake/home-manager): `f56bf065` -> `ea164b7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1757075491,
-        "narHash": "sha256-a+NMGl5tcvm+hyfSG2DlVPa8nZLpsumuRj1FfcKb2mQ=",
+        "lastModified": 1763416652,
+        "narHash": "sha256-8EBEEvtzQ11LCxpQHMNEBQAGtQiCu/pqP9zSovDSbNM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f56bf065f9abedc7bc15e1f2454aa5c8edabaacf",
+        "rev": "ea164b7c9ccdc2321379c2ff78fd4317b4c41312",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                                          |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`ea164b7c`](https://github.com/nix-community/home-manager/commit/ea164b7c9ccdc2321379c2ff78fd4317b4c41312) | `` home-manager: remove `rollback` subcommand ``                                 |
| [`7538d965`](https://github.com/nix-community/home-manager/commit/7538d965352d3bfd4c380f5b3aa618bc839a84b4) | `` fish: added abbr.name option ``                                               |
| [`3670a78e`](https://github.com/nix-community/home-manager/commit/3670a78eee49deebe4825fc8ecc46b172d1a8391) | `` vdirsyncer: Add option to request vcard 4.0 ``                                |
| [`96156a9e`](https://github.com/nix-community/home-manager/commit/96156a9e86281c4bfc451236bc2ddfe4317e6f39) | `` targets/darwin: change pathsToLink to a list (#8164) ``                       |
| [`c3bc79be`](https://github.com/nix-community/home-manager/commit/c3bc79be5ee97455262c6c677bbf065eed07948c) | `` news: set nixpkgs channel in create-news-entry shebang ``                     |
| [`7ec621b5`](https://github.com/nix-community/home-manager/commit/7ec621b510f0870a76423e5f249a8c681804f5ab) | `` bluetuith: add module ``                                                      |
| [`211594c8`](https://github.com/nix-community/home-manager/commit/211594c88d74a40d89aec879f57eac908fb549e6) | `` swww: add package to service path ``                                          |
| [`3ca51e0a`](https://github.com/nix-community/home-manager/commit/3ca51e0a334af217277465cd9af528d026b60080) | `` glab: remove module ``                                                        |
| [`0b2a2b3f`](https://github.com/nix-community/home-manager/commit/0b2a2b3f3307efaecb4ea0c88ea5f44f449dcadc) | `` Translate using Weblate (Japanese) ``                                         |
| [`229a7ab3`](https://github.com/nix-community/home-manager/commit/229a7ab373daf4871cbdff8440b2c0ffb2e2dbc9) | `` Translate using Weblate (Japanese) ``                                         |
| [`827f2a23`](https://github.com/nix-community/home-manager/commit/827f2a23373a774a8805f84ca5344654c31f354b) | `` atuin: add forceOverwriteSettings option (#8140) ``                           |
| [`747a9a77`](https://github.com/nix-community/home-manager/commit/747a9a774ed63380bfa08f7f88cf0ba136183d6e) | `` easyeffects: Fix service hanging on system shutdown (#8145) ``                |
| [`33f63da6`](https://github.com/nix-community/home-manager/commit/33f63da61a2e98020ae17c8fd1957dbe3f632382) | `` chromium: add finalPackage option (#8155) ``                                  |
| [`dfca39f8`](https://github.com/nix-community/home-manager/commit/dfca39f8af75f5d2eaff3b031cbba6a66bcfa2f2) | `` lazygit: fix bash integration (#8153) ``                                      |
| [`37a3d97f`](https://github.com/nix-community/home-manager/commit/37a3d97f2873e0f68711117c34d04b7c7ead8f4e) | `` maintainers: update all-maintainers.nix (#8147) ``                            |
| [`8e0fa3f2`](https://github.com/nix-community/home-manager/commit/8e0fa3f242f8f9cbbd6c2457e9e552c1cbf73e8d) | `` delta: use finalPackage instead of package in jujitsu config (#8150) ``       |
| [`b8645b18`](https://github.com/nix-community/home-manager/commit/b8645b18b0f5374127bbade6de7381ef0b3d5720) | `` vicinae: update theme filetype (#8141) ``                                     |
| [`be4a9233`](https://github.com/nix-community/home-manager/commit/be4a9233dd3f6104c9b0fdd3d56f953eb519a4c7) | `` retroarch: add module ``                                                      |
| [`a31a6b2d`](https://github.com/nix-community/home-manager/commit/a31a6b2d300bf6724ad70a95611f7b6668b907ed) | `` maintainers: add jtrrll ``                                                    |
| [`fa0c98a8`](https://github.com/nix-community/home-manager/commit/fa0c98a81c598b85d06aaa22a29e9cd54416e707) | `` news: add discord entry ``                                                    |
| [`fb76be5d`](https://github.com/nix-community/home-manager/commit/fb76be5dffafe943506b4a93b87efc7a9a329532) | `` tests/discord: init ``                                                        |
| [`08abff6f`](https://github.com/nix-community/home-manager/commit/08abff6fbc541d6cb3c8feaa33df187fcf570305) | `` discord service: init ``                                                      |
| [`a1224de1`](https://github.com/nix-community/home-manager/commit/a1224de197039745291c0e654346f5ba30f41c6f) | `` maintainers: add prescientmoon ``                                             |
| [`d8efc4bf`](https://github.com/nix-community/home-manager/commit/d8efc4bfa764676af1fec08f99ce9450d21f2d47) | `` docs/generic-linux-gpu: add instructions to manual ``                         |
| [`77b51dbb`](https://github.com/nix-community/home-manager/commit/77b51dbb9fd6e7bd94b2862d526a48d8af6f8164) | `` generic-linux-gpu: add a news entry ``                                        |
| [`193e44d3`](https://github.com/nix-community/home-manager/commit/193e44d316c0e0284587fa5e8cac34b7201d1d91) | `` generic-linux-gpu: add module ``                                              |
| [`066874ef`](https://github.com/nix-community/home-manager/commit/066874efb53d4101e42d6725f5d00f25c4891587) | `` nixgl: move under targets.genericLinux ``                                     |
| [`0aceb6be`](https://github.com/nix-community/home-manager/commit/0aceb6bef51ff60e93c9c29fd65ed7df52c31eee) | `` maintainers: add exzombie ``                                                  |
| [`c053d701`](https://github.com/nix-community/home-manager/commit/c053d701d64f0727f62e0269c7940da5805bc9bc) | `` ssh-agent: add macOS support ``                                               |
| [`d7b1ece7`](https://github.com/nix-community/home-manager/commit/d7b1ece79d21c9fe0d0f3dbfb97d1e8b865156bb) | `` xdg-portal: assert that required paths are linked on NixOS ``                 |
| [`0562fef0`](https://github.com/nix-community/home-manager/commit/0562fef070a1027325dd4ea10813d64d2c967b39) | `` vicinae: Remove BindTo from the systemd unit ``                               |
| [`f35d0cb7`](https://github.com/nix-community/home-manager/commit/f35d0cb75f0669ac8de18d774b336d3d3560bcde) | `` misc: Add Justfile ``                                                         |
| [`29077883`](https://github.com/nix-community/home-manager/commit/2907788315a73d3292140b4d59b5d95796565625) | `` tomat: init service (#8138) ``                                                |
| [`ba15db2a`](https://github.com/nix-community/home-manager/commit/ba15db2a1565e1779de23bdbacbc420412648289) | `` fish: added completions option (#8127) ``                                     |
| [`8929c5f3`](https://github.com/nix-community/home-manager/commit/8929c5f3bcb30d5b78d472fa12450b7dbb8a7ac2) | `` test/lazygit: add fish integration test ``                                    |
| [`d375dfc1`](https://github.com/nix-community/home-manager/commit/d375dfc1ffed64df788a399de5993728bafa0dc6) | `` lazygit: fix fish integration ``                                              |
| [`432bc8a5`](https://github.com/nix-community/home-manager/commit/432bc8a5da66638b5f139588efd6c4bd327e4cdc) | `` aerospace: simplify userSettings ``                                           |
| [`7f619d2a`](https://github.com/nix-community/home-manager/commit/7f619d2a72061c24c5ef184aa9f89a4b6c6a2e70) | `` aerospace: remove broken on-window-detected option ``                         |
| [`af119feb`](https://github.com/nix-community/home-manager/commit/af119feb17cb242398e0fb97f92b867d25882522) | `` Revert "tmpfiles: migrate to an RFC42-style option" ``                        |
| [`06aeeed6`](https://github.com/nix-community/home-manager/commit/06aeeed62ff05946871c7125befcb4563efd71a9) | `` Revert "tmpfiles: add option to purge rules' targets on change" ``            |
| [`6a40be5e`](https://github.com/nix-community/home-manager/commit/6a40be5eaf855852678e6a628018dc8ce601f024) | `` Revert "glab: remove the config file if it is empty or glab disabled" ``      |
| [`17c3ea43`](https://github.com/nix-community/home-manager/commit/17c3ea43bf1424473d3cbe0bead65e43d08df03e) | `` Revert "glab: coerce glab tmpfile rule argument to string" ``                 |
| [`d21852e8`](https://github.com/nix-community/home-manager/commit/d21852e86c7363a2deda2b7aeaf8bce0c40966e3) | `` Revert "tmpfiles: use correct path in the `onChange` hook" ``                 |
| [`b959c672`](https://github.com/nix-community/home-manager/commit/b959c67241cae17fc9e4ee7eaf13dfa8512477ea) | `` flake.lock: Update ``                                                         |
| [`34fe4880`](https://github.com/nix-community/home-manager/commit/34fe48801d2a5301b814eaa1efb496499d06cebc) | `` ghostty: Add systemd integration ``                                           |
| [`1c75dd70`](https://github.com/nix-community/home-manager/commit/1c75dd70229171f47ff10f4ed184101af7c7a392) | `` vscode: don't break when profile name has spaces ``                           |
| [`0a5a165a`](https://github.com/nix-community/home-manager/commit/0a5a165aca45dd9c9a8a87b123f1790681f6a3cb) | `` superfile: add pinnded folder and first use option ``                         |
| [`c39c07bf`](https://github.com/nix-community/home-manager/commit/c39c07bf31dc080851377c04352fa06f197f0c1c) | `` opkssh: init module ``                                                        |
| [`aa6936bb`](https://github.com/nix-community/home-manager/commit/aa6936bb637e46a49cf1292486200ba41dd4bcf7) | `` tests/yazi: fix bash/zsh integration tests ``                                 |
| [`65bf99c5`](https://github.com/nix-community/home-manager/commit/65bf99c5793ff83436fa65f64c4cdd874cdb4ebc) | `` yazi: update wrappers not to use cat in subshell ``                           |
| [`6feb3685`](https://github.com/nix-community/home-manager/commit/6feb3685114e5807b5effe7806b425b75b1b75c0) | `` news: add vicinae entry ``                                                    |
| [`5cdf9ef9`](https://github.com/nix-community/home-manager/commit/5cdf9ef99563a457f12a712e1f42c4f0d709203c) | `` vicinae service: init ``                                                      |
| [`1342b821`](https://github.com/nix-community/home-manager/commit/1342b821db15b6c79731310ba787d152cd60e74b) | `` news: add entry for mcp module and integrations ``                            |
| [`9ff9a94f`](https://github.com/nix-community/home-manager/commit/9ff9a94fd484a7e4f7bd79091a6ed65c927e6a3d) | `` vscode: add mcp module integration ``                                         |
| [`c7403518`](https://github.com/nix-community/home-manager/commit/c7403518704e2487b4deaa910628531aa91a66ee) | `` opencode: add mcp module integration ``                                       |
| [`083b20c1`](https://github.com/nix-community/home-manager/commit/083b20c1a01533efe877bfe7198e8ccd7dbf3546) | `` mcp: init module ``                                                           |
| [`1f34c2c8`](https://github.com/nix-community/home-manager/commit/1f34c2c855751c74b01df5068cf4dd64ea2c7d95) | `` zed-editor: options to generate debug.json ``                                 |
| [`95d65ddd`](https://github.com/nix-community/home-manager/commit/95d65dddae7ae6300b22cf1d61cb5e71dca8da5b) | `` gpg: fix correctly setting trust for all keys ``                              |
| [`a5fee077`](https://github.com/nix-community/home-manager/commit/a5fee077929ae2f2800c3087dce5e1abb4edfbc6) | `` rio: reformat ``                                                              |
| [`9d6e28fd`](https://github.com/nix-community/home-manager/commit/9d6e28fd32bf855d3f734ce5f2e4e2e2fc32212e) | `` rio: add support for custom themes ``                                         |
| [`e22fb25c`](https://github.com/nix-community/home-manager/commit/e22fb25cdedbc1f68f68177c5fbeb06a0a31b17a) | `` rio: use stub package for all test cases ``                                   |
| [`3c16ac36`](https://github.com/nix-community/home-manager/commit/3c16ac3646c554b21676464f85dec450f109041a) | `` home manager: add test for option subcommand ``                               |
| [`64c49b1a`](https://github.com/nix-community/home-manager/commit/64c49b1aa537a1420f8bc8ff6ab47e5ba2c75208) | `` home-manager: fix option subcommand ``                                        |
| [`c93684cd`](https://github.com/nix-community/home-manager/commit/c93684cd8717be1fb704df9ba2746572a0fed2bf) | `` tmpfiles: use correct path in the `onChange` hook ``                          |
| [`8c824254`](https://github.com/nix-community/home-manager/commit/8c824254b1ed9e797f6235fc3c62f365893c561a) | `` glab: coerce glab tmpfile rule argument to string ``                          |
| [`2318e30e`](https://github.com/nix-community/home-manager/commit/2318e30ea10b0b65b00c053e9ef432f27a215e3c) | `` tests: `hostPlatform` -> `stdenv.hostPlatform` ``                             |
| [`b5ed4afc`](https://github.com/nix-community/home-manager/commit/b5ed4afc2277339bdf0e9edf59befff7350cf075) | `` glab: remove the config file if it is empty or glab disabled ``               |
| [`7503ffb0`](https://github.com/nix-community/home-manager/commit/7503ffb0b00243bfd087f0851403291ec5b76db0) | `` tmpfiles: add maintainer bmrips ``                                            |
| [`b4350d54`](https://github.com/nix-community/home-manager/commit/b4350d54c2ec735bc841eb0f583eb889c8159fe9) | `` tmpfiles: add option to purge rules' targets on change ``                     |
| [`090aa14e`](https://github.com/nix-community/home-manager/commit/090aa14e5dbaa73f16624f408977582869c0c49a) | `` tmpfiles: migrate to an RFC42-style option ``                                 |
| [`32a671dc`](https://github.com/nix-community/home-manager/commit/32a671dce5a045f0d15a0e9fae9eaf6a56d3bdaa) | `` tests/gtk: ubuntu_font_family -> ubuntu-classic ``                            |
| [`ab0d3db1`](https://github.com/nix-community/home-manager/commit/ab0d3db1aa32a8c18807a0d0115e7f20351d2a10) | `` tests/darkman: python -> python2 ``                                           |
| [`9901bb6a`](https://github.com/nix-community/home-manager/commit/9901bb6afc1a128d236ebae30975d08d14b08d04) | `` taskwarrior-sync: taskwarrior -> taskwarrior2 ``                              |
| [`9f3a82bf`](https://github.com/nix-community/home-manager/commit/9f3a82bfd1e17b7b0e5803b8c0d48f73859bd555) | `` taskwarrior: taskwarrior -> taskwarrior2 ``                                   |
| [`acf7743c`](https://github.com/nix-community/home-manager/commit/acf7743c895187d3d7f9a58173c01fd6bdb43f13) | `` darwinScrublist: taskwarrior rename ``                                        |
| [`983cbdc7`](https://github.com/nix-community/home-manager/commit/983cbdc75c6808b8162c539cdda3c1e4edf5bc61) | `` flake.lock: Update ``                                                         |
| [`d9cd40d2`](https://github.com/nix-community/home-manager/commit/d9cd40d2daf03350b61f853653afb53625e01a80) | `` local-ai: string -> str (#8116) ``                                            |
| [`61f2cc59`](https://github.com/nix-community/home-manager/commit/61f2cc59089d48c85d761c0c94388e2dc421b712) | `` local-ai: init module (#6718) ``                                              |
| [`50a5766d`](https://github.com/nix-community/home-manager/commit/50a5766d5158309c7ff1f52fc6edcc32ee480bc0) | `` kitty: add option `mouseBindings` (#8111) ``                                  |
| [`0fe68257`](https://github.com/nix-community/home-manager/commit/0fe68257a9f80d469b2c8457f02b8d36174b1020) | `` fish: added repaint to binds (#8113) ``                                       |
| [`371608e6`](https://github.com/nix-community/home-manager/commit/371608e69cb7ffc92321555ec71aada6edeee429) | `` rclone: add option to set log-level (#8105) ``                                |
| [`43e20560`](https://github.com/nix-community/home-manager/commit/43e205606aeb253bfcee15fd8a4a01d8ce8384ca) | `` cbatticon: add `package` example ``                                           |
| [`5eaa0072`](https://github.com/nix-community/home-manager/commit/5eaa0072ff2e74d235aa6b010b6cd32f61dcf161) | `` gpg-agent: restore empty newlines after commands ``                           |
| [`363797f8`](https://github.com/nix-community/home-manager/commit/363797f8a94d703277ceae122e7c41abc07e32a2) | `` gpg-agent: fix syntax-breaking extraneous new line ``                         |
| [`c0016dd1`](https://github.com/nix-community/home-manager/commit/c0016dd14773f4ca0b467b74c7cdcc501570df4b) | `` ssh-agent: add shell integrations ``                                          |
| [`3557df69`](https://github.com/nix-community/home-manager/commit/3557df69eea94685c1ca87f2140394403d89c365) | `` gpg-agent: refactor ``                                                        |
| [`c537cb21`](https://github.com/nix-community/home-manager/commit/c537cb21e31519ea94bd99c845f493791c439447) | `` radicle: pkgs.hostPlatform -> pkgs.stdenv.hostPlatform ``                     |
| [`ae22fa93`](https://github.com/nix-community/home-manager/commit/ae22fa930e9d8f9c3cfc87523e0291e3e94818e7) | `` lazygit: fix nushell and fish integrations ``                                 |
| [`87044c57`](https://github.com/nix-community/home-manager/commit/87044c57222fb485974062e2dd557e7b8abd8fff) | `` tests: explicitly define NIX_CONFIG ``                                        |
| [`72484502`](https://github.com/nix-community/home-manager/commit/72484502065142bc66ee8f1d6a6f8c21c0339611) | `` tests: add `fzf` dependency to package ``                                     |
| [`9278414d`](https://github.com/nix-community/home-manager/commit/9278414dccd851eb559aff207abf784ca9f46e34) | `` tests: switch package to `writeShellApplication` ``                           |
| [`5fb2203a`](https://github.com/nix-community/home-manager/commit/5fb2203af7b6c6d8106f740a4141cf89ae3d8344) | `` tests: move package to its own file ``                                        |
| [`4ac96eb2`](https://github.com/nix-community/home-manager/commit/4ac96eb21c101a3e5b77ba105febc5641a8959aa) | `` easyeffects: use new typecheck (#8090) ``                                     |
| [`97e3022a`](https://github.com/nix-community/home-manager/commit/97e3022a8d2c09313fa49847f6da4d76abcfc72d) | `` news: add backupCommand entry ``                                              |
| [`ce76393b`](https://github.com/nix-community/home-manager/commit/ce76393bb74b6a4bbe02e30e9bd01e9839dc377c) | `` home-manager: add support for custom backup command (#6424) (#7153) ``        |
| [`c6d4cb31`](https://github.com/nix-community/home-manager/commit/c6d4cb31d7cef3a6deb16a6734f100e3f3a55122) | `` home-manager: define a central package ``                                     |
| [`124b99db`](https://github.com/nix-community/home-manager/commit/124b99dbd1594dbebdd575ac7142752ee96a98a0) | `` aerospace: don't use ifd ``                                                   |
| [`b8082c68`](https://github.com/nix-community/home-manager/commit/b8082c6803353456d45e6a8c0d4b36ad33fb7d6a) | `` khal: fix trailing slash bug for singlefile calendars ``                      |
| [`58d90d29`](https://github.com/nix-community/home-manager/commit/58d90d298ddc291e35c4e919526e80247b6619f0) | `` tests: khal: add testcase ``                                                  |
| [`ca2ab1d8`](https://github.com/nix-community/home-manager/commit/ca2ab1d877a24d5a437dad62f56b8b2c02e964e9) | `` cbatticon: add `package` to options ``                                        |
| [`d47259b6`](https://github.com/nix-community/home-manager/commit/d47259b685b1145b610fd8c28e7498304a97fa78) | `` flake.lock: Update ``                                                         |
| [`05c7c900`](https://github.com/nix-community/home-manager/commit/05c7c900f1530989ab4c50592e666550ee0eda42) | `` fontconfig: fix cache existence tests ``                                      |
| [`b53026f6`](https://github.com/nix-community/home-manager/commit/b53026f683a97ac37e95563680b43ffd17a5204c) | `` tmpfiles: echo the onChange command and respect `$DRY_RUN` ``                 |
| [`fca3fedc`](https://github.com/nix-community/home-manager/commit/fca3fedcdc035af13bc4a2a35ec0988f3569b075) | `` targets/darwin: do not use sudo to check for App Management ``                |
| [`e8258530`](https://github.com/nix-community/home-manager/commit/e82585308aef3d4cc2c36c7b6946051c8cdf24ef) | `` Translate using Weblate (Chinese (Simplified Han script)) ``                  |
| [`aa888ffc`](https://github.com/nix-community/home-manager/commit/aa888ffc10cad3ab6595039342f97d524fd620bf) | `` kraftkit: new module ``                                                       |
| [`0a3fb53e`](https://github.com/nix-community/home-manager/commit/0a3fb53ee2c9e1e5976d21dd9de650ce7d462e08) | `` delta: add jujutsu integration option ``                                      |
| [`a12a837d`](https://github.com/nix-community/home-manager/commit/a12a837d9927293ebb7750f46edec47758d336dd) | `` maintainers: update all-maintainers.nix ``                                    |
| [`bbaeb9f1`](https://github.com/nix-community/home-manager/commit/bbaeb9f1c29e79bb1653b32c3d73244cdf4bd888) | `` glab: init module (#8066) ``                                                  |
| [`988f2553`](https://github.com/nix-community/home-manager/commit/988f25531d88b0754ee83baf4d109b1dbee5f943) | `` news: add zapzap entry ``                                                     |
| [`5e3b79ac`](https://github.com/nix-community/home-manager/commit/5e3b79ac84e92fdaf78a1398c24abf36c2ba692e) | `` zapzap: add module ``                                                         |
| [`255b6a0e`](https://github.com/nix-community/home-manager/commit/255b6a0ef2f488a2fad051361699cc67db57338c) | `` home-manager-auto-upgrade: add flake support (#8053) ``                       |
| [`2a9969b3`](https://github.com/nix-community/home-manager/commit/2a9969b39c7f5f1dfbf5c5f1ca97151b40a1d36d) | `` .git-blame-ignore-revs: add some no-op treewide cleanup (#8062) ``            |
| [`f2f1076c`](https://github.com/nix-community/home-manager/commit/f2f1076c1f789595c2a2b18b76466fbd691025dd) | `` treewide: remove no-ops (#8061) ``                                            |
| [`879e4d90`](https://github.com/nix-community/home-manager/commit/879e4d90607d8918fc5d9edc6603fdf22a49ac0e) | `` clipse: fix keyBindings example syntax (#8058) ``                             |
| [`2aaf924e`](https://github.com/nix-community/home-manager/commit/2aaf924e82914cc2668cb9a6c29f9f82a8646132) | `` radicle: init (#5409) ``                                                      |
| [`18307160`](https://github.com/nix-community/home-manager/commit/1830716059bfee7cbcfbfcc38d7be98e482a5762) | `` nixgl: fix wrapper name typo ``                                               |
| [`64020f45`](https://github.com/nix-community/home-manager/commit/64020f453bdf3634bf88a6bbce7f3e56183c8b2b) | `` aerospace: add extraConfig ``                                                 |
| [`5c54b182`](https://github.com/nix-community/home-manager/commit/5c54b182ab5ae07e98eee7d402d12060be745408) | `` zed-editor: option to generate immutable settings ``                          |
| [`80437a57`](https://github.com/nix-community/home-manager/commit/80437a57cada22fbe4a8855810e08cb12245870e) | `` lorri: don't start until daemon is really running ``                          |
| [`d9ded14b`](https://github.com/nix-community/home-manager/commit/d9ded14b7463abc9823e62396f6313c01d069298) | `` lorri: restart notifications if events stream is disconnected ``              |
| [`b652e703`](https://github.com/nix-community/home-manager/commit/b652e703f1e686cb08eb052009d48950d31328e8) | `` picom: add test for `extraConfig` ``                                          |
| [`0bc5f414`](https://github.com/nix-community/home-manager/commit/0bc5f414f8926a0ea640b03c29605cdd97ea9a13) | `` picom: add `extraConfig` to options ``                                        |
| [`72960221`](https://github.com/nix-community/home-manager/commit/7296022150cd775917e4c831c393026eae7c2427) | `` man: add extraConfig ``                                                       |
| [`c644cb01`](https://github.com/nix-community/home-manager/commit/c644cb018f9fdec55f5ac2afb4713a8c7beb757c) | `` lorri: better notifications ``                                                |
| [`82b58f38`](https://github.com/nix-community/home-manager/commit/82b58f38202540bce4e5e00759d115c5a43cab85) | `` targets/darwin: better error message ``                                       |
| [`5c71d4a7`](https://github.com/nix-community/home-manager/commit/5c71d4a730bd3c972befff343bb074421e345937) | `` news: add news entry for targets.darwin.copyApps ``                           |
| [`4b846fa3`](https://github.com/nix-community/home-manager/commit/4b846fa3aa3a5dc792c86651901aa3bd3068e5b6) | `` targets/darwin: init copyapps ``                                              |
| [`44ca5736`](https://github.com/nix-community/home-manager/commit/44ca573665e246d3be7920deea804c64609e582b) | `` targets/darwin: refactor linkapps ``                                          |
| [`24cad38b`](https://github.com/nix-community/home-manager/commit/24cad38b3f7578a8372f5729fcc6f7018be67e09) | `` lazygit: add shell integrations ``                                            |
| [`af6bb5ea`](https://github.com/nix-community/home-manager/commit/af6bb5ea8ea75def1ec412ff3f5f93e44e733883) | `` Translate using Weblate (Turkish (Ottoman)) ``                                |
| [`36a7a673`](https://github.com/nix-community/home-manager/commit/36a7a673c0c8aec26f146b17ae479d9221ff8a27) | `` ci: backport set permissions ``                                               |
| [`0adf9ba3`](https://github.com/nix-community/home-manager/commit/0adf9ba3f567da2d53af581a857aacf671aaa547) | `` kitty: make package nullable ``                                               |
| [`4958aafe`](https://github.com/nix-community/home-manager/commit/4958aafe7b237dc1e857fb0c916efff72075048f) | `` flake.lock: Update ``                                                         |
| [`9b4a2a7c`](https://github.com/nix-community/home-manager/commit/9b4a2a7c4fbd75b422f00794af02d6edb4d9d315) | `` hyprpanel: remove `dontAssertNotificationDaemons` option ``                   |
| [`13b2744e`](https://github.com/nix-community/home-manager/commit/13b2744e117993dc5066c1710585dcb99877684f) | `` maintainers: update all-maintainers.nix ``                                    |
| [`28907d1f`](https://github.com/nix-community/home-manager/commit/28907d1f77c90ffcd77ddffdcd27d0e022bce5ef) | `` restic: make sure pre and post hooks have interpreters ``                     |
| [`aa559a68`](https://github.com/nix-community/home-manager/commit/aa559a682b4ab29e2bea410248dbc60a591299b0) | `` delta: add test where git integration is disabled ``                          |
| [`84e1adb0`](https://github.com/nix-community/home-manager/commit/84e1adb0cdd13f5f29886091c7234365e12b1e7f) | `` zellij: Allow using extraConfig without settings ``                           |
| [`c3a5e5f0`](https://github.com/nix-community/home-manager/commit/c3a5e5f0df6f53aa4b51adc0107796cc407c641c) | `` services/pimsync: init ``                                                     |
| [`2b0a4628`](https://github.com/nix-community/home-manager/commit/2b0a46285b2e7800c172525c7a6839111a05afb6) | `` tests/pimsync: init ``                                                        |
| [`f4411d1e`](https://github.com/nix-community/home-manager/commit/f4411d1e9b4e1a7d7757f044b10abd0cf8074fea) | `` pimsync: init module ``                                                       |
| [`db876d1d`](https://github.com/nix-community/home-manager/commit/db876d1d9f8dedfa4fed2e830ca99b1219e0828f) | `` programs/senpai: use new toSCFG interface ``                                  |
| [`817ca5e9`](https://github.com/nix-community/home-manager/commit/817ca5e948a26c9dedae2f1e8e1bd24c6c1b9a9a) | `` types: add SCFGDirectives type ``                                             |
| [`89a9fa0f`](https://github.com/nix-community/home-manager/commit/89a9fa0f3fc2a22b4d828d46afb1b56d9f296ce7) | `` generators: rewrite toSCFG ``                                                 |
| [`c9d758b5`](https://github.com/nix-community/home-manager/commit/c9d758b500e53db5b74aa02d17dc45b65229e8e9) | `` tests/delta: add 'delta-final-package' ``                                     |
| [`022e7e3f`](https://github.com/nix-community/home-manager/commit/022e7e3f95750ba5e1c78f1fb07a538ec3884241) | `` delta: fix wrapper usage condition ``                                         |
| [`0cb746a7`](https://github.com/nix-community/home-manager/commit/0cb746a743d36d423ba413f72808d990e756950d) | `` delta: set wrapper's 'meta' ``                                                |
| [`189c21cf`](https://github.com/nix-community/home-manager/commit/189c21cf879669008ccf06e78a553f17e88d8ef0) | `` superfile: add zoxide when zoxide_support enabled ``                          |
| [`aeabc1ac`](https://github.com/nix-community/home-manager/commit/aeabc1ac63e6ebb8ba4714c4abdfe0556f2de765) | `` tests/git: add settigs deprecation test ``                                    |
| [`a7094272`](https://github.com/nix-community/home-manager/commit/a709427248732f4d8477409467e3c5c1542b50ef) | `` git: aliases / user options -> settings ``                                    |
| [`ac7c05a9`](https://github.com/nix-community/home-manager/commit/ac7c05a90c6a2ed811d2245ae632ed3372eeefe7) | `` git: extraConfig -> settings ``                                               |
| [`85cd07b8`](https://github.com/nix-community/home-manager/commit/85cd07b8b0b686fb43bb3991ce38bd0c9f790b56) | `` diff-so-fancy: use freeform settings option ``                                |
| [`bb7bb235`](https://github.com/nix-community/home-manager/commit/bb7bb2358394f587c32bfd8fb7022dddaeac622d) | `` git: reorganize ``                                                            |
| [`7522ba8a`](https://github.com/nix-community/home-manager/commit/7522ba8a0cd16546032ed469db356f605420e012) | `` tests/riff: add ``                                                            |
| [`b695586f`](https://github.com/nix-community/home-manager/commit/b695586f924266532f0a636851a33203c7ad2acd) | `` riff: new module ``                                                           |
| [`41fd9b19`](https://github.com/nix-community/home-manager/commit/41fd9b197cdad9b7cae34e274ad2eafbb250a3ce) | `` tests/patdiff: add ``                                                         |
| [`c80be802`](https://github.com/nix-community/home-manager/commit/c80be802823626f5a23501cf09aab9eaf057e53d) | `` patdiff: new module ``                                                        |
| [`4fef8e73`](https://github.com/nix-community/home-manager/commit/4fef8e73a61fdd24737090a9377fbd2f3c83ff57) | `` tests/git: add git-lfs test ``                                                |
| [`2e527427`](https://github.com/nix-community/home-manager/commit/2e527427b135a8ac0d6efedf04e9ca94569328a7) | `` git: add git-lfs package option ``                                            |
| [`4166d4e1`](https://github.com/nix-community/home-manager/commit/4166d4e1637ce1f2e8aac6ec8df3ec5e94a3cc38) | `` tests/difftastic: add ``                                                      |
| [`111329b4`](https://github.com/nix-community/home-manager/commit/111329b475f7db892fef44059109108cbb45ab9c) | `` difftastic: new module ``                                                     |
| [`16cd8aba`](https://github.com/nix-community/home-manager/commit/16cd8abad6274a4f44bcabab13d6cbe135f3decc) | `` tests/diff-so-fancy: add ``                                                   |
| [`7a10f175`](https://github.com/nix-community/home-manager/commit/7a10f175dbaa7731fc596cc40f74b32a6db2a6f4) | `` diff-so-fancy: new module ``                                                  |
| [`486487b5`](https://github.com/nix-community/home-manager/commit/486487b5e9917392a5b3addbdc500a8324c03fad) | `` tests/diff-highlight: add ``                                                  |
| [`7d03d5fb`](https://github.com/nix-community/home-manager/commit/7d03d5fb73e7210eb70e2bbe2585df2e8c07f250) | `` diff-highlight: new module ``                                                 |
| [`2c8b9620`](https://github.com/nix-community/home-manager/commit/2c8b96209143ca9889b339d27fb20bc98ac3cf82) | `` tests/delta: add tests ``                                                     |
| [`f436677f`](https://github.com/nix-community/home-manager/commit/f436677f5f8812d9ab365a822c77d9f1fac47dac) | `` delta: create new module ``                                                   |
| [`90af98a2`](https://github.com/nix-community/home-manager/commit/90af98a2fc3a4fb4c4eb9836e8b18fc7beaef2db) | `` newsboat: add timer unit for automatically cleaning cache ``                  |
| [`a264fbea`](https://github.com/nix-community/home-manager/commit/a264fbea00831d8094cefabf690eeded81adbfd6) | `` newsboat: add timer unit for automatically fetching articles ``               |
| [`6ea30b26`](https://github.com/nix-community/home-manager/commit/6ea30b26cdd22b9535620495e026aabed76daa16) | `` opencode: make the themes also accept path ``                                 |
| [`fddb33a1`](https://github.com/nix-community/home-manager/commit/fddb33a1a554da0d38fbe5bb14f0b553fe624808) | `` opencode: make the `rules` option also accept a path ``                       |
| [`c199de6c`](https://github.com/nix-community/home-manager/commit/c199de6cd8a146382e829eded5e704cce47d22e8) | `` restic: decouple helper script from linux-specific systemd logic ``           |
| [`12bca6d4`](https://github.com/nix-community/home-manager/commit/12bca6d40adc7904c1f19ea2f9b0f2fe771fb309) | `` Revert "restic: add platform assertion (linux)" ``                            |
| [`d7f53066`](https://github.com/nix-community/home-manager/commit/d7f53066376a06db5d1584c18199aa888294fe60) | `` flake.lock: Update ``                                                         |
| [`870883ba`](https://github.com/nix-community/home-manager/commit/870883ba11ba1c84f756c0c1f9fa74cdb2a16c1e) | `` cliphist: remove example package ``                                           |
| [`99977131`](https://github.com/nix-community/home-manager/commit/99977131d33cee07da9fee9a4fe2541f8b3b17be) | `` opencode: change tilde (~) to `XDG_CONFIG_DIR` for command and agent paths `` |
| [`3fbc8790`](https://github.com/nix-community/home-manager/commit/3fbc8790219496c2b6a6c34c3d349fc8b9b77b2d) | `` restic: add platform assertion (linux) ``                                     |
| [`fc837be1`](https://github.com/nix-community/home-manager/commit/fc837be107e33f5debe7fecc5c597a8dab69d83b) | `` opencode: add themes option ``                                                |
| [`722792af`](https://github.com/nix-community/home-manager/commit/722792af097dff5790f1a66d271a47759f477755) | `` news: add wl-clip-persist entry ``                                            |
| [`7e0abd5d`](https://github.com/nix-community/home-manager/commit/7e0abd5db641525e5a3ee6f9aa8b1097718b9832) | `` ci: add wl-clip-persist labels ``                                             |
| [`47c74e4f`](https://github.com/nix-community/home-manager/commit/47c74e4fd0bec8f412b912bdef054d514ad7ac59) | `` wl-clip-persist: add module ``                                                |
| [`673e47bb`](https://github.com/nix-community/home-manager/commit/673e47bb868eec436bc17011c6b13e8ceab340be) | `` cliphist: add clipboardPackage ``                                             |
| [`847669da`](https://github.com/nix-community/home-manager/commit/847669dabf374d32a072bdab3f08cae7296ac011) | `` anki: fix boolean options ``                                                  |
| [`c53e65ec`](https://github.com/nix-community/home-manager/commit/c53e65ec92f38d30e3c14f8d628ab55d462947aa) | `` flake.lock: Update ``                                                         |
| [`ba6aaa0e`](https://github.com/nix-community/home-manager/commit/ba6aaa0e0a2046196eafa635e8fd53b1e4901286) | `` mergiraf: add merge.conflictStyle git configuration ``                        |
| [`ed1eb4cf`](https://github.com/nix-community/home-manager/commit/ed1eb4cfddba1be85cb16702d7a42803d1ff55e8) | `` fix config file location on macOS and fix test ``                             |
| [`990e5ce6`](https://github.com/nix-community/home-manager/commit/990e5ce6791ff1f497a61280a82eb66e3789e0e9) | `` docker-cli: add docker contexts support ``                                    |
| [`25ca7d29`](https://github.com/nix-community/home-manager/commit/25ca7d297fe39b5a91334ec3c118ef0b23b2627a) | `` docker-cli: add will-lol as maintainer ``                                     |
| [`aac99d40`](https://github.com/nix-community/home-manager/commit/aac99d40651696249746ef6d58af27ad8e2ccbfd) | `` maintainers: add will-lol ``                                                  |
| [`724bb5e5`](https://github.com/nix-community/home-manager/commit/724bb5e56b07967c83368acc6c889f9044edca5f) | `` maintainers: update all-maintainers.nix ``                                    |
| [`83752529`](https://github.com/nix-community/home-manager/commit/837525295fa3f32efd8ec13d0f9e49b5d99abd84) | `` obsidian: allow null package ``                                               |
| [`e121f377`](https://github.com/nix-community/home-manager/commit/e121f3773fa596ecaba5b22e518936a632d72a90) | `` gemini-cli: context support multiple file generation ``                       |
| [`5ead1867`](https://github.com/nix-community/home-manager/commit/5ead1867bbbf10949f7c7a6bb99c8ca1c91bd7c3) | `` tests/gemini-cli: add context tests ``                                        |
| [`e2d34693`](https://github.com/nix-community/home-manager/commit/e2d346936ed086b054525396c022595455e4b0bd) | `` gemini-cli: add context option ``                                             |
| [`02d23e62`](https://github.com/nix-community/home-manager/commit/02d23e6291082fb72c2cecc6cc4994dac899842a) | `` maintainers: remove swarsel duplicate ``                                      |
| [`602913bf`](https://github.com/nix-community/home-manager/commit/602913bfc5490eb7120691e3a94ad408fbfa5578) | `` pizauth: update maintainer entry ``                                           |
| [`4d64989b`](https://github.com/nix-community/home-manager/commit/4d64989b8cf6d0ad7893d7930845063d403645f2) | `` autotiling: update maintainer entry ``                                        |
| [`175bf8ce`](https://github.com/nix-community/home-manager/commit/175bf8ce19a2a36b5538cf8b5741c587dafb3309) | `` maintainers: fix typo ``                                                      |
| [`48ed66f5`](https://github.com/nix-community/home-manager/commit/48ed66f59d21a3ef1acb500a807b8df7b8aabff1) | `` maintainers: update link to NixOS' maintainer-list.nix ``                     |
| [`5cd1f79c`](https://github.com/nix-community/home-manager/commit/5cd1f79c8a6bcd92575f6cd9e7998b9c8ebf81e9) | `` flake.lock: Update ``                                                         |
| [`416ad5c0`](https://github.com/nix-community/home-manager/commit/416ad5c08a4341d3fcd6f7d4feea96ddcfd3ff29) | `` tests: remove flake.lock, add to .gitignore ``                                |
| [`904fa32d`](https://github.com/nix-community/home-manager/commit/904fa32d77609f281ef32d5209926d81848b687a) | `` vivid: modify `themes` option with custom nix entries ``                      |
| [`c4aaddea`](https://github.com/nix-community/home-manager/commit/c4aaddeaecc09554c92518fd904e3e84b497ed09) | `` home-manager: Document 'force = true' option in error output ``               |
| [`ac16cc25`](https://github.com/nix-community/home-manager/commit/ac16cc25c6151f9f90fff440f8dd9a5343b438f4) | `` autotiling: init module ``                                                    |
| [`7afeff9d`](https://github.com/nix-community/home-manager/commit/7afeff9d815e8e5edff705d8ef1de44a0c0a8b8a) | `` news: add anvil-editor entry ``                                               |
| [`f2cda99e`](https://github.com/nix-community/home-manager/commit/f2cda99e4a1528908bf00e7b9822551aa25f0fb2) | `` anvil-editor: add module ``                                                   |
| [`2574bb44`](https://github.com/nix-community/home-manager/commit/2574bb4496675238674a32a3c0db826b4d2dca03) | `` news: add anup entry ``                                                       |
| [`55091079`](https://github.com/nix-community/home-manager/commit/55091079d68635af994298b3177d0a5fea088f12) | `` anup: add module ``                                                           |
| [`e4c7df3a`](https://github.com/nix-community/home-manager/commit/e4c7df3a952c2bd41047f4df9e964edbaa35038e) | `` news: add anime-downloader entry ``                                           |
| [`95419fb9`](https://github.com/nix-community/home-manager/commit/95419fb9856b02b3bb9be558172a8436bb1d0ee4) | `` anime-downloader: add module ``                                               |
| [`4889a257`](https://github.com/nix-community/home-manager/commit/4889a257563f395d3088194370122be198c9a1a8) | `` news: add andcli entry ``                                                     |
| [`efb5aa77`](https://github.com/nix-community/home-manager/commit/efb5aa77799cb42b2e21c2f2b376b043b44dfa5d) | `` andcli: add module ``                                                         |
| [`2fffa806`](https://github.com/nix-community/home-manager/commit/2fffa806e7eed2d8948f478523c7c6aca90566b6) | `` news: add amp entry ``                                                        |
| [`91daee72`](https://github.com/nix-community/home-manager/commit/91daee72efc99b7336b7e545774e9e3c2a1910c8) | `` amp: add module ``                                                            |
| [`d305eece`](https://github.com/nix-community/home-manager/commit/d305eece827a3fe317a2d70138f53feccaf890a1) | `` zsh: fix zsh history substring search generation ``                           |
| [`bcccb01d`](https://github.com/nix-community/home-manager/commit/bcccb01d0a353c028cc8cb3254cac7ebae32929e) | `` tests/firefox: change test case to verify we handle missing addonId ``        |
| [`5200f390`](https://github.com/nix-community/home-manager/commit/5200f3903f44e05dd7230f794ef18ad7b8855676) | `` mkFirefoxModule: support extensions without addonID ``                        |
| [`c7f4214f`](https://github.com/nix-community/home-manager/commit/c7f4214faca2f196c551b767c12a70bfa0614510) | `` firefox: new permission checks for extensions ``                              |
| [`b27e5512`](https://github.com/nix-community/home-manager/commit/b27e5512709aa7ac355b78b0223096bae362003e) | `` aerc: change stylesets option to reflect the structure aerc expects ``        |
| [`88e62bca`](https://github.com/nix-community/home-manager/commit/88e62bcab2536683f1db149bd27c30b80d7614a0) | `` swayidle: make sure it's actually installed when enabled ``                   |
| [`5d61767c`](https://github.com/nix-community/home-manager/commit/5d61767c8dee7f9c66991335795dbca9e801c25a) | `` alacritty: fix eval error ``                                                  |
| [`6564ee29`](https://github.com/nix-community/home-manager/commit/6564ee29d0521af3feba937a91024e6a3e77a8b6) | `` tests/darwinScrublist: add retext ``                                          |
| [`2a1df048`](https://github.com/nix-community/home-manager/commit/2a1df048684b8f0db334c8322c6b802106368738) | `` flake.lock: Update ``                                                         |
| [`87f75c10`](https://github.com/nix-community/home-manager/commit/87f75c1044dfadc8648f49a2e85d0ad686a5d625) | `` alacritty: add package option for the theme package ``                        |
| [`f8e05607`](https://github.com/nix-community/home-manager/commit/f8e056073419ff508332f32d8df6a81806337e68) | `` alacritty: check existence of the theme without using IFD ``                  |
| [`7add5544`](https://github.com/nix-community/home-manager/commit/7add55445826e4bf9678378c256d8b119945d337) | `` macos-remap-keys: add Fn (Globe) keycode ``                                   |
| [`219150a7`](https://github.com/nix-community/home-manager/commit/219150a73cad7a0bb0193a4bb1c85623fe9157fd) | `` macos-remap-keys: add japanese Kana and Eisuu keycodes ``                     |
| [`685d8d85`](https://github.com/nix-community/home-manager/commit/685d8d85d051820164c809fbbc4c67474ee93d67) | `` desktopEntry: Remove deprecated category from example ``                      |
| [`1a09eb84`](https://github.com/nix-community/home-manager/commit/1a09eb84fa9e33748432a5253102d01251f72d6d) | `` news: add amoco entry ``                                                      |
| [`c6f8669f`](https://github.com/nix-community/home-manager/commit/c6f8669f09a7d70abb0435614febbe03bb596a16) | `` amoco: add module ``                                                          |
| [`6c5025e2`](https://github.com/nix-community/home-manager/commit/6c5025e2bb117eb16c0aa55097ce69935f72e14c) | `` tests/dircolors: add nushell integration tests ``                             |
| [`38fbd890`](https://github.com/nix-community/home-manager/commit/38fbd8909e6d4a8a36fda318c5feb8704da178d1) | `` dircolors: add nushell integration ``                                         |
| [`462363e2`](https://github.com/nix-community/home-manager/commit/462363e248b0a2e8579a904a9991a86206ca98e8) | `` dircolors: remove no-op ``                                                    |
| [`5443ca20`](https://github.com/nix-community/home-manager/commit/5443ca20ed5c5da327de37a09910dc1c66fc3712) | `` news: add amfora entry ``                                                     |
| [`40ff7901`](https://github.com/nix-community/home-manager/commit/40ff79012e44c86b2f7c8260361b80c4794e504a) | `` amfora: add module ``                                                         |
| [`929535c3`](https://github.com/nix-community/home-manager/commit/929535c3082afdf0b18afec5ea1ef14d7689ff1c) | `` git: difftastic: use 'option' attrset ``                                      |
| [`ed100232`](https://github.com/nix-community/home-manager/commit/ed10023224107dc8479ead95a448d66f046785e0) | `` maintainers: update all-maintainers.nix ``                                    |
| [`7d3d323e`](https://github.com/nix-community/home-manager/commit/7d3d323e906a06247920c0a8fb2fa473a3770fb9) | `` git: add `extraArgs` option for difftastic ``                                 |
| [`1652349e`](https://github.com/nix-community/home-manager/commit/1652349e57daa25217f32656216e404948e512f3) | `` git: add option for difftastic context ``                                     |
| [`d328666d`](https://github.com/nix-community/home-manager/commit/d328666dbac08aefd639019516f22c61be14a326) | `` git: add tests for difftastic ``                                              |
| [`e46b52ab`](https://github.com/nix-community/home-manager/commit/e46b52ab56ec5f981491a61e9aececa9e50f712c) | `` darwinScrublist: add difftastic ``                                            |
| [`b72be79a`](https://github.com/nix-community/home-manager/commit/b72be79a42d470e4bafb5348dc62df484b6baab3) | `` smug: add new option introduced by v0.3.7 (#7930) ``                          |
| [`6f4021da`](https://github.com/nix-community/home-manager/commit/6f4021da5d2bb5ea7cb782ff413ecb7062066820) | `` deprecations: move just module deprecation to new module ``                   |
| [`3f07ce05`](https://github.com/nix-community/home-manager/commit/3f07ce05c3b6d59602bc380e42320483081fa38f) | `` deprecations: add deprecations/removal module ``                              |
| [`5b45dcf4`](https://github.com/nix-community/home-manager/commit/5b45dcf4790bb94fec7e550d2915fc2540a3cdd6) | `` tests/hyprshot: add tests ``                                                  |
| [`9f2912e3`](https://github.com/nix-community/home-manager/commit/9f2912e3a6c4665bebe3d61ba967ddc65ecd18d4) | `` hyprshot: add platform assertion ``                                           |
| [`3c3076b1`](https://github.com/nix-community/home-manager/commit/3c3076b1c1b941715302d731a4a978bca88fa16f) | `` tests/discoss: add tests ``                                                   |
| [`6e8ab005`](https://github.com/nix-community/home-manager/commit/6e8ab005bc65649428cba369f2730f01955b3d6a) | `` tests/darwinscrublist: add discocss and discord ``                            |
| [`f72f6609`](https://github.com/nix-community/home-manager/commit/f72f660976628775d8a5bb5ea6a3ba7ad2000cdb) | `` discocss: only generate css when provided ``                                  |