### PR TITLE
chore(flake/tinted-schemes): `097d751b` -> `4ac26dc9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -816,11 +816,11 @@
     "tinted-schemes_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1754779259,
-        "narHash": "sha256-8KG2lXGaXLUE0F/JVwLQe7kOVm21IDfNEo0gfga5P4M=",
+        "lastModified": 1762594952,
+        "narHash": "sha256-pr+RtDs+3qo0v7ZXfcSdtP0PoDDPU9EHw2Oe5EUwWtQ=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "097d751b9e3c8b97ce158e7d141e5a292545b502",
+        "rev": "4ac26dc99141c1b2a26eb7fefe46e22e07eec77c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                  | Message                                                      |
| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`4ac26dc9`](https://github.com/tinted-theming/schemes/commit/4ac26dc99141c1b2a26eb7fefe46e22e07eec77c) | `` Move base16 scheme into base16 directory ``               |
| [`4e8453c9`](https://github.com/tinted-theming/schemes/commit/4e8453c996d930f93d5f70f2a77e37812048df59) | `` Fix scheme color errors ``                                |
| [`5bee116b`](https://github.com/tinted-theming/schemes/commit/5bee116b44c949a335a25a91530ae5c8965b7d6f) | `` Add workspace fallback to linting script ``               |
| [`83e018d4`](https://github.com/tinted-theming/schemes/commit/83e018d4da12f39fad7cf0c79818450fce58cdec) | `` Adds base16 ascendancy scheme (#82) ``                    |
| [`317a5e10`](https://github.com/tinted-theming/schemes/commit/317a5e10c35825a6c905d912e480dfe8e71c7559) | `` Add base24 version of tomorrow-night (#71) ``             |
| [`d4cf913a`](https://github.com/tinted-theming/schemes/commit/d4cf913a780991dfc1ce1bc261c569d030060b1c) | `` Added Chinoiserie, a Tomorrow variant by Di Wang (#78) `` |
| [`4d4a8b9a`](https://github.com/tinted-theming/schemes/commit/4d4a8b9a0e13e01520466b734268c775a965c966) | `` Create hardhacker.yaml (#77) ``                           |