### PR TITLE
chore(flake/nix-index-database): `3fe768e1` -> `469ef535`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -484,11 +484,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756612744,
-        "narHash": "sha256-/glV6VAq8Va3ghIbmhET3S1dzkbZqicsk5h+FtvwiPE=",
+        "lastModified": 1763265660,
+        "narHash": "sha256-Ad9Rd3ZAidrH01xP73S3CjPiyXo7ywZs3uCESjPwUdc=",
         "owner": "Mic92",
         "repo": "nix-index-database",
-        "rev": "3fe768e1f058961095b4a0d7a2ba15dc9736bdc6",
+        "rev": "469ef53571ea80890c9497952787920c79c1ee6e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                 |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`469ef535`](https://github.com/nix-community/nix-index-database/commit/469ef53571ea80890c9497952787920c79c1ee6e) | `` update generated.nix to release 2025-11-16-034114 `` |
| [`54bda85e`](https://github.com/nix-community/nix-index-database/commit/54bda85e440fb56059fa9d636018789db4546e51) | `` flake.lock: Update ``                                |
| [`15c5451c`](https://github.com/nix-community/nix-index-database/commit/15c5451c63f4c612874a43846bfe3fa828b03eee) | `` update generated.nix to release 2025-11-09-033613 `` |
| [`67bec263`](https://github.com/nix-community/nix-index-database/commit/67bec263e3f0c88b14a657760c0d79676a45647c) | `` flake.lock: Update ``                                |
| [`359ff633`](https://github.com/nix-community/nix-index-database/commit/359ff6333a7b0b60819d4c20ed05a3a1f726771f) | `` update generated.nix to release 2025-11-02-033803 `` |
| [`bd94879c`](https://github.com/nix-community/nix-index-database/commit/bd94879cd144d4a90cc0879dd57c98f12383bca2) | `` flake.lock: Update ``                                |
| [`ed6b2931`](https://github.com/nix-community/nix-index-database/commit/ed6b293161b378a7368cda38659eb8d3d9a0dac4) | `` update generated.nix to release 2025-10-26-033509 `` |
| [`10bad26d`](https://github.com/nix-community/nix-index-database/commit/10bad26dd1fd24f17c6158ff775b8590591d4ea3) | `` flake.lock: Update ``                                |
| [`5024e190`](https://github.com/nix-community/nix-index-database/commit/5024e1901239a76b7bf94a4cd27f3507e639d49e) | `` update generated.nix to release 2025-10-19-033805 `` |
| [`22d7565e`](https://github.com/nix-community/nix-index-database/commit/22d7565e57b3f050939665efc6acd96d63ea2be3) | `` flake.lock: Update ``                                |
| [`c9f5ea45`](https://github.com/nix-community/nix-index-database/commit/c9f5ea45f25652ec2f771f9426ccacb21cbbaeaa) | `` update generated.nix to release 2025-10-12-032557 `` |
| [`f0ca6a7d`](https://github.com/nix-community/nix-index-database/commit/f0ca6a7dd956b3ad8fc628e1eb1024e15c862da0) | `` flake.lock: Update ``                                |
| [`0ca69684`](https://github.com/nix-community/nix-index-database/commit/0ca69684091aa3a6b1fe994c4afeff305b15e915) | `` update generated.nix to release 2025-10-05-032844 `` |
| [`b7d515fd`](https://github.com/nix-community/nix-index-database/commit/b7d515fdd507be90afe806cb8b3e7130e7c4104b) | `` flake.lock: Update ``                                |
| [`ec7a78cb`](https://github.com/nix-community/nix-index-database/commit/ec7a78cb0e098832d8acac091a4df393259c4839) | `` update generated.nix to release 2025-09-28-033035 `` |
| [`dba023c4`](https://github.com/nix-community/nix-index-database/commit/dba023c457b6a7c826cd63397f5c6d6ff4d8b828) | `` flake.lock: Update ``                                |
| [`fd2569ca`](https://github.com/nix-community/nix-index-database/commit/fd2569ca2ef7d69f244cd9ffcb66a0540772ff85) | `` update generated.nix to release 2025-09-21-033022 `` |
| [`3bcb1214`](https://github.com/nix-community/nix-index-database/commit/3bcb1214ddc6cf50bb82811f26650f09dc354982) | `` flake.lock: Update ``                                |
| [`050a5feb`](https://github.com/nix-community/nix-index-database/commit/050a5feb5d1bb5b6e5fc04a7d3d816923a87c9ea) | `` update generated.nix to release 2025-09-14-032502 `` |
| [`80b92602`](https://github.com/nix-community/nix-index-database/commit/80b92602ddca79bd46ffa8fd244af0319c22551b) | `` flake.lock: Update ``                                |
| [`9b144dc3`](https://github.com/nix-community/nix-index-database/commit/9b144dc3ef6e42b888c4190e02746aab13b0e97f) | `` update generated.nix to release 2025-09-07-032516 `` |
| [`b33c3aad`](https://github.com/nix-community/nix-index-database/commit/b33c3aadca9343dbbcba8be71cb741d095aab8a9) | `` flake.lock: Update ``                                |